### PR TITLE
Add deterministic sequential tool execution (closes #6)

### DIFF
--- a/loop/run.go
+++ b/loop/run.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -38,11 +39,12 @@ type RunResult struct {
 // requesting tools, the provider errors, the context is canceled, or
 // MaxTurns is reached.
 //
-// Tool execution in this implementation is intentionally minimal: tools are
-// matched by name and called with the raw assistant arguments. Argument
-// normalization, error-as-tool-result conversion, and ordering guarantees
-// belong to the deterministic sequential execution path landing in a
-// follow-up issue.
+// Tool execution is sequential and deterministic: requested tool calls are
+// executed in the order they appear in the assistant message, their result
+// messages are appended in that same order, and unknown tools, invalid JSON
+// arguments, missing executors, and executor errors all become tool-result
+// messages with IsError=true so the model can see and react instead of the
+// loop crashing.
 func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if req.Provider == nil {
 		return RunResult{}, errors.New("loop: provider is required")
@@ -105,19 +107,18 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				ToolName:   call.Name,
 			})
 
-			toolMessage, err := executeBasicTool(ctx, req.Tools, call)
-			if err != nil {
-				return fail(err)
-			}
+			normalizedCall, toolResult := executeToolCall(ctx, req.Tools, call)
+			toolMessage := toolResultMessage(normalizedCall, toolResult)
 
 			messages = append(messages, toolMessage)
 			newMessages = append(newMessages, toolMessage)
 
 			emit(Event{
 				Type:       EventToolEnd,
-				ToolCall:   toolCallPtr(call),
-				ToolCallID: call.ID,
-				ToolName:   call.Name,
+				ToolCall:   toolCallPtr(normalizedCall),
+				ToolCallID: normalizedCall.ID,
+				ToolName:   normalizedCall.Name,
+				ToolResult: toolResultPtr(toolResult),
 				Message:    messagePtr(toolMessage),
 			})
 		}
@@ -128,32 +129,86 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return fail(fmt.Errorf("loop: maximum turns exceeded (%d)", maxTurns))
 }
 
