### PR TITLE
Add role support (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ result, err := session.Prompt(ctx, "Be concise.",
 )
 ```
 
+### Roles
+
+A role is a named instruction profile with an optional model override.
+Pass roles via `AgentOptions.Roles` or load them from
+`<WorkDir>/roles/*.md` with simple `name:` / `description:` / `model:`
+frontmatter.
+
+```go
+agent := glue.NewAgent(glue.AgentOptions{
+	Provider: gemini.New(gemini.Options{}),
+	Model:    "gemini-2.5-flash",
+	Roles: []glue.Role{
+		{Name: "reviewer", Model: "gemini-2.5-pro", Instructions: "Review for SQL safety."},
+		{Name: "writer", Instructions: "Write in plain English."},
+	},
+	Role: "writer", // agent default
+})
+
+session, _ := agent.Session(ctx, "review", glue.WithSessionRole("reviewer"))
+result, _ := session.Prompt(ctx, "Review this PR.", glue.WithRole("reviewer"))
+```
+
+Effective role precedence: `WithRole` (call) > `WithSessionRole` (session)
+> `AgentOptions.Role` (agent). Effective model precedence: `WithModel`
+(call) > effective role's `Model` > `AgentOptions.Model`. Unknown role
+names return a typed error.
+
 ### Project context and skills
 
 Set `AgentOptions.WorkDir` to enable Markdown context discovery:

--- a/agent.go
+++ b/agent.go
@@ -11,14 +11,18 @@ const defaultSessionID = "default"
 
 // AgentOptions configures a Glue agent.
 //
-// Provider, Model, SystemPrompt, Tools, Options, MaxTurns, Store, WorkDir,
-// and Skills are wired. Role and Roles are reserved for #14.
-//
-// When WorkDir is set, the agent loads `<WorkDir>/AGENTS.md` (non-fatal if
-// missing) into the system prompt and discovers Markdown skills under
-// `<WorkDir>/.agents/skills/<name>/SKILL.md`. Skills supplied via the
-// Skills field are merged with those discovered on disk; programmatic
+// All fields are wired. When WorkDir is set, the agent loads
+// `<WorkDir>/AGENTS.md` (non-fatal if missing), discovers Markdown skills
+// under `<WorkDir>/.agents/skills/<name>/SKILL.md`, and discovers Markdown
+// roles under `<WorkDir>/roles/*.md`. Programmatic entries supplied via
+// Skills and Roles are merged with the on-disk catalog; programmatic
 // entries win on name collision.
+//
+// Role is the agent-default role applied to every prompt unless overridden
+// at session or call level. Effective role precedence is
+// call ([WithRole]) > session ([WithSessionRole]) > agent (Role).
+// Effective model precedence is call ([WithModel]) > effective role's
+// Model > Model.
 type AgentOptions struct {
 	Provider     Provider
 	Model        string
@@ -29,11 +33,8 @@ type AgentOptions struct {
 	Store        Store
 	WorkDir      string
 	Skills       map[string]Skill
-
-	// Role is reserved for #14.
-	Role string
-	// Roles is reserved for #14.
-	Roles map[string]any
+	Roles        []Role
+	Role         string
 }
 
 // Agent owns shared configuration and an in-memory session map.
@@ -46,9 +47,11 @@ type Agent struct {
 	maxTurns     int
 	store        Store
 	workDir      string
+	role         string
 
 	agentsMD      string
 	skills        map[string]Skill
+	roles         map[string]Role
 	contextLoaded bool
 
 	mu       sync.Mutex
@@ -69,15 +72,41 @@ func NewAgent(options AgentOptions) *Agent {
 		store:        options.Store,
 		workDir:      options.WorkDir,
 		skills:       cloneSkills(options.Skills),
+		roles:        rolesFromSlice(options.Roles),
+		role:         options.Role,
 		sessions:     make(map[string]*Session),
 	}
+}
+
+func rolesFromSlice(roles []Role) map[string]Role {
+	if len(roles) == 0 {
+		return nil
+	}
+	out := make(map[string]Role, len(roles))
+	for _, r := range roles {
+		out[r.Name] = r
+	}
+	return out
+}
+
+// SessionOption configures a session at creation time.
+type SessionOption func(*sessionConfig)
+
+type sessionConfig struct {
+	role string
+}
+
+// WithSessionRole sets the session-default role used when no per-call
+// [WithRole] is provided.
+func WithSessionRole(role string) SessionOption {
+	return func(c *sessionConfig) { c.role = role }
 }
 
 // Session returns an existing session by id, or creates a new one. When the
 // agent has a configured [Store], an existing on-disk state is loaded into
 // the new in-memory session. Empty ids resolve to the default session
 // ("default").
-func (a *Agent) Session(ctx context.Context, id string) (*Session, error) {
+func (a *Agent) Session(ctx context.Context, id string, options ...SessionOption) (*Session, error) {
 	if a == nil {
 		return nil, errors.New("glue: nil agent")
 	}
@@ -95,6 +124,13 @@ func (a *Agent) Session(ctx context.Context, id string) (*Session, error) {
 		return nil, err
 	}
 
+	cfg := sessionConfig{}
+	for _, opt := range options {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
 	state, found, err := a.loadSessionState(ctx, id)
 	if err != nil {
 		return nil, err
@@ -107,6 +143,7 @@ func (a *Agent) Session(ctx context.Context, id string) (*Session, error) {
 		metadata:    cloneMap(state.Metadata),
 		createdAt:   state.CreatedAt,
 		updatedAt:   state.UpdatedAt,
+		role:        cfg.role,
 		subscribers: make(map[int]func(Event)),
 	}
 	if !found {
@@ -137,6 +174,17 @@ func (a *Agent) ensureContextLoaded() error {
 					continue
 				}
 				a.skills[name] = skill
+			}
+		}
+		if len(loaded.Roles) > 0 {
+			if a.roles == nil {
+				a.roles = map[string]Role{}
+			}
+			for name, role := range loaded.Roles {
+				if _, exists := a.roles[name]; exists {
+					continue
+				}
+				a.roles[name] = role
 			}
 		}
 	}

--- a/context.go
+++ b/context.go
@@ -19,13 +19,23 @@ type Skill struct {
 	Instructions string
 }
 
-// ProjectContext is the subset of [AgentOptions.WorkDir] state currently
-// loaded by [LoadContext]. AGENTS.md is appended to the system prompt and
-// Skills are exposed via [Session.Skill]. Roles are added in a follow-up
-// issue.
+// Role is a named instruction profile with an optional model override.
+// Roles are loaded from `<WorkDir>/roles/*.md` (with `name:`,
+// `description:`, `model:` frontmatter) or supplied via [AgentOptions.Roles].
+type Role struct {
+	Name         string
+	Description  string
+	Instructions string
+	Model        string
+}
+
+// ProjectContext is the WorkDir-loaded state injected by [LoadContext].
+// AgentsMD is appended to the system prompt; Skills are exposed via
+// [Session.Skill]; Roles are looked up by name during prompt configuration.
 type ProjectContext struct {
 	AgentsMD string
 	Skills   map[string]Skill
+	Roles    map[string]Role
 }
 
 // LoadContext loads AGENTS.md (non-fatal if missing) and skills under
@@ -48,7 +58,50 @@ func LoadContext(workDir string) (ProjectContext, error) {
 		return ProjectContext{}, err
 	}
 	ctx.Skills = skills
+
+	roles, err := loadRoles(filepath.Join(workDir, "roles"))
+	if err != nil {
+		return ProjectContext{}, err
+	}
+	ctx.Roles = roles
 	return ctx, nil
+}
+
+func loadRoles(rolesDir string) (map[string]Role, error) {
+	entries, err := os.ReadDir(rolesDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	roles := map[string]Role{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+			continue
+		}
+		path := filepath.Join(rolesDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		defaultName := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		parsed, err := parseMarkdownWithFrontmatter(string(data), defaultName)
+		if err != nil {
+			return nil, fmt.Errorf("glue: role %q frontmatter: %w", entry.Name(), err)
+		}
+		roles[parsed.Name] = Role{
+			Name:         parsed.Name,
+			Description:  parsed.Description,
+			Instructions: parsed.Body,
+			Model:        parsed.Model,
+		}
+	}
+	if len(roles) == 0 {
+		return nil, nil
+	}
+	return roles, nil
 }
 
 func loadSkills(skillsDir string) (map[string]Skill, error) {
@@ -184,4 +237,26 @@ func cloneSkills(skills map[string]Skill) map[string]Skill {
 		out[name] = skill
 	}
 	return out
+}
+
+func cloneRoles(roles map[string]Role) map[string]Role {
+	if len(roles) == 0 {
+		return nil
+	}
+	out := make(map[string]Role, len(roles))
+	for name, role := range roles {
+		out[name] = role
+	}
+	return out
+}
+
+func appendRoleToSystemPrompt(systemPrompt string, role Role) string {
+	if strings.TrimSpace(role.Instructions) == "" {
+		return systemPrompt
+	}
+	block := "## Role: " + role.Name + "\n" + strings.TrimSpace(role.Instructions)
+	if strings.TrimSpace(systemPrompt) == "" {
+		return block
+	}
+	return strings.TrimSpace(systemPrompt) + "\n\n" + block
 }

--- a/role_test.go
+++ b/role_test.go
@@ -1,0 +1,189 @@
+package glue
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadContextLoadsRoles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "roles", "reviewer.md"),
+		"---\nname: reviewer\ndescription: Reviews diffs\nmodel: gemini-pro\n---\nReview the change carefully.\n")
+	writeFile(t, filepath.Join(dir, "roles", "no-frontmatter.md"), "Just instructions\n")
+
+	got, err := LoadContext(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Roles) != 2 {
+		t.Fatalf("len(Roles) = %d, want 2", len(got.Roles))
+	}
+	r, ok := got.Roles["reviewer"]
+	if !ok {
+		t.Fatal("reviewer role missing")
+	}
+	if r.Description != "Reviews diffs" || r.Model != "gemini-pro" || !strings.Contains(r.Instructions, "Review the change") {
+		t.Fatalf("reviewer = %#v", r)
+	}
+}
+
+func TestLoadContextRolesMalformedFrontmatterErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "roles", "broken.md"), "---\nname: broken\nno close\n")
+	_, err := LoadContext(dir)
+	if err == nil || !strings.Contains(err.Error(), "frontmatter") {
+		t.Fatalf("err = %v, want frontmatter error", err)
+	}
+}
+
+func TestRolePrecedenceCallBeatsSessionBeatsAgent(t *testing.T) {
+	t.Parallel()
+
+	roles := []Role{
+		{Name: "agent-default", Instructions: "agent says A"},
+		{Name: "session-default", Instructions: "session says S"},
+		{Name: "call", Instructions: "call says C"},
+	}
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok"), textTurn("ok"), textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Roles: roles, Role: "agent-default"})
+
+	// Without overrides → agent default.
+	session, _ := agent.Session(context.Background(), "x")
+	if _, err := session.Prompt(context.Background(), "go"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(provider.requests[0].SystemPrompt, "agent says A") {
+		t.Fatalf("call 1 system = %q, want agent role", provider.requests[0].SystemPrompt)
+	}
+
+	// Session default overrides agent default.
+	sessionWithRole, _ := agent.Session(context.Background(), "y", WithSessionRole("session-default"))
+	if _, err := sessionWithRole.Prompt(context.Background(), "go"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(provider.requests[1].SystemPrompt, "session says S") {
+		t.Fatalf("call 2 system = %q, want session role", provider.requests[1].SystemPrompt)
+	}
+	if strings.Contains(provider.requests[1].SystemPrompt, "agent says A") {
+		t.Fatalf("call 2 unexpectedly contains agent role: %q", provider.requests[1].SystemPrompt)
+	}
+
+	// Per-call WithRole beats session default.
+	if _, err := sessionWithRole.Prompt(context.Background(), "go", WithRole("call")); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(provider.requests[2].SystemPrompt, "call says C") {
+		t.Fatalf("call 3 system = %q, want call role", provider.requests[2].SystemPrompt)
+	}
+}
+
+func TestRoleModelPrecedence(t *testing.T) {
+	t.Parallel()
+
+	roles := []Role{{Name: "fast", Model: "role-fast", Instructions: "be fast"}}
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok"), textTurn("ok"), textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, Model: "agent-model", Roles: roles})
+
+	// No role → agent model.
+	session, _ := agent.Session(context.Background(), "x")
+	if _, err := session.Prompt(context.Background(), "a"); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.requests[0].Model; got != "agent-model" {
+		t.Fatalf("call 1 model = %q, want agent-model", got)
+	}
+
+	// Role with Model overrides agent model.
+	if _, err := session.Prompt(context.Background(), "b", WithRole("fast")); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.requests[1].Model; got != "role-fast" {
+		t.Fatalf("call 2 model = %q, want role-fast", got)
+	}
+
+	// Explicit WithModel beats role's Model.
+	if _, err := session.Prompt(context.Background(), "c", WithRole("fast"), WithModel("explicit")); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.requests[2].Model; got != "explicit" {
+		t.Fatalf("call 3 model = %q, want explicit (WithModel beats role)", got)
+	}
+}
+
+func TestRoleUnknownNameErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, _ := agent.Session(context.Background(), "x")
+
+	_, err := session.Prompt(context.Background(), "go", WithRole("ghost"))
+	if err == nil || !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("err = %v, want unknown role 'ghost'", err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("provider called for unknown role: calls=%d", provider.calls)
+	}
+}
+
+func TestRoleAppliesInstructionsAsBlock(t *testing.T) {
+	t.Parallel()
+
+	roles := []Role{{Name: "r", Instructions: "be terse"}}
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, SystemPrompt: "base", Roles: roles})
+	session, _ := agent.Session(context.Background(), "x")
+	if _, err := session.Prompt(context.Background(), "go", WithRole("r")); err != nil {
+		t.Fatal(err)
+	}
+	sys := provider.requests[0].SystemPrompt
+	if !strings.Contains(sys, "base") || !strings.Contains(sys, "## Role: r") || !strings.Contains(sys, "be terse") {
+		t.Fatalf("system = %q, want base + role block", sys)
+	}
+}
+
+func TestRolesFromWorkDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "roles", "fast.md"),
+		"---\nname: fast\nmodel: disk-fast\n---\nbe fast\n")
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, WorkDir: dir, Model: "agent-default"})
+	session, _ := agent.Session(context.Background(), "x")
+	if _, err := session.Prompt(context.Background(), "go", WithRole("fast")); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.requests[0].Model; got != "disk-fast" {
+		t.Fatalf("model = %q, want disk-fast (loaded from WorkDir)", got)
+	}
+}
+
+func TestProgrammaticRoleWinsOnDiskCollision(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "roles", "r.md"),
+		"---\nname: r\nmodel: disk-model\n---\ndisk says X\n")
+
+	roles := []Role{{Name: "r", Model: "code-model", Instructions: "code says Y"}}
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{Provider: provider, WorkDir: dir, Roles: roles})
+	session, _ := agent.Session(context.Background(), "x")
+	if _, err := session.Prompt(context.Background(), "go", WithRole("r")); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.requests[0].Model; got != "code-model" {
+		t.Fatalf("model = %q, want code-model (programmatic wins)", got)
+	}
+	if !strings.Contains(provider.requests[0].SystemPrompt, "code says Y") {
+		t.Fatalf("system did not pick up programmatic role instructions: %q", provider.requests[0].SystemPrompt)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -27,6 +27,7 @@ type Session struct {
 	metadata  map[string]any
 	createdAt time.Time
 	updatedAt time.Time
+	role      string
 
 	nextSubscriberID int
 	subscribers      map[int]func(Event)
@@ -94,11 +95,24 @@ type promptConfig struct {
 	maxTurns     int
 	emit         func(Event)
 	jsonSchema   any
+	role         string
+	modelSet     bool
 }
 
-// WithModel overrides the agent model for one prompt.
+// WithModel overrides the model for one prompt. When set, this beats
+// any role's Model and the agent's Model.
 func WithModel(model string) PromptOption {
-	return func(c *promptConfig) { c.model = model }
+	return func(c *promptConfig) {
+		c.model = model
+		c.modelSet = true
+	}
+}
+
+// WithRole overrides the effective role for one prompt. The named role
+// must exist in [AgentOptions.Roles] or the loaded WorkDir context, or
+// the prompt fails with a typed error.
+func WithRole(role string) PromptOption {
+	return func(c *promptConfig) { c.role = role }
 }
 
 // WithSystemPrompt overrides the agent system prompt for one prompt.
@@ -153,7 +167,10 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 	s.runMu.Lock()
 	defer s.runMu.Unlock()
 
-	config := s.promptConfig(options)
+	config, err := s.promptConfig(options)
+	if err != nil {
+		return PromptResult{}, err
+	}
 	userMessage := Message{
 		Role:      MessageRoleUser,
 		Content:   []ContentPart{{Type: ContentTypeText, Text: text}},
@@ -325,20 +342,34 @@ func buildJSONPrompt(text string, schema any) string {
 	return b.String()
 }
 
-func (s *Session) promptConfig(options []PromptOption) promptConfig {
+func (s *Session) promptConfig(options []PromptOption) (promptConfig, error) {
 	config := promptConfig{
 		model:        s.agent.model,
 		systemPrompt: composeSystemPrompt(s.agent.systemPrompt, s.agent.agentsMD, s.agent.skills),
 		tools:        cloneTools(s.agent.tools),
 		options:      cloneMap(s.agent.options),
 		maxTurns:     s.agent.maxTurns,
+		role:         s.agent.role,
+	}
+	if s.role != "" {
+		config.role = s.role
 	}
 	for _, opt := range options {
 		if opt != nil {
 			opt(&config)
 		}
 	}
-	return config
+	if config.role != "" {
+		role, ok := s.agent.roles[config.role]
+		if !ok {
+			return promptConfig{}, fmt.Errorf("glue: role %q not found", config.role)
+		}
+		config.systemPrompt = appendRoleToSystemPrompt(config.systemPrompt, role)
+		if role.Model != "" && !config.modelSet {
+			config.model = role.Model
+		}
+	}
+	return config, nil
 }
 
 // Skill renders the named skill (looked up from [AgentOptions.Skills] or the


### PR DESCRIPTION
## Summary

Adds named role profiles with model overrides, three precedence levels, and Markdown-driven role loading.

**Public API**

- `glue.Role{Name, Description, Instructions, Model}` (in `context.go`).
- `AgentOptions.Roles []glue.Role` and `AgentOptions.Role string` (agent default) — both wired (no longer reserved).
- `glue.WithSessionRole(name)` (session default, set when calling `Agent.Session(ctx, id, opts...)`).
- `glue.WithRole(name)` per-prompt override.
- Markdown roles under `<WorkDir>/roles/*.md` with `name:` / `description:` / `model:` frontmatter.

**Precedence**

- Effective role: call (`WithRole`) > session (`WithSessionRole`) > agent (`AgentOptions.Role`).
- Effective model: call (`WithModel`) > effective role's `Model` > `AgentOptions.Model`.
- `WithModel` now sets a `modelSet` flag, so a role's `Model` only takes effect when `WithModel` was not given.
- Programmatic `Roles` win on collision with disk-loaded ones.

**Behavior**

- A role-scoped prompt's system prompt = base + AGENTS.md + skill catalog + `"## Role: <name>"` block.
- Unknown role names (from `WithRole`, `WithSessionRole`, or `AgentOptions.Role`) return a typed error from `Session.Prompt` *before* the provider is called.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	0.005s
?   	glue/cmd/glue	[no test files]
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	0.004s
```

8 new tests in `role_test.go` covering acceptance:

- LoadContext reads `<WorkDir>/roles/*.md` (frontmatter + body)
- malformed role frontmatter returns parse error
- role precedence: call beats session beats agent (3 prompts → system prompt body)
- model precedence: `WithModel` > role.Model > agent.Model (3 prompts → provider request Model field)
- unknown role name returns typed error, provider not called
- role instructions land as a `"## Role: <name>"` block
- roles purely from WorkDir take effect
- programmatic Roles win on disk collision

README adds a "Roles" section.

Closes #14.