### PR TITLE
Add design docs, project plan, ADR 0001, and CONTRIBUTING (closes #2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Glue
+
+Glue is built one GitHub issue at a time. The pinned project tracker
+(<https://github.com/erain/glue/issues/1>) is the source of truth for what to
+work on next and what is done.
+
+This document is the operating contract. The most important rule:
+
+> **No issue is closed without a merged PR that references it.**
+
+If you find a closed issue that has no PR linked to it, treat it as not done
+and reopen it.
+
+## Per-Issue Workflow
+
+Every unit of work follows the same shape:
+
+1. **Read the tracker.** Open issue #1 and pick the next unchecked issue in
+   the priority order listed there. Work P0 before P1 before P2 unless the
+   tracker says otherwise.
+2. **Read the issue.** Verify it has all seven required sections (Goal, Scope,
+   Out of scope, Implementation notes, Docs update required, Verification
+   commands, Acceptance criteria). If anything is missing or stale, edit the
+   issue first — do not start coding against an incomplete spec.
+3. **Branch.** Create a feature branch named `issue/<number>-<short-slug>`
+   (e.g. `issue/3-go-module-scaffold`). Branch from the latest `main`.
+4. **Implement.** Stay inside the issue's scope. If you discover work that
+   belongs to a different issue, file a follow-up issue rather than expanding
+   the current PR.
+5. **Update docs in the same PR.** When behavior, architecture, package
+   layout, or project status changes, update `docs/design.md`,
+   `docs/project-plan.md`, an ADR under `docs/adr/`, or `README.md`
+   alongside the code change.
+6. **Run verification locally.** Run every command listed in the issue's
+   Verification Commands section. Capture the output — you will paste it into
+   the closing comment.
+7. **Open a PR.** Title format: `<short summary> (closes #<number>)`. PR body
+   should include:
+   - a one-paragraph summary of the change,
+   - a `Closes #<number>` line so GitHub auto-closes the issue on merge,
+   - the verification command output,
+   - any follow-up issues you opened.
+8. **CI must be green.** PRs cannot merge until the CI workflow (`go build`,
+   `go vet`, `go test ./...`) passes.
+9. **Merge.** Squash-merge into `main`. Delete the feature branch.
+10. **Close the loop.** If the PR didn't auto-close the issue (because of a
+    typo or because the issue was already closed), close it manually. Then post
+    a summary comment on the issue containing:
+    - the PR number,
+    - the verification command output (or a faithful summary if it is large),
+    - any caveats or follow-ups for the next session.
+11. **Update the tracker.** Edit issue #1's body to:
+    - check off the completed item,
+    - update the Current Phase if a milestone advanced,
+    - update the Next Recommended Issue,
+    - move the closed item into the Completed Work section with a one-line
+      summary linking the merged PR.
+
+## Why The Closing Comment Matters
+
+Glue is built to be picked up by a fresh agent or contributor with no prior
+context. The closing comment on each issue, plus the tracker, plus the
+contents of `docs/`, must be enough to fully reconstruct progress. Don't
+treat the closing comment as bookkeeping — it's the handoff to the next
+session.
+
+A good closing comment includes:
+
+- one or two sentences on what the PR shipped,
+- the literal verification commands and their output,
+- any non-obvious decisions or trade-offs made,
+- pointers to follow-up issues you filed.
+
+## Verification Discipline
+
+- The verification commands listed in an issue are the minimum, not the maximum.
+  If you found a tricky edge case while implementing, add a test for it.
+- For loop and runtime work, prefer fake providers over live API calls.
+- Live Gemini tests must be gated behind `GEMINI_API_KEY` and must not run in
+  CI. Use a build tag, `t.Skip` based on the env var, or both.
+- Never close an issue with red tests, broken builds, or a failing CI run.
+
+## Scope Discipline
+
+Glue's design doc lists explicit non-goals for P0 and P1 (no sandboxing, no
+dynamic plugins, no MCP, no HTTP server, no auto-compaction, no parallel
+tools). Don't quietly expand scope to add any of these. If you think one
+should change, propose it as an ADR or a tracker update first, not as a PR.
+
+## Reference Implementation
+
+A prior implementation pass is preserved at `/home/ubuntu/src/glue-reference/`
+on the development machine. It is allowed as a guide — the API shapes,
+package layout, and test patterns there are useful — but it must not be
+copy-pasted. Each issue still requires its own real review and verification.
+
+## Tooling Requirements
+
+- Go: latest stable.
+- `gh` CLI: required for opening PRs, commenting on issues, and updating the
+  tracker.
+- The CI workflow (issue #22) is the canonical verification surface; mirror
+  its commands locally before opening a PR.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # glue
-There are many Agent Harness Framework. This one is mine.
+
+Glue is a Go agent harness for building local and programmable agents,
+inspired by [Flue](https://github.com/withastro/flue) and
+[pi-mono](https://github.com/badlogic/pi-mono). It is built around a reusable
+provider-agnostic agent loop, a code-first `Agent` / `Session` API, and an
+initial Gemini provider.
+
+This repository is in active bootstrap. GitHub issues are the source of truth
+for the roadmap and implementation order:
+
+- Project tracker: <https://github.com/erain/glue/issues/1>
+- Design doc: [docs/design.md](docs/design.md)
+- Project plan: [docs/project-plan.md](docs/project-plan.md)
+- Contributor workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+A user-facing quickstart lands in issue #9.

--- a/docs/adr/0001-core-loop.md
+++ b/docs/adr/0001-core-loop.md
@@ -1,0 +1,39 @@
+# ADR 0001: Make The Agent Loop Reusable And Provider-Agnostic
+
+## Status
+
+Accepted.
+
+## Context
+
+Glue is inspired by Flue and pi-mono. Flue shows a productive agent/session/skill
+developer experience, while pi-mono shows a clean runtime loop: stream model
+events, execute tool calls, append tool results, and continue until the model
+stops.
+
+The loop is the part most likely to be reused outside the initial Gemini and CLI
+use cases. If it depends on Gemini, stores, CLI rendering, Markdown discovery, or
+filesystem layout, future providers and applications will be harder to add.
+
+## Decision
+
+Glue will implement the agent loop as a standalone package.
+
+The loop accepts normalized messages, tools, provider, model/options, and a
+system prompt. It emits normalized events and returns newly produced transcript
+messages. It does not import the public `glue` package, the Gemini provider
+package, stores, CLI code, or Markdown context loaders.
+
+P0 uses deterministic sequential tool execution. Parallel execution can be added
+later as an option without changing the default transcript semantics.
+
+## Consequences
+
+- Providers must translate their native APIs into Glue's normalized event and
+  message model.
+- The public `glue` package can focus on ergonomics: agents, sessions, skills,
+  roles, stores, and options.
+- The CLI can stream loop/session events without owning runtime behavior.
+- Tests can validate the loop with fake providers before Gemini integration.
+- Some duplication may exist between low-level loop types and high-level
+  user-facing aliases, but this is preferable to coupling the loop upward.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,242 @@
+# Glue Design
+
+Glue is a Go agent harness for building local and programmable agents. It is
+inspired by Flue's agent/session/skill model and pi-mono's reusable agent loop:
+providers stream assistant events, the loop executes tools, tool results are
+fed back into the conversation, and the process repeats until the model stops.
+
+This document is the canonical design reference. GitHub issues are the source
+of truth for implementation order and status after the initial bootstrap.
+
+## Goals
+
+- Provide a code-first Go library for defining agents, sessions, tools, skills,
+  and providers.
+- Make the pi-mono-style agent loop a reusable module that is independent of
+  Gemini, CLI code, stores, and filesystem conventions.
+- Support local CLI agents as a first-class use case without making the CLI the
+  core abstraction.
+- Start with Gemini as the only built-in provider while keeping provider
+  integration pluggable.
+- Persist local sessions to files so CLI sessions can resume.
+- Treat documentation and verification as required work for every issue.
+
+## Non-Goals For P0/P1
+
+- No sandboxing, shell execution, container runtime, or remote connector.
+- No dynamic Go plugin loading.
+- No MCP integration.
+- No HTTP server or deploy target.
+- No automatic context compaction.
+- No parallel tool execution until the sequential loop is well tested.
+
+## Package Boundaries
+
+The initial module path is `glue`.
+
+- `glue`: public library surface. Owns `Agent`, `Session`, options, tools,
+  skills, roles, and store interfaces.
+- `loop`: provider-agnostic agent loop. Owns turn execution, provider event
+  consumption, tool execution, transcript append behavior, and loop events.
+- `providers/gemini`: Gemini provider implementation using
+  `google.golang.org/genai`.
+- `stores/file`: file-backed JSON session store with atomic writes.
+- `cmd/glue`: local CLI runner built on top of the public library.
+
+The dependency direction is intentionally narrow:
+
+```text
+cmd/glue -> glue -> loop
+glue    -> providers/gemini only through explicit user construction
+glue    -> stores/file only through explicit user construction
+loop    -> no dependency on glue, providers, stores, CLI, or docs
+```
+
+## Core Types
+
+Glue uses normalized provider-neutral messages.
+
+- `Message`: user, assistant, or tool result transcript entry.
+- `ContentPart`: text, thinking, image, or tool call content.
+- `ToolCall`: assistant request to invoke a named tool with JSON arguments.
+- `ToolResult`: result returned to the model for a tool call.
+- `Tool`: name, description, JSON Schema parameters, and Go executor.
+- `Provider`: model backend that streams normalized assistant events.
+- `Event`: lifecycle event emitted by the loop and sessions.
+- `Store`: persistence interface for session transcripts.
+
+Provider-specific fields may be kept in metadata, but the loop must not depend
+on provider-specific event or payload shapes.
+
+## Agent Loop
+
+The `loop` package is the architectural center. Its job is to run a transcript
+until the provider stops or the context is canceled.
+
+1. Start with a system prompt, existing messages, available tools, and provider.
+2. Ask the provider to stream an assistant response.
+3. Emit text/tool/lifecycle events as provider events arrive.
+4. Append the final assistant message to the transcript.
+5. If the assistant requested tools, execute the requested tools.
+6. Append tool result messages in deterministic order.
+7. Repeat from step 2 until no tool calls remain.
+
+The concrete P0 entry point is `loop.Run(ctx, loop.RunRequest)`. It returns a
+`loop.RunResult` containing both the full transcript and the messages produced by
+that run. `RunRequest.Emit` receives event snapshots for callers such as sessions
+and CLIs.
+
+P0 uses sequential tool execution. This keeps the transcript deterministic and
+simple to verify. Tool arguments must be JSON objects; missing arguments are
+treated as `{}`. Unknown tools, invalid arguments, and executor errors are
+represented as error tool results that are visible to the model, rather than
+crashing the loop. A later parallel mode can run tools concurrently while still
+appending results in assistant source order.
+
+The default maximum loop length is 32 assistant turns to prevent accidental
+infinite tool cycles. Callers can override this with `RunRequest.MaxTurns`.
+
+The loop must support:
+
+- text-only responses
+- one or more tool calls
+- repeated tool turns
+- provider errors
+- tool errors
+- invalid tool arguments
+- context cancellation
+- event streaming for CLI output
+
+## Public Library API
+
+The public API is code-first. A user defines an agent in Go code, configures a
+provider, registers tools, chooses a store, and opens sessions.
+
+Target P0 shape:
+
+```go
+agent := glue.NewAgent(glue.AgentOptions{
+    Provider: gemini.New(gemini.Options{APIKey: os.Getenv("GEMINI_API_KEY")}),
+    Model:    "gemini-2.5-flash",
+    Tools:    []glue.Tool{weatherTool},
+})
+
+session, err := agent.Session(ctx, "local-dev")
+if err != nil {
+    return err
+}
+
+result, err := session.Prompt(ctx, "Use the weather tool for Toronto.")
+```
+
+Sessions are in-memory in P0. `Session.Subscribe(func(glue.Event))` registers a
+session-level event handler, and `glue.WithEvents` registers a per-prompt event
+handler. File-backed stores are added in P1.
+
+`PromptJSON(ctx, prompt, outPtr, opts...)` requests structured output and
+unmarshals the assistant's final text into a caller-provided non-nil pointer. It
+adds JSON-only instructions to the prompt and sets provider options compatible
+with Gemini structured output:
+
+- `response_mime_type: application/json`
+- `response_json_schema` when `glue.WithJSONSchema(...)` is provided
+
+V1 validation is intentionally limited to JSON decoding into the caller's Go
+type. Full JSON Schema validation is out of scope for the first structured
+result API.
+
+## Gemini Provider
+
+The first provider package is `providers/gemini`, implemented with
+`google.golang.org/genai`.
+
+Gemini behavior:
+
+- uses an explicit API key or `GEMINI_API_KEY`
+- accepts a model from `glue.AgentOptions.Model`, per-call `glue.WithModel`, or
+  provider default model
+- converts text user and assistant messages to Gemini `Content`
+- streams Gemini text deltas as normalized provider events
+- maps final stop reason, response id metadata, model version, and usage when
+  reported by the SDK
+- converts Glue tools to Gemini function declarations
+- converts Gemini function calls to normalized tool calls
+- converts Glue tool result messages to Gemini function responses
+
+Offline provider tests cover message conversion, config conversion, finish
+tool conversion, function response conversion, finish reason mapping, loop
+integration, and the live test skip path. Live smoke testing is gated:
+
+```sh
+GEMINI_API_KEY=... go test ./providers/gemini -run Live
+```
+
+## CLI Runner
+
+The CLI is first-class but thin. It exercises the same library APIs that
+applications use.
+
+Target command shape:
+
+```sh
+glue run --id <session-id> --prompt "..." --model gemini/<model> --store .glue/sessions --env .env
+```
+
+The built-in runner supports the default Gemini-backed agent only. It streams
+text deltas to stdout, persists sessions through `stores/file`, loads repeatable
+`.env` files, and uses `AgentOptions.WorkDir="."` for AGENTS.md, skills, and
+roles. Dynamic Go source loading, HTTP serving, and build/deploy targets remain
+out of scope.
+
+## Context, Skills, And Roles
+
+Glue borrows Flue's Markdown-driven context model:
+
+- `AgentOptions.WorkDir` enables local context discovery.
+- `AGENTS.md` contributes project instructions to the system prompt.
+- `.agents/skills/<name>/SKILL.md` defines reusable skill instructions.
+- `Session.Skill(ctx, name, args, opts...)` renders the named skill with optional
+  JSON args and runs it through `Session.Prompt`.
+- skills support simple frontmatter: `name:` and `description:`.
+- roles can be supplied through `AgentOptions.Roles` or loaded from
+  `roles/*.md` under `AgentOptions.WorkDir`.
+- roles support simple frontmatter: `name:`, `description:`, and `model:`.
+- effective role precedence is call role (`glue.WithRole`) > session role
+  (`glue.WithSessionRole`) > agent role (`AgentOptions.Role`).
+- model precedence is explicit call model (`glue.WithModel`) > effective role
+  model > agent model.
+
+Skills and roles are layered above the loop by the `glue` package. The loop only
+sees the final system prompt, messages, tools, and provider.
+
+## Persistence
+
+Glue exposes a small `Store` interface for durable session state. `AgentOptions`
+accepts a store, and `Session.Prompt` saves the transcript after each run.
+
+The initial durable implementation is `stores/file`. It writes normalized
+session state as JSON and uses temp-file-plus-rename for atomic updates. Session
+ids are URL-escaped into `<id>.json` files below the configured directory.
+
+Persisted data includes:
+
+- session id
+- messages
+- metadata
+- timestamps
+- provider and model identifiers inside messages
+- tool calls and tool results inside messages
+- usage inside messages when available
+
+## Verification Policy
+
+Every issue must specify verification before work starts. At minimum:
+
+- run `go test ./...` after code changes
+- add fake-provider tests for loop behavior
+- use offline conversion tests for provider payload mapping
+- gate live Gemini tests behind `GEMINI_API_KEY`
+- update docs when public behavior, architecture, or project status changes
+
+The full per-issue contributor protocol — branching, PR conventions, closing
+comments, and tracker updates — is documented in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,0 +1,101 @@
+# Glue Project Plan
+
+This plan is bootstrapping material. The pinned tracker issue is
+<https://github.com/erain/glue/issues/1>. After the initial GitHub issues and
+pinned tracker are created, GitHub issues become the source of truth for
+execution order, status, and acceptance criteria.
+
+## Operating Model
+
+1. Start each work session by reading the pinned tracker issue.
+2. Pick the next open issue by milestone priority: P0, then P1, then P2.
+3. Implement exactly one issue per pull request.
+4. Run the issue's verification commands.
+5. Update docs when behavior, architecture, package layout, or status changes —
+   in the same PR.
+6. Open a PR whose title or body references the issue (`Closes #N`).
+7. After the PR merges, comment on the issue with implementation notes and
+   verification output, then close it (or let `Closes #N` close it).
+8. Update the pinned tracker with completed work and the next recommended issue.
+
+The detailed contributor protocol — including branching conventions, PR shape,
+closing-comment format, and CI expectations — is in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Milestones
+
+### P0: Foundation And Reusable Loop
+
+P0 establishes the repository, documentation, source-of-truth issue workflow,
+core types, reusable loop, public session wrapper, Gemini text streaming, and
+README quickstart.
+
+P0 issues:
+
+- #2: Create initial design docs and project tracker.
+- #3: Scaffold Go module and package boundaries.
+- #22: Add CI workflow (build, vet, test) on PRs and main.
+- #4: Define normalized message, event, tool, and provider types.
+- #5: Implement reusable pi-mono-style agent loop.
+- #6: Add deterministic sequential tool execution.
+- #7: Wire public Agent and Session over the loop.
+- #8: Implement Gemini text streaming provider.
+- #9: Add README quickstart.
+
+### P1: Persistence, Tools, Structured Output, And CLI
+
+P1 makes the framework useful locally: function calling, file-backed sessions,
+structured JSON output, skills, roles, CLI runner, and examples.
+
+P1 issues:
+
+- #10: Add Gemini function calling support.
+- #11: Implement file-backed session store.
+- #12: Add structured JSON result API.
+- #13: Add AGENTS.md and skill loading.
+- #14: Add role support.
+- #15: Build local CLI runner.
+- #16: Add example local CLI agent.
+
+### P2: Hardening And Expansion
+
+P2 improves runtime behavior, extensibility, and maintenance workflows.
+
+P2 issues:
+
+- #17: Add parallel tool execution option.
+- #18: Add context compaction design and first implementation.
+- #19: Add shell/filesystem tool design.
+- #20: Add provider plugin guide.
+- #21: Add GitHub issue automation workflow.
+
+## Issue Requirements
+
+Every issue must include:
+
+- Goal
+- Scope
+- Out of scope
+- Implementation notes
+- Docs update required
+- Verification commands
+- Acceptance criteria
+
+Each issue should be small enough for one focused implementation-and-verification
+session.
+
+## Documentation Requirements
+
+- `docs/design.md` is the canonical architecture document.
+- `docs/project-plan.md` tracks the roadmap shape and operating model.
+- `docs/adr/` records durable architectural decisions.
+- `CONTRIBUTING.md` records the per-issue contributor protocol.
+- Documentation updates are part of the definition of done when work changes
+  public API, package boundaries, architecture, or project status.
+
+## Current Status
+
+Bootstrap. The repository contains LICENSE, README, and (after issue #2 lands)
+the design docs, project plan, ADR 0001, and CONTRIBUTING. No Go module,
+package scaffold, runtime types, loop, providers, stores, or CLI exist yet —
+those are tracked by P0 issues #3 through #9. The next issue after #2 is #3:
+scaffold the Go module and package boundaries.


### PR DESCRIPTION
## Summary

Lands the bootstrap documentation surface for Glue:

- `docs/design.md` — canonical target architecture: package boundaries, normalized types, reusable loop, Gemini provider, CLI runner, skills/roles, persistence, verification policy.
- `docs/project-plan.md` — P0 / P1 / P2 milestones, operating model, current honest bootstrap status (no Go module yet — that lands in #3).
- `docs/adr/0001-core-loop.md` — decision record for keeping the agent loop reusable and provider-agnostic.
- `CONTRIBUTING.md` — per-issue contributor protocol. Encodes the rule **no issue closes without a merged PR**, defines the closing-comment shape, and codifies the tracker-update expectation. This is the operating contract a fresh agent reads to pick up work.
- `README.md` — minimal pointers to tracker, design, plan, and CONTRIBUTING. Full user-facing quickstart is deferred to issue #9.

## Verification

```sh
$ ls docs/design.md docs/project-plan.md docs/adr/0001-core-loop.md
docs/adr/0001-core-loop.md
docs/design.md
docs/project-plan.md

$ ls CONTRIBUTING.md
CONTRIBUTING.md

$ gh issue view 1 --json title,state -q '"#" + (.title) + " state=" + .state'
#Project Tracker: Glue Roadmap And Progress state=OPEN
```

All three verification commands listed in #2 pass.

Closes #2.