### PR TITLE
Implement reusable pi-mono-style agent loop (closes #5)

### DIFF
--- a/loop/run.go
+++ b/loop/run.go
@@ -1,0 +1,372 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const defaultMaxTurns = 32
+
+// RunRequest configures one [Run].
+//
+// Provider is required. MaxTurns defaults to 32 when zero or negative. Emit
+// receives a snapshot of every loop event in source order; nil disables event
+// delivery. Messages, Tools, and Options are defensively copied so callers may
+// reuse the input slices and maps.
+type RunRequest struct {
+	Provider     Provider
+	Model        string
+	SystemPrompt string
+	Messages     []Message
+	Tools        []Tool
+	Options      map[string]any
+	MaxTurns     int
+	Emit         func(Event)
+}
+
+// RunResult is returned by [Run]. Messages is the full transcript including
+// the input messages and every message produced during this run. NewMessages
+// is just the messages produced during this run, in append order.
+type RunResult struct {
+	Messages    []Message
+	NewMessages []Message
+}
+
+// Run executes a provider-agnostic agent loop until the assistant stops
+// requesting tools, the provider errors, the context is canceled, or
+// MaxTurns is reached.
+//
+// Tool execution in this implementation is intentionally minimal: tools are
+// matched by name and called with the raw assistant arguments. Argument
+// normalization, error-as-tool-result conversion, and ordering guarantees
+// belong to the deterministic sequential execution path landing in a
+// follow-up issue.
+func Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if req.Provider == nil {
+		return RunResult{}, errors.New("loop: provider is required")
+	}
+
+	maxTurns := req.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = defaultMaxTurns
+	}
+
+	messages := cloneMessages(req.Messages)
+	newMessages := make([]Message, 0)
+	emit := func(e Event) {
+		if req.Emit != nil {
+			req.Emit(e)
+		}
+	}
+	snapshot := func() RunResult {
+		return RunResult{Messages: cloneMessages(messages), NewMessages: cloneMessages(newMessages)}
+	}
+	fail := func(err error) (RunResult, error) {
+		emit(Event{Type: EventError, Error: err.Error()})
+		return snapshot(), err
+	}
+
+	emit(Event{Type: EventLoopStart})
+	defer func() {
+		emit(Event{Type: EventLoopEnd, Messages: cloneMessages(newMessages)})
+	}()
+
+	for turn := 0; turn < maxTurns; turn++ {
+		if err := ctx.Err(); err != nil {
+			return fail(err)
+		}
+
+		emit(Event{Type: EventTurnStart})
+		assistant, err := runAssistantTurn(ctx, req, messages, emit)
+		if err != nil {
+			return fail(err)
+		}
+
+		messages = append(messages, assistant)
+		newMessages = append(newMessages, assistant)
+
+		toolCalls := collectToolCalls(assistant)
+		if len(toolCalls) == 0 {
+			emit(Event{Type: EventTurnEnd, Message: messagePtr(assistant)})
+			return snapshot(), nil
+		}
+
+		for _, call := range toolCalls {
+			if err := ctx.Err(); err != nil {
+				return fail(err)
+			}
+
+			emit(Event{
+				Type:       EventToolStart,
+				ToolCall:   toolCallPtr(call),
+				ToolCallID: call.ID,
+				ToolName:   call.Name,
+			})
+
+			toolMessage, err := executeBasicTool(ctx, req.Tools, call)
+			if err != nil {
+				return fail(err)
+			}
+
+			messages = append(messages, toolMessage)
+			newMessages = append(newMessages, toolMessage)
+
+			emit(Event{
+				Type:       EventToolEnd,
+				ToolCall:   toolCallPtr(call),
+				ToolCallID: call.ID,
+				ToolName:   call.Name,
+				Message:    messagePtr(toolMessage),
+			})
+		}
+
+		emit(Event{Type: EventTurnEnd, Message: messagePtr(assistant)})
+	}
+
+	return fail(fmt.Errorf("loop: maximum turns exceeded (%d)", maxTurns))
+}
+
+// executeBasicTool resolves a tool by name and invokes its executor with the
+// raw assistant arguments. Errors propagate; richer error-as-tool-result
+// behavior lands in the deterministic sequential execution issue.
+func executeBasicTool(ctx context.Context, tools []Tool, call ToolCall) (Message, error) {
+	for _, tool := range tools {
+		if tool.Name != call.Name {
+			continue
+		}
+		if tool.Execute == nil {
+			return Message{}, fmt.Errorf("loop: tool %q has no executor", call.Name)
+		}
+		result, err := tool.Execute(ctx, call)
+		if err != nil {
+			return Message{}, fmt.Errorf("loop: tool %q execute: %w", call.Name, err)
+		}
+		return Message{
+			Role:       MessageRoleTool,
+			Content:    cloneContent(result.Content),
+			ToolCallID: call.ID,
+			ToolName:   call.Name,
+			IsError:    result.IsError,
+			CreatedAt:  time.Now().UTC(),
+			Metadata:   cloneMetadata(result.Metadata),
+		}, nil
+	}
+	return Message{}, fmt.Errorf("loop: unknown tool %q", call.Name)
+}
+
+func runAssistantTurn(ctx context.Context, req RunRequest, messages []Message, emit func(Event)) (Message, error) {
+	stream, err := req.Provider.Stream(ctx, ProviderRequest{
+		Model:        req.Model,
+		SystemPrompt: req.SystemPrompt,
+		Messages:     cloneMessages(messages),
+		Tools:        toolSpecs(req.Tools),
+		Options:      cloneOptions(req.Options),
+	})
+	if err != nil {
+		return Message{}, fmt.Errorf("loop: provider stream: %w", err)
+	}
+
+	var assistant Message
+	started := false
+	done := false
+
+	ensureStarted := func() {
+		if started {
+			return
+		}
+		started = true
+		assistant = Message{Role: MessageRoleAssistant, Model: req.Model, CreatedAt: time.Now().UTC()}
+		emit(Event{Type: EventMessageStart, Message: messagePtr(assistant)})
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return Message{}, ctx.Err()
+		case event, ok := <-stream:
+			if !ok {
+				if !done {
+					return Message{}, errors.New("loop: provider stream closed before done event")
+				}
+				return assistant, nil
+			}
+
+			switch event.Type {
+			case ProviderEventStart:
+				if event.Message != nil {
+					assistant = *event.Message
+				} else {
+					assistant = Message{Role: MessageRoleAssistant, Model: req.Model, CreatedAt: time.Now().UTC()}
+				}
+				if assistant.Role == "" {
+					assistant.Role = MessageRoleAssistant
+				}
+				if assistant.CreatedAt.IsZero() {
+					assistant.CreatedAt = time.Now().UTC()
+				}
+				started = true
+				emit(Event{Type: EventMessageStart, Message: messagePtr(assistant)})
+
+			case ProviderEventTextDelta:
+				ensureStarted()
+				appendDelta(&assistant, ContentTypeText, event.ContentIndex, event.Delta)
+				emit(Event{Type: EventTextDelta, Message: messagePtr(assistant), Delta: event.Delta})
+
+			case ProviderEventThinkingDelta:
+				ensureStarted()
+				appendDelta(&assistant, ContentTypeThinking, event.ContentIndex, event.Delta)
+
+			case ProviderEventToolCall:
+				ensureStarted()
+				if event.ToolCall == nil {
+					return Message{}, errors.New("loop: provider tool_call event missing tool call")
+				}
+				call := *event.ToolCall
+				assistant.Content = append(assistant.Content, ContentPart{Type: ContentTypeToolCall, ToolCall: &call})
+
+			case ProviderEventDone:
+				ensureStarted()
+				if event.Message != nil {
+					assistant = *event.Message
+					if assistant.Role == "" {
+						assistant.Role = MessageRoleAssistant
+					}
+				}
+				if assistant.CreatedAt.IsZero() {
+					assistant.CreatedAt = time.Now().UTC()
+				}
+				if assistant.StopReason == "" {
+					if len(collectToolCalls(assistant)) > 0 {
+						assistant.StopReason = StopReasonToolUse
+					} else {
+						assistant.StopReason = StopReasonStop
+					}
+				}
+				done = true
+				emit(Event{Type: EventMessageEnd, Message: messagePtr(assistant)})
+
+			case ProviderEventError:
+				if event.Error == "" {
+					return Message{}, errors.New("loop: provider error")
+				}
+				return Message{}, errors.New(event.Error)
+
+			default:
+				return Message{}, fmt.Errorf("loop: unknown provider event type %q", event.Type)
+			}
+		}
+	}
+}
+
+func appendDelta(message *Message, kind ContentType, index int, delta string) {
+	if index >= 0 && index < len(message.Content) && message.Content[index].Type == kind {
+		appendToPart(&message.Content[index], delta)
+		return
+	}
+	last := len(message.Content) - 1
+	if last >= 0 && message.Content[last].Type == kind {
+		appendToPart(&message.Content[last], delta)
+		return
+	}
+	part := ContentPart{Type: kind}
+	appendToPart(&part, delta)
+	message.Content = append(message.Content, part)
+}
+
+func appendToPart(part *ContentPart, delta string) {
+	switch part.Type {
+	case ContentTypeText:
+		part.Text += delta
+	case ContentTypeThinking:
+		part.Thinking += delta
+	}
+}
+
+func collectToolCalls(message Message) []ToolCall {
+	calls := make([]ToolCall, 0)
+	for _, part := range message.Content {
+		if part.Type == ContentTypeToolCall && part.ToolCall != nil {
+			calls = append(calls, *part.ToolCall)
+		}
+	}
+	return calls
+}
+
+func toolSpecs(tools []Tool) []ToolSpec {
+	specs := make([]ToolSpec, 0, len(tools))
+	for _, tool := range tools {
+		specs = append(specs, tool.ToolSpec)
+	}
+	return specs
+}
+
+func cloneMessages(messages []Message) []Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]Message, len(messages))
+	for i, m := range messages {
+		out[i] = cloneMessage(m)
+	}
+	return out
+}
+
+func cloneMessage(message Message) Message {
+	message.Content = cloneContent(message.Content)
+	message.Metadata = cloneMetadata(message.Metadata)
+	if message.Usage != nil {
+		usage := *message.Usage
+		message.Usage = &usage
+	}
+	return message
+}
+
+func messagePtr(message Message) *Message {
+	cloned := cloneMessage(message)
+	return &cloned
+}
+
+func toolCallPtr(call ToolCall) *ToolCall {
+	cloned := call
+	if len(cloned.Arguments) > 0 {
+		cloned.Arguments = append(cloned.Arguments[:0:0], cloned.Arguments...)
+	}
+	return &cloned
+}
+
+func cloneContent(content []ContentPart) []ContentPart {
+	if len(content) == 0 {
+		return nil
+	}
+	out := make([]ContentPart, len(content))
+	copy(out, content)
+	for i := range out {
+		if out[i].Image != nil {
+			image := *out[i].Image
+			out[i].Image = &image
+		}
+		if out[i].ToolCall != nil {
+			call := *out[i].ToolCall
+			if len(call.Arguments) > 0 {
+				call.Arguments = append(call.Arguments[:0:0], call.Arguments...)
+			}
+			out[i].ToolCall = &call
+		}
+	}
+	return out
+}
+
+func cloneOptions(options map[string]any) map[string]any { return cloneMetadata(options) }
+
+func cloneMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(metadata))
+	for k, v := range metadata {
+		out[k] = v
+	}
+	return out
+}

