### PR TITLE
Wire public Agent and Session over the loop (closes #7)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1,0 +1,118 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+const defaultSessionID = "default"
+
+// AgentOptions configures a Glue agent.
+//
+// Provider, Model, SystemPrompt, Tools, Options, and MaxTurns are wired in
+// this issue. Store, WorkDir, Role, and Roles are reserved for follow-up
+// issues and currently have no effect:
+//
+//   - Store: file-backed session persistence (#11).
+//   - WorkDir: AGENTS.md context and Markdown skill discovery (#13).
+//   - Role / Roles: scoped role instructions and per-role models (#14).
+//
+// They are present so the public type stays stable as those features land.
+type AgentOptions struct {
+	Provider     Provider
+	Model        string
+	SystemPrompt string
+	Tools        []Tool
+	Options      map[string]any
+	MaxTurns     int
+
+	// Store is reserved for #11.
+	Store any
+	// WorkDir is reserved for #13.
+	WorkDir string
+	// Role is reserved for #14.
+	Role string
+	// Roles is reserved for #14.
+	Roles map[string]any
+}
+
+// Agent owns shared configuration and an in-memory session map.
+type Agent struct {
+	provider     Provider
+	model        string
+	systemPrompt string
+	tools        []Tool
+	options      map[string]any
+	maxTurns     int
+
+	mu       sync.Mutex
+	sessions map[string]*Session
+}
+
+// NewAgent creates an agent with in-memory session state. The Provider must
+// be supplied for [Session.Prompt] to succeed.
+func NewAgent(options AgentOptions) *Agent {
+	return &Agent{
+		provider:     options.Provider,
+		model:        options.Model,
+		systemPrompt: options.SystemPrompt,
+		tools:        cloneTools(options.Tools),
+		options:      cloneMap(options.Options),
+		maxTurns:     options.MaxTurns,
+		sessions:     make(map[string]*Session),
+	}
+}
+
+// Session returns an existing in-memory session by id or creates a new one.
+// Empty ids resolve to the default session ("default").
+func (a *Agent) Session(_ context.Context, id string) (*Session, error) {
+	if a == nil {
+		return nil, errors.New("glue: nil agent")
+	}
+	if id == "" {
+		id = defaultSessionID
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if existing := a.sessions[id]; existing != nil {
+		return existing, nil
+	}
+	now := time.Now().UTC()
+	session := &Session{
+		id:          id,
+		agent:       a,
+		createdAt:   now,
+		updatedAt:   now,
+		subscribers: make(map[int]func(Event)),
+	}
+	a.sessions[id] = session
+	return session, nil
+}
+
+func cloneTools(tools []Tool) []Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]Tool, len(tools))
+	copy(out, tools)
+	for i := range out {
+		if len(out[i].Parameters) > 0 {
+			out[i].Parameters = append(out[i].Parameters[:0:0], out[i].Parameters...)
+		}
+	}
+	return out
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,0 +1,241 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// recordingProvider scripts a sequence of provider responses, one per turn,
+// and captures the ProviderRequest seen on each call.
+type recordingProvider struct {
+	turns    [][]ProviderEvent
+	calls    int
+	requests []ProviderRequest
+}
+
+func (p *recordingProvider) Stream(_ context.Context, req ProviderRequest) (<-chan ProviderEvent, error) {
+	if p.calls >= len(p.turns) {
+		return nil, errors.New("recordingProvider: unexpected call")
+	}
+	p.requests = append(p.requests, req)
+	events := p.turns[p.calls]
+	p.calls++
+	ch := make(chan ProviderEvent, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+func textTurn(text string) []ProviderEvent {
+	return []ProviderEvent{
+		{Type: ProviderEventStart},
+		{Type: ProviderEventTextDelta, Delta: text},
+		{Type: ProviderEventDone},
+	}
+}
+
+func TestSessionPromptHappyPath(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("hello")}}
+	agent := NewAgent(AgentOptions{
+		Provider:     provider,
+		Model:        "fake-1",
+		SystemPrompt: "be terse",
+	})
+	session, err := agent.Session(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	res, err := session.Prompt(context.Background(), "say hello")
+	if err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if res.Text != "hello" {
+		t.Fatalf("Text = %q, want hello", res.Text)
+	}
+	if res.Message == nil || res.Message.Role != MessageRoleAssistant {
+		t.Fatalf("Message = %#v, want assistant message", res.Message)
+	}
+	if len(res.NewMessages) != 1 {
+		t.Fatalf("NewMessages = %d, want 1", len(res.NewMessages))
+	}
+	if len(res.Messages) != 2 {
+		t.Fatalf("Messages = %d, want 2 (user + assistant)", len(res.Messages))
+	}
+	if got := provider.requests[0].SystemPrompt; got != "be terse" {
+		t.Fatalf("SystemPrompt = %q, want 'be terse'", got)
+	}
+	if got := provider.requests[0].Model; got != "fake-1" {
+		t.Fatalf("Model = %q, want fake-1", got)
+	}
+}
+
+func TestSessionPromptContinuation(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("hi"), textTurn("again")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Model: "m"})
+	session, err := agent.Session(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+	if session.ID() != "default" {
+		t.Fatalf("ID = %q, want default", session.ID())
+	}
+
+	if _, err := session.Prompt(context.Background(), "first"); err != nil {
+		t.Fatalf("first Prompt: %v", err)
+	}
+	if _, err := session.Prompt(context.Background(), "second"); err != nil {
+		t.Fatalf("second Prompt: %v", err)
+	}
+
+	if provider.calls != 2 {
+		t.Fatalf("calls = %d, want 2", provider.calls)
+	}
+	// The 2nd request should carry: user-1, assistant-1, user-2 (3 messages).
+	got := provider.requests[1].Messages
+	wantRoles := []MessageRole{MessageRoleUser, MessageRoleAssistant, MessageRoleUser}
+	if len(got) != len(wantRoles) {
+		t.Fatalf("2nd request len = %d, want %d", len(got), len(wantRoles))
+	}
+	for i, r := range wantRoles {
+		if got[i].Role != r {
+			t.Fatalf("2nd request [%d].Role = %q, want %q", i, got[i].Role, r)
+		}
+	}
+	if len(session.Messages()) != 4 {
+		t.Fatalf("transcript = %d, want 4 (u/a/u/a)", len(session.Messages()))
+	}
+}
+
+func TestSessionSubscribeAndUnsubscribe(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("a"), textTurn("b")}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var seen []EventType
+	unsubscribe := session.Subscribe(func(e Event) { seen = append(seen, e.Type) })
+	if _, err := session.Prompt(context.Background(), "first"); err != nil {
+		t.Fatal(err)
+	}
+	firstCount := len(seen)
+	if firstCount == 0 || !containsEventType(seen, EventLoopStart) || !containsEventType(seen, EventLoopEnd) {
+		t.Fatalf("first run events = %v, want some incl. loop_start/loop_end", seen)
+	}
+
+	unsubscribe()
+	if _, err := session.Prompt(context.Background(), "second"); err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != firstCount {
+		t.Fatalf("after unsubscribe: events grew from %d to %d", firstCount, len(seen))
+	}
+}
+
+func TestSessionPromptWithEvents(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var perPrompt []EventType
+	if _, err := session.Prompt(context.Background(), "go", WithEvents(func(e Event) {
+		perPrompt = append(perPrompt, e.Type)
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if !containsEventType(perPrompt, EventLoopStart) || !containsEventType(perPrompt, EventLoopEnd) {
+		t.Fatalf("per-prompt events = %v, missing loop bookends", perPrompt)
+	}
+}
+
+func TestSessionSubscribeAndWithEventsBothFire(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var subCount, perCount int
+	session.Subscribe(func(Event) { subCount++ })
+	if _, err := session.Prompt(context.Background(), "go", WithEvents(func(Event) { perCount++ })); err != nil {
+		t.Fatal(err)
+	}
+	if subCount == 0 || perCount == 0 {
+		t.Fatalf("subCount=%d perCount=%d, want both > 0", subCount, perCount)
+	}
+	if subCount != perCount {
+		t.Fatalf("subCount=%d perCount=%d, want equal", subCount, perCount)
+	}
+}
+
+func TestSessionPromptWithModelOverride(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Model: "default-model"})
+	session, _ := agent.Session(context.Background(), "x")
+
+	if _, err := session.Prompt(context.Background(), "go", WithModel("override-model")); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.requests[0].Model; got != "override-model" {
+		t.Fatalf("provider saw Model = %q, want override-model", got)
+	}
+}
+
+func TestPromptRequiresProvider(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(AgentOptions{}) // no provider
+	session, err := agent.Session(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = session.Prompt(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("err = nil, want provider required")
+	}
+}
+
+func TestAgentSessionReusesByID(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(AgentOptions{Provider: &recordingProvider{}})
+	first, _ := agent.Session(context.Background(), "abc")
+	second, _ := agent.Session(context.Background(), "abc")
+	if first != second {
+		t.Fatal("Session(id) returned different instances on second call")
+	}
+}
+
+func TestPublicTypeAliasesMatchLoop(t *testing.T) {
+	t.Parallel()
+
+	// Compile-time check that public re-exports satisfy expected shapes.
+	var _ Provider = &recordingProvider{}
+	var _ Event
+	var _ Message
+	var _ Tool
+	var _ ProviderEvent
+	var _ ToolCall
+	var _ ToolResult
+}
+
+func containsEventType(events []EventType, want EventType) bool {
+	for _, e := range events {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}

--- a/doc.go
+++ b/doc.go
@@ -1,10 +1,12 @@
 // Package glue provides the public API for defining and running agents.
 //
-// It is intentionally thin over the lower-level loop package. It owns
-// user-facing concepts such as agents, sessions, skills, roles, and stores.
-// The runtime mechanics — provider event consumption, tool execution, and
-// transcript management — live in the sibling [glue/loop] package.
+// It is intentionally thin over the lower-level loop package. Users
+// construct an [Agent] with [NewAgent], open a named [Session] with
+// [Agent.Session], and drive turns with [Session.Prompt]. Provider
+// implementations live in subpackages (initially providers/gemini), and
+// session persistence is provided by stores subpackages (initially
+// stores/file).
 //
-// This file is the package marker for the bootstrap scaffold. Concrete types
-// (Agent, Session, Tool, etc.) are added by later issues.
+// Normalized message and event types are re-exported here so that callers
+// only need to import "glue".
 package glue

--- a/docs/design.md
+++ b/docs/design.md
@@ -130,8 +130,12 @@ result, err := session.Prompt(ctx, "Use the weather tool for Toronto.")
 ```
 
 Sessions are in-memory in P0. `Session.Subscribe(func(glue.Event))` registers a
-session-level event handler, and `glue.WithEvents` registers a per-prompt event
-handler. File-backed stores are added in P1.
+session-level event handler that fires for every prompt run on that session,
+and `glue.WithEvents` registers a per-prompt event handler that fires
+alongside (both receive the same events for the prompt). The current
+`AgentOptions` reserves `Store`, `WorkDir`, `Role`, and `Roles` fields so the
+public type stays stable as those features land in #11, #13, and #14.
+File-backed stores are added in P1.
 
 `PromptJSON(ctx, prompt, outPtr, opts...)` requests structured output and
 unmarshals the assistant's final text into a caller-provided non-nil pointer. It

--- a/session.go
+++ b/session.go
@@ -1,0 +1,273 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"glue/loop"
+)
+
+// Session is an in-memory conversation with an [Agent]. Sessions are
+// goroutine-safe but a single session executes one [Session.Prompt] at a
+// time.
+type Session struct {
+	id    string
+	agent *Agent
+
+	runMu sync.Mutex
+	mu    sync.Mutex
+
+	messages  []Message
+	metadata  map[string]any
+	createdAt time.Time
+	updatedAt time.Time
+
+	nextSubscriberID int
+	subscribers      map[int]func(Event)
+}
+
+// ID returns the session id.
+func (s *Session) ID() string {
+	if s == nil {
+		return ""
+	}
+	return s.id
+}
+
+// Messages returns a snapshot of the session transcript.
+func (s *Session) Messages() []Message {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneMessages(s.messages)
+}
+
+// Subscribe registers a session-scoped event handler that receives every
+// loop event for every prompt run on this session. The returned function
+// removes the handler.
+func (s *Session) Subscribe(handler func(Event)) func() {
+	if s == nil || handler == nil {
+		return func() {}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.nextSubscriberID
+	s.nextSubscriberID++
+	s.subscribers[id] = handler
+	return func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		delete(s.subscribers, id)
+	}
+}
+
+// PromptResult is returned by [Session.Prompt].
+type PromptResult struct {
+	// Text concatenates all text parts of the final assistant message.
+	Text string
+	// Message is the final assistant message of this run, cloned. Nil if no
+	// assistant message was produced.
+	Message *Message
+	// NewMessages contains every message produced during this run, in append
+	// order (assistant + tool messages, possibly across multiple turns).
+	NewMessages []Message
+	// Messages is a snapshot of the full session transcript after this run.
+	Messages []Message
+}
+
+// PromptOption configures one [Session.Prompt] invocation.
+type PromptOption func(*promptConfig)
+
+type promptConfig struct {
+	model        string
+	systemPrompt string
+	tools        []Tool
+	options      map[string]any
+	maxTurns     int
+	emit         func(Event)
+}
+
+// WithModel overrides the agent model for one prompt.
+func WithModel(model string) PromptOption {
+	return func(c *promptConfig) { c.model = model }
+}
+
+// WithSystemPrompt overrides the agent system prompt for one prompt.
+func WithSystemPrompt(systemPrompt string) PromptOption {
+	return func(c *promptConfig) { c.systemPrompt = systemPrompt }
+}
+
+// WithTools replaces the agent tools for one prompt.
+func WithTools(tools []Tool) PromptOption {
+	return func(c *promptConfig) { c.tools = cloneTools(tools) }
+}
+
+// WithProviderOptions replaces provider options for one prompt.
+func WithProviderOptions(options map[string]any) PromptOption {
+	return func(c *promptConfig) { c.options = cloneMap(options) }
+}
+
+// WithMaxTurns overrides the loop max-turn guard for one prompt.
+func WithMaxTurns(maxTurns int) PromptOption {
+	return func(c *promptConfig) { c.maxTurns = maxTurns }
+}
+
+// WithEvents registers a per-prompt event handler. It receives every loop
+// event for that prompt in addition to any session-scoped subscribers
+// installed via [Session.Subscribe].
+func WithEvents(handler func(Event)) PromptOption {
+	return func(c *promptConfig) { c.emit = handler }
+}
+
+// Prompt sends a user message through the agent loop and stores the
+// resulting transcript in memory.
+func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOption) (PromptResult, error) {
+	if s == nil {
+		return PromptResult{}, errors.New("glue: nil session")
+	}
+	if s.agent == nil {
+		return PromptResult{}, errors.New("glue: session has no agent")
+	}
+	if s.agent.provider == nil {
+		return PromptResult{}, errors.New("glue: agent provider is required")
+	}
+
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+
+	config := s.promptConfig(options)
+	userMessage := Message{
+		Role:      MessageRoleUser,
+		Content:   []ContentPart{{Type: ContentTypeText, Text: text}},
+		CreatedAt: time.Now().UTC(),
+	}
+
+	s.mu.Lock()
+	base := cloneMessages(s.messages)
+	s.mu.Unlock()
+	runMessages := append(base, userMessage)
+
+	result, runErr := loop.Run(ctx, loop.RunRequest{
+		Provider:     s.agent.provider,
+		Model:        config.model,
+		SystemPrompt: config.systemPrompt,
+		Messages:     runMessages,
+		Tools:        config.tools,
+		Options:      config.options,
+		MaxTurns:     config.maxTurns,
+		Emit: func(event Event) {
+			if config.emit != nil {
+				config.emit(event)
+			}
+			s.dispatchEvent(event)
+		},
+	})
+
+	s.mu.Lock()
+	s.messages = append(s.messages, userMessage)
+	s.messages = append(s.messages, result.NewMessages...)
+	s.updatedAt = time.Now().UTC()
+	transcript := cloneMessages(s.messages)
+	s.mu.Unlock()
+
+	return PromptResult{
+		Text:        assistantText(result.NewMessages),
+		Message:     lastAssistantMessage(result.NewMessages),
+		NewMessages: cloneMessages(result.NewMessages),
+		Messages:    transcript,
+	}, runErr
+}
+
+func (s *Session) promptConfig(options []PromptOption) promptConfig {
+	config := promptConfig{
+		model:        s.agent.model,
+		systemPrompt: s.agent.systemPrompt,
+		tools:        cloneTools(s.agent.tools),
+		options:      cloneMap(s.agent.options),
+		maxTurns:     s.agent.maxTurns,
+	}
+	for _, opt := range options {
+		if opt != nil {
+			opt(&config)
+		}
+	}
+	return config
+}
+
+func (s *Session) dispatchEvent(event Event) {
+	s.mu.Lock()
+	handlers := make([]func(Event), 0, len(s.subscribers))
+	for _, h := range s.subscribers {
+		handlers = append(handlers, h)
+	}
+	s.mu.Unlock()
+	for _, h := range handlers {
+		h(event)
+	}
+}
+
+func cloneMessages(messages []Message) []Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]Message, len(messages))
+	for i, m := range messages {
+		out[i] = cloneMessage(m)
+	}
+	return out
+}
+
+func cloneMessage(m Message) Message {
+	if len(m.Content) > 0 {
+		c := make([]ContentPart, len(m.Content))
+		copy(c, m.Content)
+		for i := range c {
+			if c[i].Image != nil {
+				image := *c[i].Image
+				c[i].Image = &image
+			}
+			if c[i].ToolCall != nil {
+				tc := *c[i].ToolCall
+				if len(tc.Arguments) > 0 {
+					tc.Arguments = append(tc.Arguments[:0:0], tc.Arguments...)
+				}
+				c[i].ToolCall = &tc
+			}
+		}
+		m.Content = c
+	}
+	if m.Usage != nil {
+		usage := *m.Usage
+		m.Usage = &usage
+	}
+	m.Metadata = cloneMap(m.Metadata)
+	return m
+}
+
+func assistantText(messages []Message) string {
+	msg := lastAssistantMessage(messages)
+	if msg == nil {
+		return ""
+	}
+	var text string
+	for _, p := range msg.Content {
+		if p.Type == ContentTypeText {
+			text += p.Text
+		}
+	}
+	return text
+}
+
+func lastAssistantMessage(messages []Message) *Message {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == MessageRoleAssistant {
+			cloned := cloneMessage(messages[i])
+			return &cloned
+		}
+	}
+	return nil
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,76 @@
+package glue
+
+import "glue/loop"
+
+// Re-export the loop package's normalized types as part of the public API so
+// callers only need to import `glue`.
+type (
+	Message      = loop.Message
+	MessageRole  = loop.MessageRole
+	ContentPart  = loop.ContentPart
+	ContentType  = loop.ContentType
+	ImageContent = loop.ImageContent
+	ToolCall     = loop.ToolCall
+	ToolResult   = loop.ToolResult
+	ToolSpec     = loop.ToolSpec
+	ToolExecutor = loop.ToolExecutor
+	Tool         = loop.Tool
+	Usage        = loop.Usage
+	StopReason   = loop.StopReason
+
+	ProviderRequest   = loop.ProviderRequest
+	Provider          = loop.Provider
+	ProviderEvent     = loop.ProviderEvent
+	ProviderEventType = loop.ProviderEventType
+
+	Event     = loop.Event
+	EventType = loop.EventType
+)
+
+// MessageRole constants re-exported from package loop.
+const (
+	MessageRoleUser      = loop.MessageRoleUser
+	MessageRoleAssistant = loop.MessageRoleAssistant
+	MessageRoleTool      = loop.MessageRoleTool
+)
+
+// ContentType constants re-exported from package loop.
+const (
+	ContentTypeText     = loop.ContentTypeText
+	ContentTypeThinking = loop.ContentTypeThinking
+	ContentTypeImage    = loop.ContentTypeImage
+	ContentTypeToolCall = loop.ContentTypeToolCall
+)
+
+// StopReason constants re-exported from package loop.
+const (
+	StopReasonStop     = loop.StopReasonStop
+	StopReasonLength   = loop.StopReasonLength
+	StopReasonToolUse  = loop.StopReasonToolUse
+	StopReasonError    = loop.StopReasonError
+	StopReasonCanceled = loop.StopReasonCanceled
+)
+
+// EventType constants re-exported from package loop.
+const (
+	EventLoopStart    = loop.EventLoopStart
+	EventLoopEnd      = loop.EventLoopEnd
+	EventTurnStart    = loop.EventTurnStart
+	EventTurnEnd      = loop.EventTurnEnd
+	EventMessageStart = loop.EventMessageStart
+	EventMessageEnd   = loop.EventMessageEnd
+	EventTextDelta    = loop.EventTextDelta
+	EventToolStart    = loop.EventToolStart
+	EventToolEnd      = loop.EventToolEnd
+	EventError        = loop.EventError
+)
+
+// ProviderEventType constants re-exported from package loop.
+const (
+	ProviderEventStart         = loop.ProviderEventStart
+	ProviderEventTextDelta     = loop.ProviderEventTextDelta
+	ProviderEventThinkingDelta = loop.ProviderEventThinkingDelta
+	ProviderEventToolCall      = loop.ProviderEventToolCall
+	ProviderEventDone          = loop.ProviderEventDone
+	ProviderEventError         = loop.ProviderEventError
+)


### PR DESCRIPTION
## Summary

Lands the public `glue` API on top of `loop.Run`.

**New public surface**

- `glue.NewAgent(glue.AgentOptions) *glue.Agent`
- `AgentOptions{ Provider, Model, SystemPrompt, Tools, Options, MaxTurns }` are wired now. `Store`, `WorkDir`, `Role`, `Roles` are reserved for #11/#13/#14 with godoc explaining they have no effect yet.
- `Agent.Session(ctx, id) (*Session, error)` — empty id → `"default"`; the same id returns the same in-memory session.
- `Session.Prompt(ctx, text, opts...) (PromptResult, error)`.
- `Session.Subscribe(func(Event)) (unsubscribe func())` — session-scoped event delivery for every future prompt.
- `glue.WithEvents(handler)` — per-prompt event handler that fires *alongside* session subscribers, not instead.
- `glue.WithModel`, `WithSystemPrompt`, `WithTools`, `WithProviderOptions`, `WithMaxTurns`.
- `glue/types.go` re-exports loop's normalized types (`Message`, `Event`, `Tool`, `Provider`, ...) so callers depend on `glue` alone.

`PromptJSON`, `Skill`, role precedence, and store wiring are intentionally deferred to their own issues.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	0.004s
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	(cached)
?   	glue/providers/gemini	[no test files]
?   	glue/stores/file	[no test files]
```

The 9 new tests cover the acceptance criteria with a recording fake provider:

- `TestSessionPromptHappyPath` — text, message, transcript shape, model + system prompt reach the provider request
- `TestSessionPromptContinuation` — multi-prompt; 2nd provider request carries user/assistant/user
- `TestSessionSubscribeAndUnsubscribe` — events delivered, then stop after unsubscribe
- `TestSessionPromptWithEvents` — per-prompt handler delivery
- `TestSessionSubscribeAndWithEventsBothFire` — both handlers receive equal event counts
- `TestSessionPromptWithModelOverride` — `WithModel` reaches the provider
- `TestPromptRequiresProvider` — clear error when no provider
- `TestAgentSessionReusesByID` — same id returns same instance
- `TestPublicTypeAliasesMatchLoop` — compile-time check on the re-exports

`docs/design.md` updated with the dual-handler event delivery and the reserved-field note on `AgentOptions`.

Closes #7.