-// executeBasicTool resolves a tool by name and invokes its executor with the
-// raw assistant arguments. Errors propagate; richer error-as-tool-result
-// behavior lands in the deterministic sequential execution issue.
-func executeBasicTool(ctx context.Context, tools []Tool, call ToolCall) (Message, error) {
+// executeToolCall normalizes a single tool call's arguments and invokes its
+// executor. Unknown tools, missing executors, invalid JSON arguments, and
+// executor errors all return a ToolResult with IsError=true so the loop can
+// surface them to the model instead of failing the whole run.
+//
+// The first return value is the (possibly argument-normalized) tool call
+// that should be referenced by the resulting tool message.
+func executeToolCall(ctx context.Context, tools []Tool, call ToolCall) (ToolCall, ToolResult) {
+	normalizedCall, err := normalizeToolCallArguments(call)
+	if err != nil {
+		return call, errorToolResult(fmt.Sprintf("invalid arguments for tool %q: %v", call.Name, err))
+	}
+
 	for _, tool := range tools {
-		if tool.Name != call.Name {
+		if tool.Name != normalizedCall.Name {
 			continue
 		}
 		if tool.Execute == nil {
-			return Message{}, fmt.Errorf("loop: tool %q has no executor", call.Name)
+			return normalizedCall, errorToolResult(fmt.Sprintf("tool %q has no executor", normalizedCall.Name))
 		}
-		result, err := tool.Execute(ctx, call)
+		result, err := tool.Execute(ctx, normalizedCall)
 		if err != nil {
-			return Message{}, fmt.Errorf("loop: tool %q execute: %w", call.Name, err)
+			return normalizedCall, errorToolResult(err.Error())
 		}
-		return Message{
-			Role:       MessageRoleTool,
-			Content:    cloneContent(result.Content),
-			ToolCallID: call.ID,
-			ToolName:   call.Name,
-			IsError:    result.IsError,
-			CreatedAt:  time.Now().UTC(),
-			Metadata:   cloneMetadata(result.Metadata),
-		}, nil
+		return normalizedCall, result
 	}
-	return Message{}, fmt.Errorf("loop: unknown tool %q", call.Name)
+	return normalizedCall, errorToolResult(fmt.Sprintf("unknown tool %q", normalizedCall.Name))
+}
+
+// normalizeToolCallArguments enforces that arguments are a JSON object and
+// substitutes "{}" for empty arguments. The returned call always has a
+// non-empty Arguments slice.
+func normalizeToolCallArguments(call ToolCall) (ToolCall, error) {
+	if len(call.Arguments) == 0 {
+		call.Arguments = json.RawMessage(`{}`)
+		return call, nil
+	}
+
+	var args map[string]any
+	if err := json.Unmarshal(call.Arguments, &args); err != nil {
+		return call, err
+	}
+	if args == nil {
+		return call, errors.New("arguments must be a JSON object")
+	}
+
+	normalized, err := json.Marshal(args)
+	if err != nil {
+		return call, err
+	}
+	call.Arguments = normalized
+	return call, nil
+}
+
+func errorToolResult(text string) ToolResult {
+	return ToolResult{
+		Content: []ContentPart{{Type: ContentTypeText, Text: text}},
+		IsError: true,
+	}
+}
+
+func toolResultMessage(call ToolCall, result ToolResult) Message {
+	return Message{
+		Role:       MessageRoleTool,
+		Content:    cloneContent(result.Content),
+		ToolCallID: call.ID,
+		ToolName:   call.Name,
+		IsError:    result.IsError,
+		CreatedAt:  time.Now().UTC(),
+		Metadata:   cloneMetadata(result.Metadata),
+	}
+}
+
+func toolResultPtr(result ToolResult) *ToolResult {
+	cloned := ToolResult{
+		Content:  cloneContent(result.Content),
+		IsError:  result.IsError,
+		Metadata: cloneMetadata(result.Metadata),
+	}
+	return &cloned
 }
 
 func runAssistantTurn(ctx context.Context, req RunRequest, messages []Message, emit func(Event)) (Message, error) {

--- a/loop/tool_exec_test.go
+++ b/loop/tool_exec_test.go
@@ -1,0 +1,283 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// scriptTwoToolCallsThenStop returns a fake provider whose first turn issues
+// two tool calls in the given order and whose second turn returns a final
+// "ok" text response.
+func scriptTwoToolCallsThenStop(calls ...ToolCall) *fakeProvider {
+	first := []ProviderEvent{{Type: ProviderEventStart}}
+	for i := range calls {
+		c := calls[i]
+		first = append(first, ProviderEvent{Type: ProviderEventToolCall, ToolCall: &c})
+	}
+	first = append(first, ProviderEvent{Type: ProviderEventDone})
+	return &fakeProvider{turns: [][]ProviderEvent{
+		first,
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventTextDelta, Delta: "ok"},
+			{Type: ProviderEventDone},
+		},
+	}}
+}
+
+func runWithTools(t *testing.T, p Provider, tools ...Tool) RunResult {
+	t.Helper()
+	res, err := Run(context.Background(), RunRequest{Provider: p, Tools: tools})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	return res
+}
+
+func TestExecToolValidArgsHappyPath(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "echo", Arguments: json.RawMessage(`{"v":"hi"}`)},
+	)
+	echo := Tool{
+		ToolSpec: ToolSpec{Name: "echo"},
+		Execute: func(_ context.Context, call ToolCall) (ToolResult, error) {
+			var args map[string]string
+			if err := json.Unmarshal(call.Arguments, &args); err != nil {
+				return ToolResult{}, err
+			}
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: args["v"]}}}, nil
+		},
+	}
+	res := runWithTools(t, provider, echo)
+
+	tool := res.NewMessages[1]
+	if tool.Role != MessageRoleTool || tool.IsError {
+		t.Fatalf("tool message = %+v, want non-error tool message", tool)
+	}
+	if got := tool.Content[0].Text; got != "hi" {
+		t.Fatalf("content = %q, want %q", got, "hi")
+	}
+}
+
+func TestExecToolInvalidJSONArgs(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "echo", Arguments: json.RawMessage(`not-json`)},
+	)
+	echo := Tool{
+		ToolSpec: ToolSpec{Name: "echo"},
+		Execute:  func(context.Context, ToolCall) (ToolResult, error) { return ToolResult{}, nil },
+	}
+	res := runWithTools(t, provider, echo)
+
+	tool := res.NewMessages[1]
+	if !tool.IsError {
+		t.Fatalf("IsError = false, want true; content=%q", tool.Content[0].Text)
+	}
+	if !strings.Contains(tool.Content[0].Text, "invalid arguments") {
+		t.Fatalf("content = %q, want 'invalid arguments'", tool.Content[0].Text)
+	}
+}
+
+func TestExecToolNonObjectArgs(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"array":  `[1,2,3]`,
+		"null":   `null`,
+		"number": `42`,
+		"string": `"oops"`,
+	}
+	for name, args := range cases {
+		args := args
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			provider := scriptTwoToolCallsThenStop(
+				ToolCall{ID: "c1", Name: "echo", Arguments: json.RawMessage(args)},
+			)
+			echo := Tool{ToolSpec: ToolSpec{Name: "echo"}, Execute: func(context.Context, ToolCall) (ToolResult, error) { return ToolResult{}, nil }}
+			res := runWithTools(t, provider, echo)
+			tool := res.NewMessages[1]
+			if !tool.IsError {
+				t.Fatalf("IsError = false, want true; content=%q", tool.Content[0].Text)
+			}
+			if !strings.Contains(tool.Content[0].Text, "invalid arguments for tool \"echo\"") {
+				t.Fatalf("content = %q, want phrase 'invalid arguments for tool \"echo\"'", tool.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestExecToolUnknownTool(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "ghost", Arguments: json.RawMessage(`{}`)},
+	)
+	res := runWithTools(t, provider /* no tools */)
+
+	tool := res.NewMessages[1]
+	if !tool.IsError {
+		t.Fatalf("IsError = false, want true")
+	}
+	if !strings.Contains(tool.Content[0].Text, `unknown tool "ghost"`) {
+		t.Fatalf("content = %q, want unknown tool", tool.Content[0].Text)
+	}
+}
+
+func TestExecToolMissingExecutor(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "stub", Arguments: json.RawMessage(`{}`)},
+	)
+	stub := Tool{ToolSpec: ToolSpec{Name: "stub"}, Execute: nil}
+	res := runWithTools(t, provider, stub)
+
+	tool := res.NewMessages[1]
+	if !tool.IsError {
+		t.Fatalf("IsError = false, want true")
+	}
+	if !strings.Contains(tool.Content[0].Text, "no executor") {
+		t.Fatalf("content = %q, want 'no executor'", tool.Content[0].Text)
+	}
+}
+
+func TestExecToolExecutorError(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "fail", Arguments: json.RawMessage(`{}`)},
+	)
+	fail := Tool{
+		ToolSpec: ToolSpec{Name: "fail"},
+		Execute:  func(context.Context, ToolCall) (ToolResult, error) { return ToolResult{}, errors.New("kaboom") },
+	}
+	res := runWithTools(t, provider, fail)
+
+	tool := res.NewMessages[1]
+	if !tool.IsError {
+		t.Fatalf("IsError = false, want true")
+	}
+	if tool.Content[0].Text != "kaboom" {
+		t.Fatalf("content = %q, want 'kaboom'", tool.Content[0].Text)
+	}
+}
+
+func TestExecToolEmptyArgsDefaultToObject(t *testing.T) {
+	t.Parallel()
+
+	var seen json.RawMessage
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "noop"}, // no arguments at all
+	)
+	noop := Tool{
+		ToolSpec: ToolSpec{Name: "noop"},
+		Execute: func(_ context.Context, call ToolCall) (ToolResult, error) {
+			seen = call.Arguments
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: "done"}}}, nil
+		},
+	}
+	res := runWithTools(t, provider, noop)
+
+	if string(seen) != "{}" {
+		t.Fatalf("executor saw arguments = %q, want \"{}\"", string(seen))
+	}
+	tool := res.NewMessages[1]
+	if tool.IsError {
+		t.Fatalf("IsError = true, want false; content=%q", tool.Content[0].Text)
+	}
+}
+
+func TestExecToolPreservesAssistantSourceOrder(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "tag", Arguments: json.RawMessage(`{"n":"first"}`)},
+		ToolCall{ID: "c2", Name: "tag", Arguments: json.RawMessage(`{"n":"second"}`)},
+		ToolCall{ID: "c3", Name: "tag", Arguments: json.RawMessage(`{"n":"third"}`)},
+	)
+	tag := Tool{
+		ToolSpec: ToolSpec{Name: "tag"},
+		Execute: func(_ context.Context, call ToolCall) (ToolResult, error) {
+			var a map[string]string
+			_ = json.Unmarshal(call.Arguments, &a)
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: a["n"]}}}, nil
+		},
+	}
+	res := runWithTools(t, provider, tag)
+
+	// new = [assistant1, tool1, tool2, tool3, assistant2]
+	wantRoles := []MessageRole{
+		MessageRoleAssistant, MessageRoleTool, MessageRoleTool, MessageRoleTool, MessageRoleAssistant,
+	}
+	if len(res.NewMessages) != len(wantRoles) {
+		t.Fatalf("len(NewMessages) = %d, want %d", len(res.NewMessages), len(wantRoles))
+	}
+	for i, want := range wantRoles {
+		if got := res.NewMessages[i].Role; got != want {
+			t.Fatalf("NewMessages[%d].Role = %q, want %q", i, got, want)
+		}
+	}
+	gotIDs := []string{
+		res.NewMessages[1].ToolCallID,
+		res.NewMessages[2].ToolCallID,
+		res.NewMessages[3].ToolCallID,
+	}
+	wantIDs := []string{"c1", "c2", "c3"}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Fatalf("tool[%d] ToolCallID = %q, want %q (full: %v)", i, gotIDs[i], wantIDs[i], gotIDs)
+		}
+	}
+	gotTexts := []string{
+		res.NewMessages[1].Content[0].Text,
+		res.NewMessages[2].Content[0].Text,
+		res.NewMessages[3].Content[0].Text,
+	}
+	wantTexts := []string{"first", "second", "third"}
+	for i := range wantTexts {
+		if gotTexts[i] != wantTexts[i] {
+			t.Fatalf("tool[%d] text = %q, want %q (full: %v)", i, gotTexts[i], wantTexts[i], gotTexts)
+		}
+	}
+}
+
+func TestExecToolMixedSuccessAndErrorOrdering(t *testing.T) {
+	t.Parallel()
+
+	provider := scriptTwoToolCallsThenStop(
+		ToolCall{ID: "c1", Name: "ok", Arguments: json.RawMessage(`{}`)},
+		ToolCall{ID: "c2", Name: "ghost", Arguments: json.RawMessage(`{}`)},
+		ToolCall{ID: "c3", Name: "ok", Arguments: json.RawMessage(`{}`)},
+	)
+	ok := Tool{
+		ToolSpec: ToolSpec{Name: "ok"},
+		Execute: func(context.Context, ToolCall) (ToolResult, error) {
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: "ok"}}}, nil
+		},
+	}
+	res := runWithTools(t, provider, ok)
+
+	if got := res.NewMessages[1].IsError; got {
+		t.Fatalf("[1].IsError = true, want false (c1 ok)")
+	}
+	if got := res.NewMessages[2].IsError; !got {
+		t.Fatalf("[2].IsError = false, want true (c2 ghost)")
+	}
+	if got := res.NewMessages[3].IsError; got {
+		t.Fatalf("[3].IsError = true, want false (c3 ok)")
+	}
+	wantIDs := []string{"c1", "c2", "c3"}
+	for i, want := range wantIDs {
+		if got := res.NewMessages[i+1].ToolCallID; got != want {
+			t.Fatalf("[%d] ToolCallID = %q, want %q", i+1, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Wraps the loop's tool-call path with full deterministic sequential semantics. The loop already executed tools in source order (#5), but a malformed argument or an unknown tool name would fail the whole run. Now those failure modes become tool-result messages with `IsError: true` so the model can see and react.

**Behavior changes (`loop/run.go`)**

- `executeToolCall(ctx, tools, call) (ToolCall, ToolResult)` — never errors at the loop level. Unknown tool, missing executor, invalid JSON args, executor error — all become `errorToolResult(...)`.
- `normalizeToolCallArguments` — empty `Arguments` default to `{}`; non-object JSON (array / null / number / string) and malformed JSON yield an "invalid arguments for tool …" error tool result.
- `EventToolEnd` events now carry the `ToolResult` for observability.

**Tests added (`loop/tool_exec_test.go`)**

- valid args happy path
- invalid JSON args
- non-object args (array / null / number / string subtests)
- unknown tool name
- missing executor
- executor error
- empty arguments default to `{}`
- transcript ordering across 3 successful tool calls
- transcript ordering with mixed success/error tool results

The `loop` package is still stdlib-only (added `encoding/json` for normalization).

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./loop/... -v
... 24 tests, all PASS ...
ok  	glue/loop	0.025s
$ go test ./...
?   	glue	[no test files]
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	0.025s
?   	glue/providers/gemini	[no test files]
?   	glue/stores/file	[no test files]
```

Closes #6.