--- a/loop/run_test.go
+++ b/loop/run_test.go
@@ -1,0 +1,324 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeProvider scripts a sequence of provider responses, one per assistant turn.
+type fakeProvider struct {
+	mu     sync.Mutex
+	turns  [][]ProviderEvent
+	calls  int
+	openCh chan ProviderEvent // optional: returned from the first call when set
+}
+
+func (p *fakeProvider) Stream(ctx context.Context, _ ProviderRequest) (<-chan ProviderEvent, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.openCh != nil {
+		ch := p.openCh
+		p.openCh = nil
+		return ch, nil
+	}
+	if p.calls >= len(p.turns) {
+		ch := make(chan ProviderEvent)
+		close(ch)
+		return ch, nil
+	}
+	events := p.turns[p.calls]
+	p.calls++
+	ch := make(chan ProviderEvent, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+type erroringProvider struct{ err error }
+
+func (p erroringProvider) Stream(context.Context, ProviderRequest) (<-chan ProviderEvent, error) {
+	return nil, p.err
+}
+
+func TestRunRequiresProvider(t *testing.T) {
+	t.Parallel()
+	if _, err := Run(context.Background(), RunRequest{}); err == nil {
+		t.Fatal("err = nil, want error")
+	}
+}
+
+func TestRunTextOnlyResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{turns: [][]ProviderEvent{{
+		{Type: ProviderEventStart},
+		{Type: ProviderEventTextDelta, Delta: "hello"},
+		{Type: ProviderEventTextDelta, Delta: " world"},
+		{Type: ProviderEventDone},
+	}}}
+
+	var seen []EventType
+	res, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Model:    "fake-1",
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "hi"}}}},
+		Emit:     func(e Event) { seen = append(seen, e.Type) },
+	})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(res.NewMessages) != 1 {
+		t.Fatalf("new messages = %d, want 1", len(res.NewMessages))
+	}
+	final := res.NewMessages[0]
+	if final.Role != MessageRoleAssistant {
+		t.Fatalf("role = %q, want assistant", final.Role)
+	}
+	if got := assistantText(final); got != "hello world" {
+		t.Fatalf("text = %q, want %q", got, "hello world")
+	}
+	if final.StopReason != StopReasonStop {
+		t.Fatalf("stop reason = %q, want stop", final.StopReason)
+	}
+	if len(res.Messages) != 2 {
+		t.Fatalf("transcript = %d, want 2 (1 user + 1 assistant)", len(res.Messages))
+	}
+	if seen[0] != EventLoopStart || seen[len(seen)-1] != EventLoopEnd {
+		t.Fatalf("event bookends = %q...%q, want loop_start...loop_end (full: %v)",
+			seen[0], seen[len(seen)-1], seen)
+	}
+}
+
+func TestRunRepeatedToolTurns(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{turns: [][]ProviderEvent{
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "c1", Name: "echo", Arguments: json.RawMessage(`{"v":"a"}`)}},
+			{Type: ProviderEventDone},
+		},
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "c2", Name: "echo", Arguments: json.RawMessage(`{"v":"b"}`)}},
+			{Type: ProviderEventDone},
+		},
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventTextDelta, Delta: "done"},
+			{Type: ProviderEventDone},
+		},
+	}}
+
+	echo := Tool{
+		ToolSpec: ToolSpec{Name: "echo", Description: "echoes v"},
+		Execute: func(_ context.Context, call ToolCall) (ToolResult, error) {
+			var args map[string]string
+			if err := json.Unmarshal(call.Arguments, &args); err != nil {
+				return ToolResult{}, err
+			}
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: args["v"]}}}, nil
+		},
+	}
+
+	res, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Tools:    []Tool{echo},
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "go"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	wantRoles := []MessageRole{MessageRoleAssistant, MessageRoleTool, MessageRoleAssistant, MessageRoleTool, MessageRoleAssistant}
+	if len(res.NewMessages) != len(wantRoles) {
+		t.Fatalf("new messages = %d, want %d", len(res.NewMessages), len(wantRoles))
+	}
+	for i, role := range wantRoles {
+		if res.NewMessages[i].Role != role {
+			t.Fatalf("new[%d].Role = %q, want %q", i, res.NewMessages[i].Role, role)
+		}
+	}
+	if got := res.NewMessages[1].Content[0].Text; got != "a" {
+		t.Fatalf("tool1 result = %q, want a", got)
+	}
+	if got := res.NewMessages[3].Content[0].Text; got != "b" {
+		t.Fatalf("tool2 result = %q, want b", got)
+	}
+	if res.NewMessages[1].ToolCallID != "c1" || res.NewMessages[3].ToolCallID != "c2" {
+		t.Fatalf("tool call ids = %q,%q, want c1,c2",
+			res.NewMessages[1].ToolCallID, res.NewMessages[3].ToolCallID)
+	}
+	if got := assistantText(res.NewMessages[4]); got != "done" {
+		t.Fatalf("final text = %q, want done", got)
+	}
+	if len(res.Messages) != 1+len(wantRoles) {
+		t.Fatalf("transcript = %d, want %d", len(res.Messages), 1+len(wantRoles))
+	}
+}
+
+func TestRunProviderStreamEventError(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{turns: [][]ProviderEvent{{
+		{Type: ProviderEventStart},
+		{Type: ProviderEventError, Error: "boom"},
+	}}}
+
+	var seenError string
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Emit: func(e Event) {
+			if e.Type == EventError {
+				seenError = e.Error
+			}
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want containing 'boom'", err)
+	}
+	if seenError != err.Error() {
+		t.Fatalf("emitted error = %q, want %q", seenError, err.Error())
+	}
+}
+
+func TestRunProviderStreamReturnError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("network down")
+	_, err := Run(context.Background(), RunRequest{Provider: erroringProvider{err: want}})
+	if err == nil || !errors.Is(err, want) {
+		t.Fatalf("err = %v, want wrapping %v", err, want)
+	}
+}
+
+func TestRunContextPreCanceled(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{turns: [][]ProviderEvent{{{Type: ProviderEventStart}, {Type: ProviderEventDone}}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Run(ctx, RunRequest{Provider: provider})
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestRunContextCancelMidStream(t *testing.T) {
+	t.Parallel()
+
+	open := make(chan ProviderEvent)
+	provider := &fakeProvider{openCh: open}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := Run(ctx, RunRequest{Provider: provider})
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	close(open)
+}
+
+func TestRunMaxTurnsExplicit(t *testing.T) {
+	t.Parallel()
+
+	turns := make([][]ProviderEvent, 5)
+	for i := range turns {
+		turns[i] = []ProviderEvent{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "x", Name: "noop", Arguments: json.RawMessage(`{}`)}},
+			{Type: ProviderEventDone},
+		}
+	}
+	noop := Tool{
+		ToolSpec: ToolSpec{Name: "noop"},
+		Execute:  func(context.Context, ToolCall) (ToolResult, error) { return ToolResult{}, nil },
+	}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: &fakeProvider{turns: turns},
+		Tools:    []Tool{noop},
+		MaxTurns: 2,
+	})
+	if err == nil || !strings.Contains(err.Error(), "maximum turns exceeded (2)") {
+		t.Fatalf("err = %v, want max turns 2", err)
+	}
+}
+
+func TestRunMaxTurnsDefaultIs32(t *testing.T) {
+	t.Parallel()
+
+	turns := make([][]ProviderEvent, 50)
+	for i := range turns {
+		turns[i] = []ProviderEvent{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "x", Name: "noop", Arguments: json.RawMessage(`{}`)}},
+			{Type: ProviderEventDone},
+		}
+	}
+	noop := Tool{
+		ToolSpec: ToolSpec{Name: "noop"},
+		Execute:  func(context.Context, ToolCall) (ToolResult, error) { return ToolResult{}, nil },
+	}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: &fakeProvider{turns: turns},
+		Tools:    []Tool{noop},
+	})
+	if err == nil || !strings.Contains(err.Error(), "maximum turns exceeded (32)") {
+		t.Fatalf("err = %v, want default max turns 32", err)
+	}
+}
+
+func TestRunEmitsEventsInOrder(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{turns: [][]ProviderEvent{{
+		{Type: ProviderEventStart},
+		{Type: ProviderEventTextDelta, Delta: "ok"},
+		{Type: ProviderEventDone},
+	}}}
+
+	var got []EventType
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Emit:     func(e Event) { got = append(got, e.Type) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []EventType{
+		EventLoopStart,
+		EventTurnStart,
+		EventMessageStart,
+		EventTextDelta,
+		EventMessageEnd,
+		EventTurnEnd,
+		EventLoopEnd,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("event types = %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("types[%d] = %q, want %q (full: %v)", i, got[i], w, got)
+		}
+	}
+}
+
+func assistantText(m Message) string {
+	var b strings.Builder
+	for _, p := range m.Content {
+		if p.Type == ContentTypeText {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Adds `loop.Run` — the provider-agnostic agent loop. It streams provider events, builds the assistant message, executes any tool calls, appends tool-result messages, and repeats until the assistant stops, the provider errors, the context is canceled, or MaxTurns is reached.

**Public surface (in `package loop`)**

- `RunRequest` — provider, model, system prompt, messages, tools, options, optional `MaxTurns`, `Emit func(Event)`.
- `RunResult` — `Messages` (full transcript) and `NewMessages` (messages produced during this run, in append order).
- `Run(ctx, req) (RunResult, error)` — entry point.

**Behavior**

- Stream provider events: `start`, `text_delta`, `thinking_delta`, `tool_call`, `done`, `error`.
- Append final assistant message; if it has tool calls, execute them; otherwise stop.
- Default `MaxTurns` = 32; explicit override honored.
- `Emit` receives `loop_start` / `turn_start` / `message_start` / `text_delta` / `message_end` / `tool_start` / `tool_end` / `turn_end` / `error` / `loop_end` in source order.
- Tool execution is intentionally minimal — resolve by name, invoke, propagate errors. The deterministic-ordering and error-as-tool-result semantics belong to #6.

**Boundaries**

- `loop` has no upward import on `glue`, providers, stores, CLI, or context loaders. Verified by inspection — only stdlib imports (`context`, `encoding/json`, `errors`, `fmt`, `time`).

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./loop/... -v
... 16 tests pass ...
ok  	glue/loop	0.025s
$ go test ./...
?   	glue	[no test files]
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	0.024s
?   	glue/providers/gemini	[no test files]
?   	glue/stores/file	[no test files]
```

Tests covering acceptance criteria:

- `TestRunTextOnlyResponse` — text-only response shape, transcript, stop reason.
- `TestRunRepeatedToolTurns` — 2 tool turns + final text, role ordering, tool-call linkage.
- `TestRunProviderStreamEventError` / `TestRunProviderStreamReturnError` — provider errors at event and call level.
- `TestRunContextPreCanceled` / `TestRunContextCancelMidStream` — cancellation before and during a stream.
- `TestRunMaxTurnsExplicit` / `TestRunMaxTurnsDefaultIs32` — cap enforcement at custom and default values.
- `TestRunEmitsEventsInOrder` — exact event ordering for a text-only run.
- `TestRunRequiresProvider` — input validation.

Closes #5.