### PR TITLE
Scaffold Go module and package boundaries (closes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Local agent harness state
+.claude/

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -1,0 +1,7 @@
+// Command glue is the local CLI runner for Glue agents.
+//
+// This is the bootstrap scaffold; the run subcommand and Gemini wiring are
+// added by later issues.
+package main
+
+func main() {}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,10 @@
+// Package glue provides the public API for defining and running agents.
+//
+// It is intentionally thin over the lower-level loop package. It owns
+// user-facing concepts such as agents, sessions, skills, roles, and stores.
+// The runtime mechanics — provider event consumption, tool execution, and
+// transcript management — live in the sibling [glue/loop] package.
+//
+// This file is the package marker for the bootstrap scaffold. Concrete types
+// (Agent, Session, Tool, etc.) are added by later issues.
+package glue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module glue
+
+go 1.24.5

--- a/loop/doc.go
+++ b/loop/doc.go
@@ -1,0 +1,10 @@
+// Package loop contains Glue's provider-agnostic agent loop.
+//
+// The loop streams assistant responses from a provider, executes requested
+// tools, appends tool results, and repeats until the provider stops or the
+// context is canceled. It must not depend on the public glue package,
+// provider packages, stores, CLI code, or Markdown context discovery.
+//
+// This file is the package marker for the bootstrap scaffold. The concrete
+// loop entry point and types are added by later issues.
+package loop

--- a/providers/gemini/doc.go
+++ b/providers/gemini/doc.go
@@ -1,0 +1,7 @@
+// Package gemini adapts Google's Gemini API to Glue's provider interface.
+//
+// The provider will support text streaming and Gemini function calling through
+// Glue's normalized tool interface. This file is the package marker for the
+// bootstrap scaffold; the SDK dependency and concrete implementation are added
+// by later issues.
+package gemini

--- a/stores/file/doc.go
+++ b/stores/file/doc.go
@@ -1,0 +1,6 @@
+// Package file provides a local JSON-backed session store for Glue.
+//
+// This file is the package marker for the bootstrap scaffold. Atomic
+// temp-file-plus-rename writes and the Store interface implementation are
+// added by later issues.
+package file


### PR DESCRIPTION
## Summary

Lands the minimal compile-safe Go scaffold described in `docs/design.md`:

- `go.mod` — `module glue`, `go 1.24.5`, no external dependencies yet (the Gemini SDK lands with #8).
- `doc.go` (root) — public `glue` package marker.
- `loop/doc.go` — provider-agnostic loop package marker.
- `providers/gemini/doc.go` — Gemini provider package marker.
- `stores/file/doc.go` — file-backed store package marker.
- `cmd/glue/main.go` — `package main` with an empty entrypoint so the binary compiles.
- `.gitignore` — ignore the local `.claude/` harness state directory.

The dependency direction matches `docs/design.md` (cmd/glue → glue → loop; loop has no upward deps). Concrete runtime behavior is intentionally deferred to #4 onward.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
?   	glue	[no test files]
?   	glue/cmd/glue	[no test files]
?   	glue/loop	[no test files]
?   	glue/providers/gemini	[no test files]
?   	glue/stores/file	[no test files]
```

`go test ./...` exits 0 (no failing packages); the `?` rows are Go's signal that the package has no test files, which is correct for this scaffold-only issue. Real tests start arriving with #4.

Closes #3.