### PR TITLE
Add Gemini function calling support (closes #10)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -163,12 +163,10 @@ Gemini behavior:
 - streams Gemini text deltas (and thinking deltas) as normalized provider events
 - maps final stop reason, response id metadata, model version, and usage when
   reported by the SDK
-- converts Glue tools to Gemini function declarations (added with function
-  calling support)
-- converts Gemini function calls to normalized tool calls (added with function
-  calling support)
-- converts Glue tool result messages to Gemini function responses (added with
-  function calling support)
+- converts Glue tools to Gemini function declarations
+- converts Gemini function calls to normalized tool calls
+- converts Glue tool result messages to Gemini function responses, grouping
+  consecutive tool-role messages into a single Gemini content per Glue turn
 
 Offline provider tests cover message conversion, config conversion, finish
 tool conversion, function response conversion, finish reason mapping, loop

--- a/providers/gemini/convert.go
+++ b/providers/gemini/convert.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	"glue/loop"
@@ -9,22 +10,38 @@ import (
 	"google.golang.org/genai"
 )
 
-// ConvertMessages converts Glue text messages to Gemini contents.
+// ConvertMessages converts Glue messages to Gemini contents.
 //
-// Tool-call assistant content and tool-role messages are not supported in
-// the text-only provider; they will be wired up alongside Gemini function
-// calling in a follow-up issue. Encountering them here yields a clear error
-// rather than silently dropping the message.
+// Consecutive tool-role messages are grouped into a single Gemini content
+// with role "user" and one FunctionResponse part per message, matching how
+// the genai SDK expects multi-tool turns to be expressed.
 func ConvertMessages(messages []loop.Message) ([]*genai.Content, error) {
 	contents := make([]*genai.Content, 0, len(messages))
-	for _, message := range messages {
-		content, err := convertMessage(message)
+	for i := 0; i < len(messages); {
+		if messages[i].Role == loop.MessageRoleTool {
+			parts := make([]*genai.Part, 0)
+			for i < len(messages) && messages[i].Role == loop.MessageRoleTool {
+				part, err := convertToolMessage(messages[i])
+				if err != nil {
+					return nil, err
+				}
+				parts = append(parts, part)
+				i++
+			}
+			if len(parts) > 0 {
+				contents = append(contents, genai.NewContentFromParts(parts, genai.RoleUser))
+			}
+			continue
+		}
+
+		content, err := convertMessage(messages[i])
 		if err != nil {
 			return nil, err
 		}
 		if content != nil {
 			contents = append(contents, content)
 		}
+		i++
 	}
 	return contents, nil
 }
@@ -37,7 +54,7 @@ func convertMessage(message loop.Message) (*genai.Content, error) {
 	case loop.MessageRoleAssistant:
 		role = genai.RoleModel
 	case loop.MessageRoleTool:
-		return nil, fmt.Errorf("gemini: tool messages require function-calling support (not yet implemented)")
+		return nil, fmt.Errorf("gemini: tool messages should be converted via ConvertMessages, not convertMessage")
 	default:
 		return nil, fmt.Errorf("gemini: unsupported message role %q", message.Role)
 	}
@@ -63,7 +80,18 @@ func convertMessage(message loop.Message) (*genai.Content, error) {
 			}
 			parts = append(parts, genai.NewPartFromBytes(data, part.Image.MIMEType))
 		case loop.ContentTypeToolCall:
-			return nil, fmt.Errorf("gemini: tool-call content requires function-calling support (not yet implemented)")
+			if part.ToolCall == nil {
+				return nil, fmt.Errorf("gemini: tool call content missing payload")
+			}
+			args, err := rawObject(part.ToolCall.Arguments)
+			if err != nil {
+				return nil, fmt.Errorf("gemini: tool call %q arguments: %w", part.ToolCall.Name, err)
+			}
+			parts = append(parts, &genai.Part{FunctionCall: &genai.FunctionCall{
+				ID:   part.ToolCall.ID,
+				Name: part.ToolCall.Name,
+				Args: args,
+			}})
 		default:
 			return nil, fmt.Errorf("gemini: unsupported content type %q", part.Type)
 		}
@@ -74,11 +102,94 @@ func convertMessage(message loop.Message) (*genai.Content, error) {
 	return genai.NewContentFromParts(parts, role), nil
 }
 
+func convertToolMessage(message loop.Message) (*genai.Part, error) {
+	if message.ToolName == "" {
+		return nil, fmt.Errorf("gemini: tool message missing tool name")
+	}
+	key := "output"
+	if message.IsError {
+		key = "error"
+	}
+	return &genai.Part{FunctionResponse: &genai.FunctionResponse{
+		ID:       message.ToolCallID,
+		Name:     message.ToolName,
+		Response: map[string]any{key: toolMessageText(message)},
+	}}, nil
+}
+
+func toolMessageText(message loop.Message) string {
+	var text string
+	for _, part := range message.Content {
+		if part.Type == loop.ContentTypeText {
+			if text != "" {
+				text += "\n"
+			}
+			text += part.Text
+		}
+	}
+	return text
+}
+
+// ConvertTools converts Glue tool specs to Gemini function declarations.
+// All declarations are bundled into a single Gemini Tool, which is how
+// genai expects multiple tools to be exposed to the model.
+func ConvertTools(tools []loop.ToolSpec) ([]*genai.Tool, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	declarations := make([]*genai.FunctionDeclaration, 0, len(tools))
+	for _, tool := range tools {
+		declaration := &genai.FunctionDeclaration{
+			Name:        tool.Name,
+			Description: tool.Description,
+		}
+		if len(tool.Parameters) > 0 {
+			schema, err := rawSchema(tool.Parameters)
+			if err != nil {
+				return nil, fmt.Errorf("gemini: tool %q parameters: %w", tool.Name, err)
+			}
+			declaration.ParametersJsonSchema = schema
+		}
+		declarations = append(declarations, declaration)
+	}
+	return []*genai.Tool{{FunctionDeclarations: declarations}}, nil
+}
+
+func rawObject(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, fmt.Errorf("must be a JSON object")
+	}
+	return object, nil
+}
+
+func rawSchema(raw json.RawMessage) (any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var schema any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
 func buildGenerateConfig(req loop.ProviderRequest) (*genai.GenerateContentConfig, error) {
 	config := &genai.GenerateContentConfig{}
 	if req.SystemPrompt != "" {
 		config.SystemInstruction = genai.NewContentFromText(req.SystemPrompt, genai.RoleUser)
 	}
+	tools, err := ConvertTools(req.Tools)
+	if err != nil {
+		return nil, err
+	}
+	config.Tools = tools
 
 	for key, value := range req.Options {
 		switch key {
@@ -96,9 +207,9 @@ func buildGenerateConfig(req loop.ProviderRequest) (*genai.GenerateContentConfig
 			config.MaxOutputTokens = maxTokens
 		}
 	}
-	// Tools and structured-output options (response_mime_type,
-	// response_json_schema) are intentionally unhandled here; they belong
-	// to the function-calling and structured-JSON issues respectively.
+	// Structured-output options (response_mime_type, response_json_schema)
+	// are intentionally unhandled here; they belong to the structured-JSON
+	// result issue.
 	return config, nil
 }
 

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -43,11 +44,11 @@ func New(options Options) *Provider {
 	}
 }
 
-// Stream implements [loop.Provider]. The current implementation supports
-// text-only conversations; function calling lands in a follow-up issue and
-// will extend ConvertMessages and buildGenerateConfig accordingly. Until
-// then, [loop.ProviderRequest.Tools] is silently ignored so the provider
-// never produces tool-call parts.
+// Stream implements [loop.Provider]. It supports text-only conversations
+// and Gemini function calling: tool specs in [loop.ProviderRequest.Tools]
+// are converted to function declarations, inbound function calls become
+// [loop.ProviderEventToolCall] events, and tool-role messages in the
+// transcript are converted to function responses.
 func (p *Provider) Stream(ctx context.Context, req loop.ProviderRequest) (<-chan loop.ProviderEvent, error) {
 	if p == nil {
 		return nil, errors.New("gemini: nil provider")
@@ -118,6 +119,7 @@ func (p *Provider) stream(
 		return
 	}
 
+	toolCallCount := 0
 	for response, err := range client.Models.GenerateContentStream(ctx, model, contents, config) {
 		if err != nil {
 			send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: err.Error()})
@@ -136,7 +138,23 @@ func (p *Provider) stream(
 			continue
 		}
 		for _, part := range candidate.Content.Parts {
-			if part == nil || part.Text == "" {
+			if part == nil {
+				continue
+			}
+			if part.FunctionCall != nil {
+				toolCallCount++
+				toolCall, err := convertFunctionCall(part.FunctionCall, toolCallCount)
+				if err != nil {
+					send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: err.Error()})
+					return
+				}
+				output.Content = append(output.Content, loop.ContentPart{Type: loop.ContentTypeToolCall, ToolCall: &toolCall})
+				if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventToolCall, ToolCall: &toolCall}) {
+					return
+				}
+				continue
+			}
+			if part.Text == "" {
 				continue
 			}
 			if part.Thought {
@@ -153,6 +171,9 @@ func (p *Provider) stream(
 		}
 	}
 
+	if hasToolCall(output) {
+		output.StopReason = loop.StopReasonToolUse
+	}
 	if output.StopReason == "" {
 		output.StopReason = loop.StopReasonStop
 	}
@@ -222,6 +243,38 @@ func applyResponseMetadata(message *loop.Message, response *genai.GenerateConten
 			TotalTokens:     int64(usage.TotalTokenCount),
 		}
 	}
