### PR TITLE
Add structured JSON result API (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ result, err := session.Prompt(ctx, "Be concise.",
 )
 ```
 
+### Structured JSON results
+
+```go
+var out struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+_, err := session.PromptJSON(ctx, "Return a project name and count.", &out)
+```
+
+`PromptJSON` augments the prompt with JSON-only instructions and sets
+`response_mime_type: application/json` on the provider request. Pass
+`glue.WithJSONSchema(schema)` to forward an explicit JSON Schema (Gemini:
+`response_json_schema`). V1 validation is JSON decoding into the caller's Go
+type.
+
 ## Testing without Gemini
 
 The `glue.Provider` interface is small, so tests can drive sessions with a

--- a/prompt_json_test.go
+++ b/prompt_json_test.go
@@ -1,0 +1,174 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func jsonTurn(text string) []ProviderEvent {
+	return []ProviderEvent{
+		{Type: ProviderEventStart},
+		{Type: ProviderEventTextDelta, Delta: text},
+		{Type: ProviderEventDone},
+	}
+}
+
+func TestPromptJSONDecodesIntoStructPointer(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{"name":"glue","count":2}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var out struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	res, err := session.PromptJSON(context.Background(), "give me a result", &out)
+	if err != nil {
+		t.Fatalf("PromptJSON: %v", err)
+	}
+	if out.Name != "glue" || out.Count != 2 {
+		t.Fatalf("out = %#v, want glue/2", out)
+	}
+	if res.Text != `{"name":"glue","count":2}` {
+		t.Fatalf("Text = %q, want raw JSON", res.Text)
+	}
+
+	if got := provider.requests[0].Options["response_mime_type"]; got != "application/json" {
+		t.Fatalf("response_mime_type = %v, want application/json", got)
+	}
+	if _, ok := provider.requests[0].Options["response_json_schema"]; ok {
+		t.Fatal("response_json_schema set without WithJSONSchema")
+	}
+	if !strings.Contains(provider.requests[0].Messages[0].Content[0].Text, "Respond with only valid JSON") {
+		t.Fatalf("user prompt missing JSON-only instruction: %q", provider.requests[0].Messages[0].Content[0].Text)
+	}
+}
+
+func TestPromptJSONForwardsSchema(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{"name":"glue","count":2}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"count":{"type":"integer"}}}`)
+	var out struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	if _, err := session.PromptJSON(context.Background(), "make json", &out, WithJSONSchema(schema)); err != nil {
+		t.Fatalf("PromptJSON: %v", err)
+	}
+	got := provider.requests[0].Options["response_json_schema"]
+	if got == nil {
+		t.Fatal("response_json_schema missing on provider request")
+	}
+	asMap, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("response_json_schema = %T, want map[string]any", got)
+	}
+	if asMap["type"] != "object" {
+		t.Fatalf("schema.type = %v, want object", asMap["type"])
+	}
+	if !strings.Contains(provider.requests[0].Messages[0].Content[0].Text, "must conform to this schema") {
+		t.Fatal("schema not embedded in user prompt")
+	}
+}
+
+func TestPromptJSONInvalidJSONReturnsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var out struct{ Name string }
+	_, err := session.PromptJSON(context.Background(), "bad", &out)
+	if err == nil || !strings.Contains(err.Error(), "decode JSON result") {
+		t.Fatalf("err = %v, want decode JSON result", err)
+	}
+}
+
+func TestPromptJSONTypeMismatchReturnsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{"count":"twelve"}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var out struct {
+		Count int `json:"count"`
+	}
+	_, err := session.PromptJSON(context.Background(), "bad", &out)
+	if err == nil || !strings.Contains(err.Error(), "decode JSON result") {
+		t.Fatalf("err = %v, want decode JSON result", err)
+	}
+}
+
+func TestPromptJSONNilTargetErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	if _, err := session.PromptJSON(context.Background(), "x", nil); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("err = %v, want nil-target error", err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("provider was called with nil target: calls=%d", provider.calls)
+	}
+}
+
+func TestPromptJSONNonPointerErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var out struct{}
+	if _, err := session.PromptJSON(context.Background(), "x", out); err == nil || !strings.Contains(err.Error(), "non-nil pointer") {
+		t.Fatalf("err = %v, want non-pointer error", err)
+	}
+}
+
+func TestPromptJSONStringSchemaIsParsed(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{"x":1}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var out struct {
+		X int `json:"x"`
+	}
+	if _, err := session.PromptJSON(context.Background(), "x", &out, WithJSONSchema(`{"type":"object"}`)); err != nil {
+		t.Fatal(err)
+	}
+	got := provider.requests[0].Options["response_json_schema"]
+	if got == nil {
+		t.Fatal("schema missing")
+	}
+	if _, ok := got.(map[string]any); !ok {
+		t.Fatalf("schema type = %T, want map[string]any (decoded)", got)
+	}
+}
+
+func TestPromptJSONInvalidStringSchemaErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{jsonTurn(`{}`)}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	var out struct{}
+	_, err := session.PromptJSON(context.Background(), "x", &out, WithJSONSchema("not-json"))
+	if err == nil || !strings.Contains(err.Error(), "invalid JSON schema") {
+		t.Fatalf("err = %v, want invalid JSON schema", err)
+	}
+}

