### PR TITLE
Define normalized message, event, tool, and provider types (closes #4)

### DIFF
--- a/loop/types.go
+++ b/loop/types.go
@@ -1,0 +1,185 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// MessageRole identifies which actor produced a transcript message.
+type MessageRole string
+
+const (
+	MessageRoleUser      MessageRole = "user"
+	MessageRoleAssistant MessageRole = "assistant"
+	MessageRoleTool      MessageRole = "tool"
+)
+
+// ContentType identifies the active payload field in a [ContentPart].
+type ContentType string
+
+const (
+	ContentTypeText     ContentType = "text"
+	ContentTypeThinking ContentType = "thinking"
+	ContentTypeImage    ContentType = "image"
+	ContentTypeToolCall ContentType = "tool_call"
+)
+
+// StopReason explains why a provider finished an assistant turn.
+type StopReason string
+
+const (
+	StopReasonStop     StopReason = "stop"
+	StopReasonLength   StopReason = "length"
+	StopReasonToolUse  StopReason = "tool_use"
+	StopReasonError    StopReason = "error"
+	StopReasonCanceled StopReason = "canceled"
+)
+
+// ContentPart is a provider-neutral message content block.
+//
+// Type selects which payload field is meaningful; other fields stay zero.
+// The struct shape is intentionally JSON-friendly so transcripts can be
+// persisted by file-backed stores without a separate wire format.
+type ContentPart struct {
+	Type      ContentType   `json:"type"`
+	Text      string        `json:"text,omitempty"`
+	Thinking  string        `json:"thinking,omitempty"`
+	Image     *ImageContent `json:"image,omitempty"`
+	ToolCall  *ToolCall     `json:"tool_call,omitempty"`
+	Signature string        `json:"signature,omitempty"`
+}
+
+// ImageContent stores an inline base64-encoded image.
+type ImageContent struct {
+	Data     string `json:"data"`
+	MIMEType string `json:"mime_type"`
+}
+
+// ToolCall is a model request to invoke a named tool with JSON arguments.
+type ToolCall struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// Message is a normalized transcript entry.
+type Message struct {
+	ID         string         `json:"id,omitempty"`
+	Role       MessageRole    `json:"role"`
+	Content    []ContentPart  `json:"content,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolName   string         `json:"tool_name,omitempty"`
+	IsError    bool           `json:"is_error,omitempty"`
+	Provider   string         `json:"provider,omitempty"`
+	Model      string         `json:"model,omitempty"`
+	StopReason StopReason     `json:"stop_reason,omitempty"`
+	Usage      *Usage         `json:"usage,omitempty"`
+	CreatedAt  time.Time      `json:"created_at,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+// Usage captures token accounting reported by a provider when available.
+type Usage struct {
+	InputTokens      int64 `json:"input_tokens,omitempty"`
+	OutputTokens     int64 `json:"output_tokens,omitempty"`
+	CacheReadTokens  int64 `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int64 `json:"cache_write_tokens,omitempty"`
+	TotalTokens      int64 `json:"total_tokens,omitempty"`
+}
+
+// ToolSpec is the provider-visible description of a tool.
+type ToolSpec struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// ToolExecutor runs a tool call locally and returns a normalized result.
+type ToolExecutor func(ctx context.Context, call ToolCall) (ToolResult, error)
+
+// Tool combines the provider-visible specification with its local executor.
+// The Execute field is intentionally tagged json:"-" so transcripts and
+// provider payloads exclude it.
+type Tool struct {
+	ToolSpec
+	Execute ToolExecutor `json:"-"`
+}
+
+// ToolResult is the local result produced by a [ToolExecutor].
+type ToolResult struct {
+	Content  []ContentPart  `json:"content,omitempty"`
+	IsError  bool           `json:"is_error,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// ProviderRequest is the normalized input sent to a provider for one assistant
+// turn.
+type ProviderRequest struct {
+	Model        string         `json:"model"`
+	SystemPrompt string         `json:"system_prompt,omitempty"`
+	Messages     []Message      `json:"messages,omitempty"`
+	Tools        []ToolSpec     `json:"tools,omitempty"`
+	Options      map[string]any `json:"options,omitempty"`
+}
+
+// Provider streams assistant events for a single assistant turn. Implementations
+// must close the returned channel when the turn ends, including on error.
+type Provider interface {
+	Stream(ctx context.Context, req ProviderRequest) (<-chan ProviderEvent, error)
+}
+
+// ProviderEventType identifies events emitted by a provider stream.
+type ProviderEventType string
+
+const (
+	ProviderEventStart         ProviderEventType = "start"
+	ProviderEventTextDelta     ProviderEventType = "text_delta"
+	ProviderEventThinkingDelta ProviderEventType = "thinking_delta"
+	ProviderEventToolCall      ProviderEventType = "tool_call"
+	ProviderEventDone          ProviderEventType = "done"
+	ProviderEventError         ProviderEventType = "error"
+)
+
+// ProviderEvent is a provider-neutral streaming event. The active fields
+// depend on Type: TextDelta uses Delta, ToolCall uses ToolCall, Done uses
+// Message, Error uses Error.
+type ProviderEvent struct {
+	Type         ProviderEventType `json:"type"`
+	Message      *Message          `json:"message,omitempty"`
+	Delta        string            `json:"delta,omitempty"`
+	ContentIndex int               `json:"content_index,omitempty"`
+	ToolCall     *ToolCall         `json:"tool_call,omitempty"`
+	Error        string            `json:"error,omitempty"`
+}
+
+// EventType identifies events emitted by the agent loop.
+type EventType string
+
+const (
+	EventLoopStart    EventType = "loop_start"
+	EventLoopEnd      EventType = "loop_end"
+	EventTurnStart    EventType = "turn_start"
+	EventTurnEnd      EventType = "turn_end"
+	EventMessageStart EventType = "message_start"
+	EventMessageEnd   EventType = "message_end"
+	EventTextDelta    EventType = "text_delta"
+	EventToolStart    EventType = "tool_start"
+	EventToolEnd      EventType = "tool_end"
+	EventError        EventType = "error"
+)
+
+// Event is emitted by the agent loop for callers such as sessions and CLIs.
+// The active fields depend on Type.
+type Event struct {
+	Type       EventType      `json:"type"`
+	Message    *Message       `json:"message,omitempty"`
+	Messages   []Message      `json:"messages,omitempty"`
+	Delta      string         `json:"delta,omitempty"`
+	ToolCall   *ToolCall      `json:"tool_call,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolName   string         `json:"tool_name,omitempty"`
+	ToolResult *ToolResult    `json:"tool_result,omitempty"`
+	Error      string         `json:"error,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}

--- a/loop/types_test.go
+++ b/loop/types_test.go
@@ -1,0 +1,198 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMessageJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	msg := Message{
+		ID:   "msg_1",
+		Role: MessageRoleAssistant,
+		Content: []ContentPart{
+			{Type: ContentTypeText, Text: "Checking the weather."},
+			{
+				Type: ContentTypeToolCall,
+				ToolCall: &ToolCall{
+					ID:        "call_1",
+					Name:      "weather",
+					Arguments: json.RawMessage(`{"city":"Toronto"}`),
+				},
+			},
+		},
+		Provider:   "gemini",
+		Model:      "gemini-2.5-flash",
+		StopReason: StopReasonToolUse,
+		Usage:      &Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+		CreatedAt:  createdAt,
+		Metadata:   map[string]any{"response_id": "resp_1"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+
+	var got Message
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+
+	if got.Role != MessageRoleAssistant {
+		t.Fatalf("role = %q, want %q", got.Role, MessageRoleAssistant)
+	}
+	if got.StopReason != StopReasonToolUse {
+		t.Fatalf("stop reason = %q, want %q", got.StopReason, StopReasonToolUse)
+	}
+	if len(got.Content) != 2 {
+		t.Fatalf("content len = %d, want 2", len(got.Content))
+	}
+	call := got.Content[1].ToolCall
+	if call == nil {
+		t.Fatal("tool call missing after round trip")
+	}
+	if call.ID != "call_1" || call.Name != "weather" {
+		t.Fatalf("tool call = %#v, want id call_1 and name weather", call)
+	}
+	var args map[string]string
+	if err := json.Unmarshal(call.Arguments, &args); err != nil {
+		t.Fatalf("unmarshal tool args: %v", err)
+	}
+	if args["city"] != "Toronto" {
+		t.Fatalf("city arg = %q, want Toronto", args["city"])
+	}
+	if got.Usage == nil || got.Usage.TotalTokens != 15 {
+		t.Fatalf("usage = %#v, want total tokens 15", got.Usage)
+	}
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Fatalf("created at = %s, want %s", got.CreatedAt, createdAt)
+	}
+}
+
+func TestToolMarshalExcludesExecutor(t *testing.T) {
+	t.Parallel()
+
+	tool := Tool{
+		ToolSpec: ToolSpec{
+			Name:        "weather",
+			Description: "Look up weather for a city.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+		},
+		Execute: func(context.Context, ToolCall) (ToolResult, error) {
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: "sunny"}}}, nil
+		},
+	}
+
+	data, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+	if !json.Valid(data) {
+		t.Fatalf("tool JSON is invalid: %s", data)
+	}
+	if strings.Contains(string(data), "Execute") {
+		t.Fatalf("tool JSON leaks Execute: %s", data)
+	}
+
+	var got ToolSpec
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal tool spec: %v", err)
+	}
+	if got.Name != "weather" {
+		t.Fatalf("name = %q, want weather", got.Name)
+	}
+	if len(got.Parameters) == 0 {
+		t.Fatal("parameters missing after round trip")
+	}
+}
+
+func TestToolResultJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	res := ToolResult{
+		Content:  []ContentPart{{Type: ContentTypeText, Text: "sunny, 21C"}},
+		IsError:  false,
+		Metadata: map[string]any{"source": "fake"},
+	}
+	data, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ToolResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Content) != 1 || got.Content[0].Text != "sunny, 21C" {
+		t.Fatalf("content = %#v, want one text part 'sunny, 21C'", got.Content)
+	}
+	if got.Metadata["source"] != "fake" {
+		t.Fatalf("metadata[source] = %v, want fake", got.Metadata["source"])
+	}
+}
+
+func TestProviderEventJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ev := ProviderEvent{Type: ProviderEventTextDelta, Delta: "hello"}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ProviderEvent
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Type != ProviderEventTextDelta || got.Delta != "hello" {
+		t.Fatalf("event = %#v, want text delta 'hello'", got)
+	}
+}
+
+func TestLoopEventJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ev := Event{
+		Type:       EventToolEnd,
+		ToolCallID: "call_1",
+		ToolName:   "weather",
+		ToolResult: &ToolResult{
+			Content: []ContentPart{{Type: ContentTypeText, Text: "sunny"}},
+		},
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Event
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Type != EventToolEnd {
+		t.Fatalf("type = %q, want %q", got.Type, EventToolEnd)
+	}
+	if got.ToolResult == nil || len(got.ToolResult.Content) != 1 {
+		t.Fatalf("tool result = %#v, want one content part", got.ToolResult)
+	}
+	if got.ToolName != "weather" || got.ToolCallID != "call_1" {
+		t.Fatalf("tool name/id = %q/%q, want weather/call_1", got.ToolName, got.ToolCallID)
+	}
+}
+
+func TestProviderInterfaceCompiles(t *testing.T) {
+	t.Parallel()
+
+	var _ Provider = staticProvider{}
+}
+
+type staticProvider struct{}
+
+func (staticProvider) Stream(_ context.Context, _ ProviderRequest) (<-chan ProviderEvent, error) {
+	ch := make(chan ProviderEvent)
+	close(ch)
+	return ch, nil
+}


