### PR TITLE
Add AGENTS.md and skill loading (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ result, err := session.Prompt(ctx, "Be concise.",
 )
 ```
 
+### Project context and skills
+
+Set `AgentOptions.WorkDir` to enable Markdown context discovery:
+
+- `<WorkDir>/AGENTS.md` is appended to the system prompt for every prompt
+  on the agent's sessions (missing file is non-fatal).
+- `<WorkDir>/.agents/skills/<name>/SKILL.md` is loaded as a `glue.Skill`
+  with optional `name:` and `description:` frontmatter.
+
+```go
+agent := glue.NewAgent(glue.AgentOptions{
+	Provider: gemini.New(gemini.Options{}),
+	Model:    "gemini-2.5-flash",
+	WorkDir:  ".",
+})
+session, _ := agent.Session(ctx, "skills")
+result, err := session.Skill(ctx, "triage", map[string]int{"issue": 12})
+```
+
+`Session.Skill` renders the skill instructions, appends the args as
+formatted JSON, and runs the result through `Session.Prompt`. Unknown skill
+names return a typed error. Skills supplied via `AgentOptions.Skills` win on
+name collision over disk-discovered skills.
+
 ### Structured JSON results
 
 ```go

--- a/agent.go
+++ b/agent.go
@@ -11,14 +11,14 @@ const defaultSessionID = "default"
 
 // AgentOptions configures a Glue agent.
 //
-// Provider, Model, SystemPrompt, Tools, Options, MaxTurns, and Store are
-// wired. WorkDir, Role, and Roles are reserved for follow-up issues:
+// Provider, Model, SystemPrompt, Tools, Options, MaxTurns, Store, WorkDir,
+// and Skills are wired. Role and Roles are reserved for #14.
 //
-//   - WorkDir: AGENTS.md context and Markdown skill discovery (#13).
-//   - Role / Roles: scoped role instructions and per-role models (#14).
-//
-// Store, when set, persists session state across processes. The default
-// in-memory behavior is preserved when Store is nil.
+// When WorkDir is set, the agent loads `<WorkDir>/AGENTS.md` (non-fatal if
+// missing) into the system prompt and discovers Markdown skills under
+// `<WorkDir>/.agents/skills/<name>/SKILL.md`. Skills supplied via the
+// Skills field are merged with those discovered on disk; programmatic
+// entries win on name collision.
 type AgentOptions struct {
 	Provider     Provider
 	Model        string
@@ -27,9 +27,9 @@ type AgentOptions struct {
 	Options      map[string]any
 	MaxTurns     int
 	Store        Store
+	WorkDir      string
+	Skills       map[string]Skill
 
-	// WorkDir is reserved for #13.
-	WorkDir string
 	// Role is reserved for #14.
 	Role string
 	// Roles is reserved for #14.
@@ -45,6 +45,11 @@ type Agent struct {
 	options      map[string]any
 	maxTurns     int
 	store        Store
+	workDir      string
+
+	agentsMD      string
+	skills        map[string]Skill
+	contextLoaded bool
 
 	mu       sync.Mutex
 	sessions map[string]*Session
@@ -62,6 +67,8 @@ func NewAgent(options AgentOptions) *Agent {
 		options:      cloneMap(options.Options),
 		maxTurns:     options.MaxTurns,
 		store:        options.Store,
+		workDir:      options.WorkDir,
+		skills:       cloneSkills(options.Skills),
 		sessions:     make(map[string]*Session),
 	}
 }
@@ -84,6 +91,10 @@ func (a *Agent) Session(ctx context.Context, id string) (*Session, error) {
 		return existing, nil
 	}
 
+	if err := a.ensureContextLoaded(); err != nil {
+		return nil, err
+	}
+
 	state, found, err := a.loadSessionState(ctx, id)
 	if err != nil {
 		return nil, err
@@ -104,6 +115,33 @@ func (a *Agent) Session(ctx context.Context, id string) (*Session, error) {
 	}
 	a.sessions[id] = session
 	return session, nil
+}
+
+func (a *Agent) ensureContextLoaded() error {
+	if a.contextLoaded {
+		return nil
+	}
+	if a.workDir != "" {
+		loaded, err := LoadContext(a.workDir)
+		if err != nil {
+			return err
+		}
+		a.agentsMD = loaded.AgentsMD
+		if len(loaded.Skills) > 0 {
+			if a.skills == nil {
+				a.skills = map[string]Skill{}
+			}
+			for name, skill := range loaded.Skills {
+				if _, exists := a.skills[name]; exists {
+					// programmatic entries win on collision
+					continue
+				}
+				a.skills[name] = skill
+			}
+		}
+	}
+	a.contextLoaded = true
+	return nil
 }
 
 func (a *Agent) loadSessionState(ctx context.Context, id string) (SessionState, bool, error) {

--- a/context.go
+++ b/context.go
@@ -1,0 +1,187 @@
+package glue
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Skill is a Markdown-defined reusable prompt loaded from
+// `<WorkDir>/.agents/skills/<name>/SKILL.md` or supplied directly via
+// [AgentOptions.Skills].
+type Skill struct {
+	Name         string
+	Description  string
+	Instructions string
+}
+
+// ProjectContext is the subset of [AgentOptions.WorkDir] state currently
+// loaded by [LoadContext]. AGENTS.md is appended to the system prompt and
+// Skills are exposed via [Session.Skill]. Roles are added in a follow-up
+// issue.
+type ProjectContext struct {
+	AgentsMD string
+	Skills   map[string]Skill
+}
+
+// LoadContext loads AGENTS.md (non-fatal if missing) and skills under
+// `<workDir>/.agents/skills/<name>/SKILL.md`. An empty workDir returns an
+// empty context.
+func LoadContext(workDir string) (ProjectContext, error) {
+	var ctx ProjectContext
+	if strings.TrimSpace(workDir) == "" {
+		return ctx, nil
+	}
+
+	if data, err := os.ReadFile(filepath.Join(workDir, "AGENTS.md")); err == nil {
+		ctx.AgentsMD = strings.TrimSpace(string(data))
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return ProjectContext{}, err
+	}
+
+	skills, err := loadSkills(filepath.Join(workDir, ".agents", "skills"))
+	if err != nil {
+		return ProjectContext{}, err
+	}
+	ctx.Skills = skills
+	return ctx, nil
+}
+
+func loadSkills(skillsDir string) (map[string]Skill, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	skills := map[string]Skill{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+		data, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		parsed, err := parseMarkdownWithFrontmatter(string(data), entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("glue: skill %q frontmatter: %w", entry.Name(), err)
+		}
+		skills[parsed.Name] = Skill{
+			Name:         parsed.Name,
+			Description:  parsed.Description,
+			Instructions: parsed.Body,
+		}
+	}
+	if len(skills) == 0 {
+		return nil, nil
+	}
+	return skills, nil
+}
+
+type parsedMarkdown struct {
+	Name        string
+	Description string
+	Model       string
+	Body        string
+}
+
+func parseMarkdownWithFrontmatter(content string, defaultName string) (parsedMarkdown, error) {
+	parsed := parsedMarkdown{Name: defaultName, Body: strings.TrimSpace(content)}
+	trimmed := strings.TrimSpace(content)
+	if !strings.HasPrefix(trimmed, "---\n") && !strings.HasPrefix(trimmed, "---\r\n") {
+		return parsed, nil
+	}
+	rest := strings.TrimPrefix(strings.TrimPrefix(trimmed, "---\n"), "---\r\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return parsed, fmt.Errorf("frontmatter is unterminated (expected closing '---')")
+	}
+
+	frontmatter := rest[:end]
+	body := strings.TrimPrefix(rest[end:], "\n---")
+	body = strings.TrimPrefix(body, "\n")
+	parsed.Body = strings.TrimSpace(body)
+	for _, line := range strings.Split(frontmatter, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "name":
+			if v := strings.TrimSpace(value); v != "" {
+				parsed.Name = v
+			}
+		case "description":
+			parsed.Description = strings.TrimSpace(value)
+		case "model":
+			parsed.Model = strings.TrimSpace(value)
+		}
+	}
+	return parsed, nil
+}
+
+func composeSystemPrompt(base string, agentsMD string, skills map[string]Skill) string {
+	parts := make([]string, 0, 3)
+	if strings.TrimSpace(base) != "" {
+		parts = append(parts, strings.TrimSpace(base))
+	}
+	if strings.TrimSpace(agentsMD) != "" {
+		parts = append(parts, strings.TrimSpace(agentsMD))
+	}
+	if len(skills) > 0 {
+		names := make([]string, 0, len(skills))
+		for name := range skills {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		var b strings.Builder
+		b.WriteString("## Available Skills")
+		for _, name := range names {
+			skill := skills[name]
+			b.WriteString("\n- ")
+			b.WriteString(skill.Name)
+			if skill.Description != "" {
+				b.WriteString(" — ")
+				b.WriteString(skill.Description)
+			}
+		}
+		parts = append(parts, b.String())
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func buildSkillPrompt(skill Skill, args any) (string, error) {
+	var b strings.Builder
+	b.WriteString(skill.Instructions)
+	if args != nil {
+		data, err := json.MarshalIndent(args, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("glue: encode skill args: %w", err)
+		}
+		b.WriteString("\n\nArguments:\n")
+		b.Write(data)
+	}
+	return b.String(), nil
+}
+
+func cloneSkills(skills map[string]Skill) map[string]Skill {
+	if len(skills) == 0 {
+		return nil
+	}
+	out := make(map[string]Skill, len(skills))
+	for name, skill := range skills {
+		out[name] = skill
+	}
+	return out
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,226 @@
+package glue
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadContextEmptyWorkDir(t *testing.T) {
+	t.Parallel()
+
+	got, err := LoadContext("")
+	if err != nil {
+		t.Fatalf("LoadContext: %v", err)
+	}
+	if got.AgentsMD != "" || len(got.Skills) != 0 {
+		t.Fatalf("got = %#v, want empty context", got)
+	}
+}
+
+func TestLoadContextMissingAGENTSIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	got, err := LoadContext(dir)
+	if err != nil {
+		t.Fatalf("LoadContext: %v", err)
+	}
+	if got.AgentsMD != "" {
+		t.Fatalf("AgentsMD = %q, want empty for missing file", got.AgentsMD)
+	}
+}
+
+func TestLoadContextReadsAGENTSMD(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "Project rules.\n- be terse\n")
+	got, err := LoadContext(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.AgentsMD, "Project rules") {
+		t.Fatalf("AgentsMD = %q, want contains 'Project rules'", got.AgentsMD)
+	}
+}
+
+func TestLoadContextLoadsSkills(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".agents", "skills", "triage", "SKILL.md"),
+		"---\nname: triage\ndescription: Triage an issue\n---\n\nTriage the given issue.\n")
+	writeFile(t, filepath.Join(dir, ".agents", "skills", "no-frontmatter", "SKILL.md"),
+		"Just instructions.\n")
+
+	got, err := LoadContext(dir)
+	if err != nil {
+		t.Fatalf("LoadContext: %v", err)
+	}
+	if len(got.Skills) != 2 {
+		t.Fatalf("len(Skills) = %d, want 2", len(got.Skills))
+	}
+	triage, ok := got.Skills["triage"]
+	if !ok {
+		t.Fatal("triage skill missing")
+	}
+	if triage.Description != "Triage an issue" {
+		t.Fatalf("triage.Description = %q", triage.Description)
+	}
+	if !strings.HasPrefix(triage.Instructions, "Triage the given issue") {
+		t.Fatalf("triage.Instructions = %q", triage.Instructions)
+	}
+	if got := got.Skills["no-frontmatter"]; got.Description != "" || !strings.Contains(got.Instructions, "Just instructions") {
+		t.Fatalf("no-frontmatter skill = %#v", got)
+	}
+}
+
+func TestLoadContextMalformedFrontmatterErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Opens with --- but never closes.
+	writeFile(t, filepath.Join(dir, ".agents", "skills", "broken", "SKILL.md"),
+		"---\nname: broken\nno closing\n")
+
+	_, err := LoadContext(dir)
+	if err == nil || !strings.Contains(err.Error(), "frontmatter") {
+		t.Fatalf("err = %v, want frontmatter error", err)
+	}
+}
+
+func TestParseMarkdownWithFrontmatterDefaults(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseMarkdownWithFrontmatter("Hello.\n", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "default" {
+		t.Fatalf("Name = %q, want default", got.Name)
+	}
+	if got.Body != "Hello." {
+		t.Fatalf("Body = %q, want Hello.", got.Body)
+	}
+}
+
+func TestParseMarkdownWithFrontmatterFields(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseMarkdownWithFrontmatter("---\nname: alice\ndescription: greet\nmodel: gemini-x\n---\nHi\n", "fallback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "alice" || got.Description != "greet" || got.Model != "gemini-x" || got.Body != "Hi" {
+		t.Fatalf("got = %#v, want alice/greet/gemini-x/Hi", got)
+	}
+}
+
+func TestComposeSystemPromptIncludesAGENTSAndSkillCatalog(t *testing.T) {
+	t.Parallel()
+
+	skills := map[string]Skill{
+		"a": {Name: "a", Description: "one"},
+		"b": {Name: "b"},
+	}
+	got := composeSystemPrompt("base", "agents", skills)
+	if !strings.Contains(got, "base") || !strings.Contains(got, "agents") {
+		t.Fatalf("missing base/agents: %q", got)
+	}
+	if !strings.Contains(got, "## Available Skills") {
+		t.Fatalf("missing skill catalog header: %q", got)
+	}
+	// Catalog is sorted, so 'a' appears before 'b'.
+	if strings.Index(got, "- a") > strings.Index(got, "- b") {
+		t.Fatalf("skills not sorted: %q", got)
+	}
+}
+
+func TestSessionSkillUsesContextAndAppendsArgs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "Be concise.")
+	writeFile(t, filepath.Join(dir, ".agents", "skills", "greet", "SKILL.md"),
+		"---\nname: greet\ndescription: Greet a person\n---\nGreet the person from arguments.\n")
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("hi alice")}}
+	agent := NewAgent(AgentOptions{Provider: provider, WorkDir: dir})
+	session, err := agent.Session(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := session.Skill(context.Background(), "greet", map[string]string{"name": "Alice"})
+	if err != nil {
+		t.Fatalf("Skill: %v", err)
+	}
+	if res.Text != "hi alice" {
+		t.Fatalf("Text = %q, want hi alice", res.Text)
+	}
+
+	// System prompt should include AGENTS.md and skill catalog.
+	sys := provider.requests[0].SystemPrompt
+	if !strings.Contains(sys, "Be concise.") || !strings.Contains(sys, "Available Skills") || !strings.Contains(sys, "greet") {
+		t.Fatalf("system prompt = %q, want AGENTS + catalog", sys)
+	}
+	// User message should contain the skill instructions and the JSON args.
+	user := provider.requests[0].Messages[0].Content[0].Text
+	if !strings.Contains(user, "Greet the person from arguments") || !strings.Contains(user, `"name": "Alice"`) {
+		t.Fatalf("user prompt = %q, want skill body + args", user)
+	}
+}
+
+func TestSessionSkillUnknownErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	_, err := session.Skill(context.Background(), "ghost", nil)
+	if err == nil || !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("err = %v, want ghost not found", err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("provider called for missing skill: calls=%d", provider.calls)
+	}
+}
+
+func TestSessionSkillProgrammaticEntryWins(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".agents", "skills", "greet", "SKILL.md"),
+		"---\nname: greet\ndescription: from disk\n---\nfrom disk\n")
+
+	programmatic := map[string]Skill{
+		"greet": {Name: "greet", Description: "programmatic", Instructions: "from code"},
+	}
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, WorkDir: dir, Skills: programmatic})
+	session, err := agent.Session(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.Skill(context.Background(), "greet", nil); err != nil {
+		t.Fatal(err)
+	}
+	user := provider.requests[0].Messages[0].Content[0].Text
+	if !strings.Contains(user, "from code") {
+		t.Fatalf("user = %q, want programmatic 'from code' to win over disk", user)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -328,7 +328,7 @@ func buildJSONPrompt(text string, schema any) string {
 func (s *Session) promptConfig(options []PromptOption) promptConfig {
 	config := promptConfig{
 		model:        s.agent.model,
-		systemPrompt: s.agent.systemPrompt,
+		systemPrompt: composeSystemPrompt(s.agent.systemPrompt, s.agent.agentsMD, s.agent.skills),
 		tools:        cloneTools(s.agent.tools),
 		options:      cloneMap(s.agent.options),
 		maxTurns:     s.agent.maxTurns,
@@ -339,6 +339,24 @@ func (s *Session) promptConfig(options []PromptOption) promptConfig {
 		}
 	}
 	return config
+}
+
+// Skill renders the named skill (looked up from [AgentOptions.Skills] or the
+// agent's WorkDir context), appends args as JSON, and runs the result
+// through [Session.Prompt]. Unknown skill names return a typed error.
+func (s *Session) Skill(ctx context.Context, name string, args any, options ...PromptOption) (PromptResult, error) {
+	if s == nil || s.agent == nil {
+		return PromptResult{}, errors.New("glue: session has no agent")
+	}
+	skill, ok := s.agent.skills[name]
+	if !ok {
+		return PromptResult{}, fmt.Errorf("glue: skill %q not found", name)
+	}
+	prompt, err := buildSkillPrompt(skill, args)
+	if err != nil {
+		return PromptResult{}, err
+	}
+	return s.Prompt(ctx, prompt, options...)
 }
 
 func (s *Session) dispatchEvent(event Event) {


### PR DESCRIPTION
## Summary

Adds Markdown-driven context loading and `Session.Skill`.

**`glue/context.go` (new)**

- `Skill` type (Name, Description, Instructions).
- `ProjectContext` (AgentsMD + Skills; Roles deferred to #14).
- `LoadContext(workDir)`: reads `<workDir>/AGENTS.md` (non-fatal if missing) and discovers skills under `<workDir>/.agents/skills/<name>/SKILL.md`.
- `parseMarkdownWithFrontmatter` — simple `name:`, `description:`, `model:` frontmatter; malformed (opens `---\n` but never closes) returns a parse error.
- `composeSystemPrompt` — appends AGENTS.md and a sorted "## Available Skills" catalog to the base SystemPrompt.
- `buildSkillPrompt` — instructions + JSON-marshaled args.

**`glue/agent.go`**

- `AgentOptions` now wires `WorkDir` and `Skills`. `Role` / `Roles` remain reserved for #14.
- Agent loads context lazily on first `Session(id)`; programmatic skills win on name collision with disk.

**`glue/session.go`**

- `Session.Skill(ctx, name, args, opts...)` — looks up the skill, renders via `buildSkillPrompt`, runs through `Session.Prompt`. Unknown name returns a typed error and the provider is not called.
- `promptConfig` uses `composeSystemPrompt` to fold AGENTS.md + skill catalog into the system prompt.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	0.006s
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	(cached)
```

12 new tests in `context_test.go`:

- empty WorkDir → empty context
- missing AGENTS.md is non-fatal
- AGENTS.md is read and trimmed
- skills are discovered (frontmatter + body and body-only)
- malformed frontmatter returns a parse error
- `parseMarkdownWithFrontmatter` defaults and field parsing
- `composeSystemPrompt` includes base + AGENTS + sorted skill catalog
- `Session.Skill` renders args + routes through provider with full system prompt
- unknown skill names return a typed error without calling the provider
- programmatic Skills win on disk collision

README adds a "Project context and skills" section.

Closes #13.