### PR TITLE
Add CI workflow: build, vet, test on PRs and main (closes #22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: build / vet / test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # glue
 
+[![CI](https://github.com/erain/glue/actions/workflows/ci.yml/badge.svg)](https://github.com/erain/glue/actions/workflows/ci.yml)
+
 Glue is a Go agent harness for building local and programmable agents,
 inspired by [Flue](https://github.com/withastro/flue) and
 [pi-mono](https://github.com/badlogic/pi-mono). It is built around a reusable


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` that runs `go build`, `go vet`, and `go test ./...` on every pull request into `main` and on every push to `main`. Uses `actions/setup-go@v5` with `go-version: stable` and the built-in module cache.

The workflow has no secrets configured, so live Gemini tests must remain gated behind `GEMINI_API_KEY` (already required by `docs/design.md` and `CONTRIBUTING.md`).

README gets a CI status badge. `CONTRIBUTING.md` already encodes the "PRs cannot merge until CI passes" rule, so no additional contributor-doc change is needed.

## Verification

Local:

```
$ go build ./...
$ go vet ./...
$ go test ./...
?   	glue	[no test files]
?   	glue/cmd/glue	[no test files]
?   	glue/loop	[no test files]
?   	glue/providers/gemini	[no test files]
?   	glue/stores/file	[no test files]
```

CI: this PR is itself the demonstration run for the workflow. Will wait for green checks before merging.

Closes #22.