+}
+
+func convertFunctionCall(call *genai.FunctionCall, fallbackIndex int) (loop.ToolCall, error) {
+	if call == nil {
+		return loop.ToolCall{}, errors.New("gemini: nil function call")
+	}
+	args, err := json.Marshal(call.Args)
+	if err != nil {
+		return loop.ToolCall{}, fmt.Errorf("gemini: marshal function call args: %w", err)
+	}
+	if string(args) == "null" {
+		args = []byte(`{}`)
+	}
+
+	id := call.ID
+	if id == "" {
+		id = fmt.Sprintf("%s_%d", call.Name, fallbackIndex)
+	}
+	return loop.ToolCall{
+		ID:        id,
+		Name:      call.Name,
+		Arguments: args,
+	}, nil
+}
+
+func hasToolCall(message loop.Message) bool {
+	for _, part := range message.Content {
+		if part.Type == loop.ContentTypeToolCall && part.ToolCall != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func mapFinishReason(reason genai.FinishReason) loop.StopReason {

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -51,27 +52,131 @@ func TestConvertMessagesEmptyTextDropsMessage(t *testing.T) {
 	}
 }
 
-func TestConvertMessagesToolCallNotYetSupported(t *testing.T) {
+func TestConvertMessagesToolCallContent(t *testing.T) {
 	t.Parallel()
 
-	_, err := ConvertMessages([]loop.Message{
+	contents, err := ConvertMessages([]loop.Message{
 		{Role: loop.MessageRoleAssistant, Content: []loop.ContentPart{
-			{Type: loop.ContentTypeToolCall, ToolCall: &loop.ToolCall{ID: "x", Name: "y"}},
+			{Type: loop.ContentTypeToolCall, ToolCall: &loop.ToolCall{
+				ID:        "call_1",
+				Name:      "weather",
+				Arguments: json.RawMessage(`{"city":"Toronto"}`),
+			}},
 		}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "function-calling") {
-		t.Fatalf("err = %v, want function-calling not implemented", err)
+	if err != nil {
+		t.Fatalf("ConvertMessages: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("len(contents) = %d, want 1", len(contents))
+	}
+	if contents[0].Role != string(genai.RoleModel) {
+		t.Fatalf("role = %q, want model", contents[0].Role)
+	}
+	fc := contents[0].Parts[0].FunctionCall
+	if fc == nil {
+		t.Fatal("FunctionCall part missing")
+	}
+	if fc.Name != "weather" || fc.ID != "call_1" {
+		t.Fatalf("FunctionCall = %#v, want name=weather id=call_1", fc)
+	}
+	if fc.Args["city"] != "Toronto" {
+		t.Fatalf("Args[city] = %v, want Toronto", fc.Args["city"])
 	}
 }
 
-func TestConvertMessagesToolRoleNotYetSupported(t *testing.T) {
+func TestConvertMessagesToolResultGroupsConsecutiveAsOneContent(t *testing.T) {
 	t.Parallel()
 
-	_, err := ConvertMessages([]loop.Message{
-		{Role: loop.MessageRoleTool, ToolName: "x", Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "result"}}},
+	contents, err := ConvertMessages([]loop.Message{
+		{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "hi"}}},
+		{Role: loop.MessageRoleTool, ToolCallID: "c1", ToolName: "weather", Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "sunny"}}},
+		{Role: loop.MessageRoleTool, ToolCallID: "c2", ToolName: "time", Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "noon"}}, IsError: true},
 	})
-	if err == nil || !strings.Contains(err.Error(), "function-calling") {
-		t.Fatalf("err = %v, want function-calling not implemented", err)
+	if err != nil {
+		t.Fatalf("ConvertMessages: %v", err)
+	}
+	if len(contents) != 2 {
+		t.Fatalf("len(contents) = %d, want 2 (user + grouped tool responses)", len(contents))
+	}
+	tools := contents[1]
+	if tools.Role != string(genai.RoleUser) {
+		t.Fatalf("tool group role = %q, want user", tools.Role)
+	}
+	if len(tools.Parts) != 2 {
+		t.Fatalf("tool group parts = %d, want 2", len(tools.Parts))
+	}
+	r1 := tools.Parts[0].FunctionResponse
+	if r1 == nil || r1.Name != "weather" || r1.Response["output"] != "sunny" {
+		t.Fatalf("response[0] = %#v, want weather output=sunny", r1)
+	}
+	r2 := tools.Parts[1].FunctionResponse
+	if r2 == nil || r2.Name != "time" || r2.Response["error"] != "noon" {
+		t.Fatalf("response[1] = %#v, want time error=noon", r2)
+	}
+}
+
+func TestConvertToolsBuildsFunctionDeclarations(t *testing.T) {
+	t.Parallel()
+
+	tools, err := ConvertTools([]loop.ToolSpec{
+		{
+			Name:        "weather",
+			Description: "Get weather for a city.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+		},
+		{Name: "time"},
+	})
+	if err != nil {
+		t.Fatalf("ConvertTools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("len(tools) = %d, want 1 (single bundle)", len(tools))
+	}
+	decls := tools[0].FunctionDeclarations
+	if len(decls) != 2 {
+		t.Fatalf("len(decls) = %d, want 2", len(decls))
+	}
+	if decls[0].Name != "weather" || decls[0].ParametersJsonSchema == nil {
+		t.Fatalf("decls[0] = %#v, want weather with schema", decls[0])
+	}
+	if decls[1].Name != "time" || decls[1].ParametersJsonSchema != nil {
+		t.Fatalf("decls[1] = %#v, want time with no schema", decls[1])
+	}
+}
+
+func TestConvertToolsBadSchemaErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := ConvertTools([]loop.ToolSpec{{Name: "x", Parameters: json.RawMessage(`not-json`)}})
+	if err == nil || !strings.Contains(err.Error(), "tool \"x\"") {
+		t.Fatalf("err = %v, want tool x parameters error", err)
+	}
+}
+
+func TestConvertFunctionCallFillsIDAndCleansNullArgs(t *testing.T) {
+	t.Parallel()
+
+	tc, err := convertFunctionCall(&genai.FunctionCall{Name: "weather"}, 7)
+	if err != nil {
+		t.Fatalf("convertFunctionCall: %v", err)
+	}
+	if tc.ID != "weather_7" {
+		t.Fatalf("ID = %q, want weather_7", tc.ID)
+	}
+	if string(tc.Arguments) != "{}" {
+		t.Fatalf("Arguments = %q, want {}", string(tc.Arguments))
+	}
+
+	tc2, err := convertFunctionCall(&genai.FunctionCall{ID: "abc", Name: "weather", Args: map[string]any{"city": "T"}}, 1)
+	if err != nil {
+		t.Fatalf("convertFunctionCall: %v", err)
+	}
+	if tc2.ID != "abc" {
+		t.Fatalf("ID = %q, want abc", tc2.ID)
+	}
+	if !strings.Contains(string(tc2.Arguments), `"city":"T"`) {
+		t.Fatalf("Arguments = %q, want {\"city\":\"T\"}", string(tc2.Arguments))
 	}
 }
 


### PR DESCRIPTION
## Summary

Lifts the deferred function-calling restrictions added by #8.

**Conversion (`providers/gemini/convert.go`)**

- `ConvertTools` — bundles all Glue `ToolSpec`s into a single `genai.Tool` with one `FunctionDeclaration` per tool; parameters JSON Schema forwarded as-is.
- `buildGenerateConfig` — wires the converted tools onto the request.
- `convertMessage` — `ContentTypeToolCall` → `genai.Part.FunctionCall`. Arguments parsed via `rawObject` (must be a JSON object).
- `ConvertMessages` — groups consecutive tool-role messages into a single `genai.Content` with role `user` and one `FunctionResponse` part each (matches how the genai SDK expects multi-tool turns).
- `convertToolMessage` — tool result → `genai.FunctionResponse{Response: {output|error: text}}` keyed by `Message.IsError`.

**Streaming (`providers/gemini/gemini.go`)**

- Inbound `part.FunctionCall` now becomes a `ContentTypeToolCall` content part on the accumulated message and a `ProviderEventToolCall` event.
- Final assistant message stop reason is `StopReasonToolUse` when the message contains tool calls.
- `convertFunctionCall` synthesizes a fallback id `<name>_<n>` when Gemini omits one and rewrites `null` args to `{}`.

**Tests**

Three new conversion tests (replacing the two "not yet implemented" tests):

- `TestConvertMessagesToolCallContent` — assistant `tool_call` → `FunctionCall` with id, name, args
- `TestConvertMessagesToolResultGroupsConsecutiveAsOneContent` — success **and** error tool results in one grouped content (matches the issue's "success and error tool results" acceptance criterion)
- `TestConvertToolsBuildsFunctionDeclarations` — schema and no-schema cases
- `TestConvertToolsBadSchemaErrors` — malformed schema surfaces per-tool error
- `TestConvertFunctionCallFillsIDAndCleansNullArgs` — fallback id + null-arg cleanup

The `loop` package's existing `tool_exec_test.go` already covers tool-call execution end-to-end through `loop.Run`; the gemini provider plugs into that same path through the conversion functions tested here.

`docs/design.md` updated: removed the "added with function calling support" qualifiers and noted the consecutive-tool-grouping convention.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	(cached)
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	0.009s
?   	glue/stores/file	[no test files]
$ go test ./providers/gemini -v
... 14 PASS, 1 SKIP (TestLiveSmoke - no GEMINI_API_KEY) ...
ok  	glue/providers/gemini	0.009s
```

Closes #10.