### PR DESCRIPTION
## Summary

Adds the provider-neutral runtime types that the agent loop will use, all under `package loop`. Matches the type catalog in `docs/design.md` (Core Types section).

**Types added**

- Enums: `MessageRole`, `ContentType`, `StopReason`, `ProviderEventType`, `EventType`.
- Content: `ContentPart` (text/thinking/image/tool_call variants), `ImageContent`, `ToolCall`.
- Transcript: `Message` (with role, content parts, tool-call linkage, provider/model metadata, usage, timestamps), `Usage`.
- Tools: `ToolSpec`, `ToolExecutor`, `Tool` (Execute is `json:"-"`), `ToolResult`.
- Provider surface: `ProviderRequest`, `Provider` interface, `ProviderEvent`.
- Loop surface: `Event`.

**Boundaries**

- Loop package has no upward import — no `glue`, `providers/*`, `stores/*`, or CLI.
- Public re-exports/aliases for the `glue` package land with #7 (Agent + Session). Out of scope here.
- Loop execution lives in #5; Gemini conversion in #8.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
?   	glue	[no test files]
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	0.003s
?   	glue/providers/gemini	[no test files]
?   	glue/stores/file	[no test files]
```

`loop` now has 6 tests covering JSON round-trips for Message (with tool calls and usage), Tool (asserting Execute is excluded from JSON), ToolResult, ProviderEvent, loop Event, plus a compile-time check that a stub satisfies the `Provider` interface.

Closes #4.