### PR TITLE
Implement file-backed session store (closes #11)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -11,15 +11,14 @@ const defaultSessionID = "default"
 
 // AgentOptions configures a Glue agent.
 //
-// Provider, Model, SystemPrompt, Tools, Options, and MaxTurns are wired in
-// this issue. Store, WorkDir, Role, and Roles are reserved for follow-up
-// issues and currently have no effect:
+// Provider, Model, SystemPrompt, Tools, Options, MaxTurns, and Store are
+// wired. WorkDir, Role, and Roles are reserved for follow-up issues:
 //
-//   - Store: file-backed session persistence (#11).
 //   - WorkDir: AGENTS.md context and Markdown skill discovery (#13).
 //   - Role / Roles: scoped role instructions and per-role models (#14).
 //
-// They are present so the public type stays stable as those features land.
+// Store, when set, persists session state across processes. The default
+// in-memory behavior is preserved when Store is nil.
 type AgentOptions struct {
 	Provider     Provider
 	Model        string
@@ -27,9 +26,8 @@ type AgentOptions struct {
 	Tools        []Tool
 	Options      map[string]any
 	MaxTurns     int
+	Store        Store
 
-	// Store is reserved for #11.
-	Store any
 	// WorkDir is reserved for #13.
 	WorkDir string
 	// Role is reserved for #14.
@@ -46,13 +44,15 @@ type Agent struct {
 	tools        []Tool
 	options      map[string]any
 	maxTurns     int
+	store        Store
 
 	mu       sync.Mutex
 	sessions map[string]*Session
 }
 
-// NewAgent creates an agent with in-memory session state. The Provider must
-// be supplied for [Session.Prompt] to succeed.
+// NewAgent creates an agent. When [AgentOptions.Store] is set, sessions are
+// loaded from and saved to that store; otherwise sessions are in-memory.
+// The Provider must be supplied for [Session.Prompt] to succeed.
 func NewAgent(options AgentOptions) *Agent {
 	return &Agent{
 		provider:     options.Provider,
@@ -61,13 +61,16 @@ func NewAgent(options AgentOptions) *Agent {
 		tools:        cloneTools(options.Tools),
 		options:      cloneMap(options.Options),
 		maxTurns:     options.MaxTurns,
+		store:        options.Store,
 		sessions:     make(map[string]*Session),
 	}
 }
 
-// Session returns an existing in-memory session by id or creates a new one.
-// Empty ids resolve to the default session ("default").
-func (a *Agent) Session(_ context.Context, id string) (*Session, error) {
+// Session returns an existing session by id, or creates a new one. When the
+// agent has a configured [Store], an existing on-disk state is loaded into
+// the new in-memory session. Empty ids resolve to the default session
+// ("default").
+func (a *Agent) Session(ctx context.Context, id string) (*Session, error) {
 	if a == nil {
 		return nil, errors.New("glue: nil agent")
 	}
@@ -80,16 +83,47 @@ func (a *Agent) Session(_ context.Context, id string) (*Session, error) {
 	if existing := a.sessions[id]; existing != nil {
 		return existing, nil
 	}
+
+	state, found, err := a.loadSessionState(ctx, id)
+	if err != nil {
+		return nil, err
+	}
 	now := time.Now().UTC()
 	session := &Session{
 		id:          id,
 		agent:       a,
-		createdAt:   now,
-		updatedAt:   now,
+		messages:    cloneMessages(state.Messages),
+		metadata:    cloneMap(state.Metadata),
+		createdAt:   state.CreatedAt,
+		updatedAt:   state.UpdatedAt,
 		subscribers: make(map[int]func(Event)),
+	}
+	if !found {
+		session.createdAt = now
+		session.updatedAt = now
 	}
 	a.sessions[id] = session
 	return session, nil
+}
+
+func (a *Agent) loadSessionState(ctx context.Context, id string) (SessionState, bool, error) {
+	if a.store == nil {
+		return SessionState{Version: SessionStateVersion, ID: id}, false, nil
+	}
+	state, found, err := a.store.Load(ctx, id)
+	if err != nil {
+		return SessionState{}, false, err
+	}
+	if !found {
+		return SessionState{Version: SessionStateVersion, ID: id}, false, nil
+	}
+	if state.ID == "" {
+		state.ID = id
+	}
+	if state.Version == 0 {
+		state.Version = SessionStateVersion
+	}
+	return state, true, nil
 }
 
 func cloneTools(tools []Tool) []Tool {

--- a/docs/design.md
+++ b/docs/design.md
@@ -133,9 +133,10 @@ Sessions are in-memory in P0. `Session.Subscribe(func(glue.Event))` registers a
 session-level event handler that fires for every prompt run on that session,
 and `glue.WithEvents` registers a per-prompt event handler that fires
 alongside (both receive the same events for the prompt). The current
-`AgentOptions` reserves `Store`, `WorkDir`, `Role`, and `Roles` fields so the
-public type stays stable as those features land in #11, #13, and #14.
-File-backed stores are added in P1.
+`AgentOptions` exposes `Store` (typed [`Store`](#persistence) interface) for
+durable session state and reserves `WorkDir`, `Role`, and `Roles` for #13 and
+#14 so the public type stays stable as those features land. The default
+in-memory behavior is preserved when `Store` is nil.
 
 `PromptJSON(ctx, prompt, outPtr, opts...)` requests structured output and
 unmarshals the assistant's final text into a caller-provided non-nil pointer. It

--- a/session.go
+++ b/session.go
@@ -172,14 +172,49 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 	s.messages = append(s.messages, result.NewMessages...)
 	s.updatedAt = time.Now().UTC()
 	transcript := cloneMessages(s.messages)
+	state := s.stateLocked()
 	s.mu.Unlock()
 
-	return PromptResult{
+	saveErr := s.save(ctx, state)
+
+	response := PromptResult{
 		Text:        assistantText(result.NewMessages),
 		Message:     lastAssistantMessage(result.NewMessages),
 		NewMessages: cloneMessages(result.NewMessages),
 		Messages:    transcript,
-	}, runErr
+	}
+	if runErr != nil && saveErr != nil {
+		return response, errors.Join(runErr, saveErr)
+	}
+	if runErr != nil {
+		return response, runErr
+	}
+	return response, saveErr
+}
+
+// State returns a snapshot of the durable session state.
+func (s *Session) State() SessionState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stateLocked()
+}
+
+func (s *Session) stateLocked() SessionState {
+	return SessionState{
+		Version:   SessionStateVersion,
+		ID:        s.id,
+		Messages:  cloneMessages(s.messages),
+		Metadata:  cloneMap(s.metadata),
+		CreatedAt: s.createdAt,
+		UpdatedAt: s.updatedAt,
+	}
+}
+
+func (s *Session) save(ctx context.Context, state SessionState) error {
+	if s.agent == nil || s.agent.store == nil {
+		return nil
+	}
+	return s.agent.store.Save(ctx, s.id, state)
 }
 
 func (s *Session) promptConfig(options []PromptOption) promptConfig {

--- a/store.go
+++ b/store.go
@@ -1,0 +1,32 @@
+package glue
+
+import (
+	"context"
+	"time"
+)
+
+// SessionStateVersion is the on-disk version tag for [SessionState].
+const SessionStateVersion = 1
+
+// Store persists Glue session state. Implementations are expected to be
+// goroutine-safe across distinct session ids; concurrent calls for the same
+// id within a single session are serialized by the session itself.
+//
+// Load returns found=false when the id is not present, with a zero-valued
+// SessionState and a nil error. Save must be atomic against partial writes.
+// Delete must be idempotent — removing a missing id is a no-op success.
+type Store interface {
+	Load(ctx context.Context, id string) (SessionState, bool, error)
+	Save(ctx context.Context, id string, state SessionState) error
+	Delete(ctx context.Context, id string) error
+}
+
+// SessionState is the durable representation of a session.
+type SessionState struct {
+	Version   int            `json:"version"`
+	ID        string         `json:"id"`
+	Messages  []Message      `json:"messages,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+}

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,170 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// memStore is an in-memory glue.Store for testing without the file store.
+type memStore struct {
+	mu     sync.Mutex
+	states map[string]SessionState
+	saves  int
+	loads  int
+}
+
+func newMemStore() *memStore { return &memStore{states: map[string]SessionState{}} }
+
+func (m *memStore) Load(_ context.Context, id string) (SessionState, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.loads++
+	state, ok := m.states[id]
+	if !ok {
+		return SessionState{}, false, nil
+	}
+	return state, true, nil
+}
+
+func (m *memStore) Save(_ context.Context, id string, state SessionState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saves++
+	m.states[id] = state
+	return nil
+}
+
+func (m *memStore) Delete(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.states, id)
+	return nil
+}
+
+func TestSessionPromptSavesViaStore(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("hello")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Store: store})
+
+	session, err := agent.Session(context.Background(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.Prompt(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if store.saves != 1 {
+		t.Fatalf("saves = %d, want 1", store.saves)
+	}
+	state := store.states["dev"]
+	if state.Version != SessionStateVersion || state.ID != "dev" {
+		t.Fatalf("state = %#v, want version %d id dev", state, SessionStateVersion)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("state messages = %d, want 2 (user + assistant)", len(state.Messages))
+	}
+}
+
+func TestSessionContinuesAcrossAgentInstancesWithStore(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+
+	// First "process": run a prompt through one Agent, save state.
+	{
+		provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("hello")}}
+		agent := NewAgent(AgentOptions{Provider: provider, Store: store})
+		session, err := agent.Session(context.Background(), "dev")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := session.Prompt(context.Background(), "hi"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Second "process": brand-new Agent, same store, same id.
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("again")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Store: store})
+	session, err := agent.Session(context.Background(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := session.Messages(); len(got) != 2 {
+		t.Fatalf("Messages = %d, want 2 loaded from store", len(got))
+	}
+
+	res, err := session.Prompt(context.Background(), "continue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "again" {
+		t.Fatalf("Text = %q, want again", res.Text)
+	}
+
+	// Provider should now have been called once and seen 3 messages
+	// (loaded user/assistant + new user).
+	if provider.calls != 1 {
+		t.Fatalf("calls = %d, want 1 in second process", provider.calls)
+	}
+	wantRoles := []MessageRole{MessageRoleUser, MessageRoleAssistant, MessageRoleUser}
+	got := provider.requests[0].Messages
+	if len(got) != len(wantRoles) {
+		t.Fatalf("provider saw %d messages, want %d", len(got), len(wantRoles))
+	}
+	for i, r := range wantRoles {
+		if got[i].Role != r {
+			t.Fatalf("messages[%d].Role = %q, want %q", i, got[i].Role, r)
+		}
+	}
+	if len(session.Messages()) != 4 {
+		t.Fatalf("transcript = %d, want 4 (u/a/u/a)", len(session.Messages()))
+	}
+	if store.saves != 2 {
+		t.Fatalf("saves = %d, want 2 across the two prompts", store.saves)
+	}
+}
+
+type savingErrStore struct{ err error }
+
+func (s savingErrStore) Load(context.Context, string) (SessionState, bool, error) {
+	return SessionState{}, false, nil
+}
+func (s savingErrStore) Save(context.Context, string, SessionState) error  { return s.err }
+func (savingErrStore) Delete(context.Context, string) error               { return nil }
+
+func TestSessionPromptSurfacesSaveError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("disk full")
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Store: savingErrStore{err: wantErr}})
+	session, _ := agent.Session(context.Background(), "x")
+
+	_, err := session.Prompt(context.Background(), "hi")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want disk full", err)
+	}
+}
+
+func TestSessionStateSnapshot(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+	if _, err := session.Prompt(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+	state := session.State()
+	if state.ID != "x" || state.Version != SessionStateVersion {
+		t.Fatalf("state = %#v, want id x version %d", state, SessionStateVersion)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2", len(state.Messages))
+	}
+}

--- a/stores/file/store.go
+++ b/stores/file/store.go
@@ -1,0 +1,138 @@
+// Package file provides a local JSON-backed session store for Glue.
+//
+// Each session is written to <dir>/<url-escaped-id>.json. Saves are atomic:
+// the JSON payload is first written to a sibling temp file in the same
+// directory and then [os.Rename]'d into place, so concurrent readers either
+// see the previous file or the new file but never a partial write.
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"glue"
+)
+
+// Store persists Glue sessions as local JSON files.
+type Store struct {
+	dir string
+}
+
+// New creates a file-backed store rooted at dir. The directory is created on
+// first save; calling New does not touch the filesystem.
+func New(dir string) *Store {
+	return &Store{dir: dir}
+}
+
+// Load reads a session state. Missing sessions return found=false with no
+// error.
+func (s *Store) Load(_ context.Context, id string) (glue.SessionState, bool, error) {
+	path, err := s.path(id)
+	if err != nil {
+		return glue.SessionState{}, false, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return glue.SessionState{}, false, nil
+	}
+	if err != nil {
+		return glue.SessionState{}, false, err
+	}
+
+	var state glue.SessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return glue.SessionState{}, false, fmt.Errorf("file store: load %q: %w", id, err)
+	}
+	if state.ID == "" {
+		state.ID = id
+	}
+	if state.Version == 0 {
+		state.Version = glue.SessionStateVersion
+	}
+	return state, true, nil
+}
+
+// Save writes a session state atomically.
+func (s *Store) Save(_ context.Context, id string, state glue.SessionState) error {
+	path, err := s.path(id)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	if state.ID == "" {
+		state.ID = id
+	}
+	if state.Version == 0 {
+		state.Version = glue.SessionStateVersion
+	}
+	if state.CreatedAt.IsZero() {
+		state.CreatedAt = now
+	}
+	if state.UpdatedAt.IsZero() {
+		state.UpdatedAt = now
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// Delete removes a session state. Missing sessions are a no-op success.
+func (s *Store) Delete(_ context.Context, id string) error {
+	path, err := s.path(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// Path returns the JSON file path for a session id. It is exposed for tests
+// and debugging; production code should not rely on it.
+func (s *Store) Path(id string) (string, error) {
+	return s.path(id)
+}
+
+func (s *Store) path(id string) (string, error) {
+	if s == nil {
+		return "", errors.New("file store: nil store")
+	}
+	if strings.TrimSpace(s.dir) == "" {
+		return "", errors.New("file store: directory is required")
+	}
+	if strings.TrimSpace(id) == "" {
+		return "", errors.New("file store: session id is required")
+	}
+	return filepath.Join(s.dir, url.PathEscape(id)+".json"), nil
+}

--- a/stores/file/store_test.go
+++ b/stores/file/store_test.go
@@ -1,0 +1,203 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"glue"
+)
+
+func newTempStore(t *testing.T) *Store {
+	t.Helper()
+	return New(t.TempDir())
+}
+
+func TestStoreLoadMissingReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	got, found, err := s.Load(context.Background(), "ghost")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if found {
+		t.Fatalf("found=true for missing session, state=%#v", got)
+	}
+}
+
+func TestStoreSaveLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	state := glue.SessionState{
+		ID: "dev",
+		Messages: []glue.Message{
+			{Role: glue.MessageRoleUser, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "hi"}}},
+			{Role: glue.MessageRoleAssistant, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "hello"}}},
+		},
+		Metadata: map[string]any{"k": "v"},
+	}
+	if err := s.Save(context.Background(), "dev", state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, found, err := s.Load(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !found {
+		t.Fatal("found=false after Save")
+	}
+	if got.Version != glue.SessionStateVersion || got.ID != "dev" {
+		t.Fatalf("version=%d id=%q, want %d/dev", got.Version, got.ID, glue.SessionStateVersion)
+	}
+	if len(got.Messages) != 2 || got.Messages[0].Content[0].Text != "hi" {
+		t.Fatalf("messages = %#v, want hi/hello", got.Messages)
+	}
+	if got.Metadata["k"] != "v" {
+		t.Fatalf("metadata = %#v, want k=v", got.Metadata)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Fatalf("timestamps not set: created=%v updated=%v", got.CreatedAt, got.UpdatedAt)
+	}
+}
+
+func TestStoreSaveOverwritesExisting(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	if err := s.Save(context.Background(), "x", glue.SessionState{ID: "x", Messages: []glue.Message{{Role: glue.MessageRoleUser, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "first"}}}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Save(context.Background(), "x", glue.SessionState{ID: "x", Messages: []glue.Message{{Role: glue.MessageRoleUser, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "second"}}}}}); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := s.Load(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Messages[0].Content[0].Text != "second" {
+		t.Fatalf("text = %q, want second", got.Messages[0].Content[0].Text)
+	}
+}
+
+func TestStoreDeleteIdempotent(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	if err := s.Delete(context.Background(), "ghost"); err != nil {
+		t.Fatalf("Delete missing: %v", err)
+	}
+	if err := s.Save(context.Background(), "x", glue.SessionState{ID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(context.Background(), "x"); err != nil {
+		t.Fatalf("Delete existing: %v", err)
+	}
+	_, found, err := s.Load(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatal("found=true after Delete")
+	}
+	if err := s.Delete(context.Background(), "x"); err != nil {
+		t.Fatalf("Delete after delete: %v", err)
+	}
+}
+
+func TestStoreCorruptedJSONReturnsError(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	path, err := s.Path("broken")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = s.Load(context.Background(), "broken")
+	if err == nil || !strings.Contains(err.Error(), "load") {
+		t.Fatalf("err = %v, want load error", err)
+	}
+}
+
+func TestStoreURLEscapesSpecialIDs(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	id := "weird id/with*chars"
+	if err := s.Save(context.Background(), id, glue.SessionState{ID: id}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path, err := s.Path(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsAny(filepath.Base(path), "/*") {
+		t.Fatalf("path %q contains unescaped chars", path)
+	}
+	got, found, err := s.Load(context.Background(), id)
+	if err != nil || !found {
+		t.Fatalf("Load missed escaped id: found=%v err=%v", found, err)
+	}
+	if got.ID != id {
+		t.Fatalf("ID = %q, want %q", got.ID, id)
+	}
+}
+
+func TestStoreEmptyDirOrIDErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New("").Path("x"); err == nil {
+		t.Fatal("expected error for empty dir")
+	}
+	if _, err := newTempStore(t).Path(""); err == nil {
+		t.Fatal("expected error for empty id")
+	}
+}
+
+func TestStoreSavesValidJSON(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	if err := s.Save(context.Background(), "x", glue.SessionState{ID: "x", Messages: []glue.Message{{Role: glue.MessageRoleUser, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "hi"}}}}}); err != nil {
+		t.Fatal(err)
+	}
+	path, _ := s.Path("x")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(data) {
+		t.Fatalf("on-disk JSON invalid: %s", data)
+	}
+	if !strings.HasSuffix(string(data), "\n") {
+		t.Fatalf("file does not end with newline: %q", data[len(data)-3:])
+	}
+}
+
+func TestStoreSetsTimestampsWhenZero(t *testing.T) {
+	t.Parallel()
+
+	s := newTempStore(t)
+	before := time.Now().UTC().Add(-time.Second)
+	if err := s.Save(context.Background(), "x", glue.SessionState{ID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := s.Load(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CreatedAt.Before(before) || got.UpdatedAt.Before(before) {
+		t.Fatalf("timestamps = %v / %v, want >= %v", got.CreatedAt, got.UpdatedAt, before)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the typed `glue.Store` interface and `stores/file` implementation, and wires sessions through them so transcripts persist across processes.

**`glue/store.go` (new)**

- `Store` interface: `Load(ctx, id) (SessionState, bool, error)`, `Save(ctx, id, state) error`, `Delete(ctx, id) error`. Load returns found=false for missing ids; Save must be atomic; Delete is idempotent.
- `SessionState` with Version / ID / Messages / Metadata / CreatedAt / UpdatedAt.
- `SessionStateVersion = 1`.

**`glue/agent.go`**

- `AgentOptions.Store` changes from `any` (reserved in #7) to the typed `Store` interface.
- `Agent.Session(ctx, id)` loads existing state from the store and seeds the in-memory session.

**`glue/session.go`**

- `Session.Prompt` calls `store.Save` after each run with the new transcript. `errors.Join` joins run + save errors when both occur.
- `Session.State()` returns a snapshot `SessionState`.

**`stores/file/store.go` (new)**

- JSON files at `<dir>/<url-PathEscape(id)>.json`.
- Atomic writes via temp file + `os.Rename`.
- Save fills `Version` / `ID` / `CreatedAt` / `UpdatedAt` when zero.
- `Path()` exposed for tests/debugging.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	0.003s
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	0.006s
```

**`stores/file/store_test.go` — 9 tests:**

- missing session returns `found=false`
- save+load round trip preserves messages/metadata/timestamps
- save overwrites existing file
- delete is idempotent (both missing and present)
- corrupted JSON returns a clear load error
- ids with `/`, `*`, spaces are URL-escaped on disk
- empty dir/id error paths
- on-disk JSON is valid and ends with a newline
- timestamps populated from `time.Now` when zero

**`glue/store_test.go` — 4 tests + a `memStore` helper:**

- `Prompt` invokes `Store.Save` once per run with version + id + messages set
- session continues across two `Agent` instances sharing the same store (simulating two processes); second prompt sees prior user/assistant + new user in the provider request and grows the transcript to 4 messages
- save errors propagate out of `Prompt` (`errors.Is` matches the cause)
- `Session.State()` snapshot has the expected version / id / message count

`docs/design.md` updated: `Store` is now a real typed field; only `WorkDir`, `Role`, `Roles` remain reserved.

Closes #11.