--- a/providers/gemini/convert.go
+++ b/providers/gemini/convert.go
@@ -205,11 +205,16 @@ func buildGenerateConfig(req loop.ProviderRequest) (*genai.GenerateContentConfig
 				return nil, fmt.Errorf("gemini: %s must be numeric", key)
 			}
 			config.MaxOutputTokens = maxTokens
+		case "response_mime_type":
+			mimeType, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("gemini: response_mime_type must be a string")
+			}
+			config.ResponseMIMEType = mimeType
+		case "response_json_schema":
+			config.ResponseJsonSchema = value
 		}
 	}
-	// Structured-output options (response_mime_type, response_json_schema)
-	// are intentionally unhandled here; they belong to the structured-JSON
-	// result issue.
 	return config, nil
 }
 

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -226,6 +226,39 @@ func TestBuildGenerateConfigInvalidNumeric(t *testing.T) {
 	}
 }
 
+func TestBuildGenerateConfigStructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := buildGenerateConfig(loop.ProviderRequest{
+		Options: map[string]any{
+			"response_mime_type":   "application/json",
+			"response_json_schema": map[string]any{"type": "object"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildGenerateConfig: %v", err)
+	}
+	if cfg.ResponseMIMEType != "application/json" {
+		t.Fatalf("ResponseMIMEType = %q, want application/json", cfg.ResponseMIMEType)
+	}
+	asMap, ok := cfg.ResponseJsonSchema.(map[string]any)
+	if !ok {
+		t.Fatalf("ResponseJsonSchema = %T, want map[string]any", cfg.ResponseJsonSchema)
+	}
+	if asMap["type"] != "object" {
+		t.Fatalf("schema.type = %v, want object", asMap["type"])
+	}
+}
+
+func TestBuildGenerateConfigBadResponseMIMEType(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"response_mime_type": 42}})
+	if err == nil || !strings.Contains(err.Error(), "response_mime_type") {
+		t.Fatalf("err = %v, want response_mime_type error", err)
+	}
+}
+
 func TestMapFinishReason(t *testing.T) {
 	t.Parallel()
 

--- a/session.go
+++ b/session.go
@@ -2,7 +2,11 @@ package glue
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -89,6 +93,7 @@ type promptConfig struct {
 	options      map[string]any
 	maxTurns     int
 	emit         func(Event)
+	jsonSchema   any
 }
 
 // WithModel overrides the agent model for one prompt.
@@ -121,6 +126,15 @@ func WithMaxTurns(maxTurns int) PromptOption {
 // installed via [Session.Subscribe].
 func WithEvents(handler func(Event)) PromptOption {
 	return func(c *promptConfig) { c.emit = handler }
+}
+
+// WithJSONSchema attaches a JSON Schema for [Session.PromptJSON]. The
+// schema may be passed as a Go value (map / struct), a json.RawMessage, a
+// []byte, or a string; bytes/string forms are JSON-decoded once. When the
+// active provider supports structured output, the schema is forwarded as
+// the provider's structured-response config (Gemini: `response_json_schema`).
+func WithJSONSchema(schema any) PromptOption {
+	return func(c *promptConfig) { c.jsonSchema = schema }
 }
 
 // Prompt sends a user message through the agent loop and stores the
@@ -215,6 +229,100 @@ func (s *Session) save(ctx context.Context, state SessionState) error {
 		return nil
 	}
 	return s.agent.store.Save(ctx, s.id, state)
+}
+
+// PromptJSON sends a prompt and decodes the assistant's final text into
+// outPtr, which must be a non-nil pointer. It augments the user prompt with
+// JSON-only instructions so non-Gemini providers can still produce
+// parseable output, and sets `response_mime_type: application/json` on the
+// provider request. When [WithJSONSchema] is provided, the schema is also
+// forwarded as `response_json_schema`.
+//
+// V1 validation is intentionally limited to JSON decoding into the
+// caller's Go type; full JSON Schema validation is out of scope.
+func (s *Session) PromptJSON(ctx context.Context, text string, outPtr any, options ...PromptOption) (PromptResult, error) {
+	if err := validateJSONOutputTarget(outPtr); err != nil {
+		return PromptResult{}, err
+	}
+
+	var probe promptConfig
+	for _, opt := range options {
+		if opt != nil {
+			opt(&probe)
+		}
+	}
+	schema, err := normalizeJSONSchema(probe.jsonSchema)
+	if err != nil {
+		return PromptResult{}, err
+	}
+
+	providerOptions := cloneMap(probe.options)
+	if providerOptions == nil {
+		providerOptions = map[string]any{}
+	}
+	providerOptions["response_mime_type"] = "application/json"
+	if schema != nil {
+		providerOptions["response_json_schema"] = schema
+	}
+
+	merged := append([]PromptOption{}, options...)
+	merged = append(merged, WithProviderOptions(providerOptions))
+
+	result, err := s.Prompt(ctx, buildJSONPrompt(text, schema), merged...)
+	if err != nil {
+		return result, err
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(result.Text)), outPtr); err != nil {
+		return result, fmt.Errorf("glue: decode JSON result: %w", err)
+	}
+	return result, nil
+}
+
+func validateJSONOutputTarget(out any) error {
+	if out == nil {
+		return errors.New("glue: PromptJSON output target is nil")
+	}
+	value := reflect.ValueOf(out)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return errors.New("glue: PromptJSON output target must be a non-nil pointer")
+	}
+	return nil
+}
+
+func normalizeJSONSchema(schema any) (any, error) {
+	switch value := schema.(type) {
+	case nil:
+		return nil, nil
+	case json.RawMessage:
+		return decodeJSONSchemaBytes(value)
+	case []byte:
+		return decodeJSONSchemaBytes(value)
+	case string:
+		return decodeJSONSchemaBytes([]byte(value))
+	default:
+		return value, nil
+	}
+}
+
+func decodeJSONSchemaBytes(data []byte) (any, error) {
+	var schema any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("glue: invalid JSON schema: %w", err)
+	}
+	return schema, nil
+}
+
+func buildJSONPrompt(text string, schema any) string {
+	var b strings.Builder
+	b.WriteString(text)
+	b.WriteString("\n\nRespond with only valid JSON. Do not include markdown fences, prose, or commentary.")
+	if schema != nil {
+		if data, err := json.MarshalIndent(schema, "", "  "); err == nil {
+			b.WriteString("\n\nThe JSON must conform to this schema:\n")
+			b.Write(data)
+		}
+	}
+	return b.String()
 }
 
 func (s *Session) promptConfig(options []PromptOption) promptConfig {


### PR DESCRIPTION
## Summary

Adds `Session.PromptJSON`, `glue.WithJSONSchema`, and Gemini-side wiring for structured-output options.

**`glue/session.go`**

- `WithJSONSchema(schema any)` — accepts Go value, `json.RawMessage`, `[]byte`, or `string`; bytes/string are JSON-decoded once.
- `Session.PromptJSON(ctx, text, outPtr, opts...)`:
  - validates `outPtr` is a non-nil pointer
  - augments the user prompt with `"Respond with only valid JSON..."` plus the schema if provided
  - sets `response_mime_type: application/json` on the provider request
  - forwards `response_json_schema` when a schema is set
  - `json.Unmarshal`s the assistant's final text into `outPtr`
- Helpers: `validateJSONOutputTarget`, `normalizeJSONSchema`, `decodeJSONSchemaBytes`, `buildJSONPrompt`.

V1 validation is JSON decode into the caller's type only; full JSON Schema validation is out of scope per `docs/design.md`.

**`providers/gemini/convert.go`**

- `buildGenerateConfig` now honors `response_mime_type` (string) and `response_json_schema` (any). Non-string `response_mime_type` errors.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	0.003s
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	0.009s
ok  	glue/stores/file	(cached)
```

**8 new glue tests** in `prompt_json_test.go`:

- struct decode happy path (response_mime_type forwarded, JSON-only instruction in prompt)
- schema forwarded as map (response_json_schema present in provider options)
- invalid JSON returns `decode JSON result` error
- type mismatch returns `decode JSON result` error
- nil target errors **before** the provider is called
- non-pointer target errors before the provider is called
- string schema is parsed into a map
- invalid string schema errors before the provider is called

**+2 gemini tests** in `gemini_test.go`:

- structured output options populate the genai config
- bad `response_mime_type` type errors

README adds a "Structured JSON results" section showing `PromptJSON` + `WithJSONSchema`.

Closes #12.