### PR TITLE
Build local CLI runner (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,31 @@ smoke test:
 GEMINI_API_KEY=... go test ./providers/gemini -run Live
 ```
 
+## CLI
+
+A thin local CLI is built on the same library API:
+
+```sh
+go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
+```
+
+Flags:
+
+- `--id` — session id (default `"default"`).
+- `--prompt` — prompt text (required).
+- `--model` — model id or `gemini/<model>` (default `gemini-2.5-flash`).
+- `--store` — file session store directory (default `.glue/sessions`).
+- `--env` — `.env` file to load before reading `GEMINI_API_KEY`. Repeatable;
+  shell environment wins on conflict.
+
+The CLI streams text deltas to stdout, persists sessions through
+`stores/file`, and uses `WorkDir="."` so `AGENTS.md`, `.agents/skills`, and
+`roles/` discovery work from the invocation directory. Errors return a
+non-zero exit code; missing `GEMINI_API_KEY` produces a clear message.
+
 ## Roadmap
 
-The P1 milestone adds Gemini function calling, a file-backed session store,
-structured JSON results, AGENTS.md and skill loading, role support, and a
-local CLI runner. See [docs/project-plan.md](docs/project-plan.md) and the
-project tracker (#1).
+P2 covers parallel tool execution, context compaction, an opt-in shell/
+filesystem tool design, a provider plugin guide, and the GitHub issue
+automation workflow. See [docs/project-plan.md](docs/project-plan.md) and
+the project tracker (#1).

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -1,7 +1,211 @@
 // Command glue is the local CLI runner for Glue agents.
 //
-// This is the bootstrap scaffold; the run subcommand and Gemini wiring are
-// added by later issues.
+// Run a single prompt:
+//
+//	glue run --prompt "Say hi" --id local-dev --store .glue/sessions
+//
+// The default subcommand uses Glue's Gemini-backed agent. Streaming text
+// is written to stdout; provider, store, or flag errors exit non-zero.
 package main
 
-func main() {}
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"glue"
+	"glue/providers/gemini"
+	filestore "glue/stores/file"
+)
+
+const defaultModel = "gemini-2.5-flash"
+
+// providerFactory returns a [glue.Provider] or an error. The error is the
+// hook the default factory uses to surface "GEMINI_API_KEY missing"
+// before any API call is attempted.
+type providerFactory func() (glue.Provider, error)
+
+type envFiles []string
+
+func (e *envFiles) String() string { return strings.Join(*e, ",") }
+
+func (e *envFiles) Set(value string) error {
+	*e = append(*e, value)
+	return nil
+}
+
+func main() {
+	os.Exit(runCLI(context.Background(), os.Args[1:], os.Stdout, os.Stderr, defaultGeminiFactory))
+}
+
+func defaultGeminiFactory() (glue.Provider, error) {
+	if strings.TrimSpace(os.Getenv("GEMINI_API_KEY")) == "" {
+		return nil, errors.New("GEMINI_API_KEY is required (set in shell or pass --env <file>)")
+	}
+	return gemini.New(gemini.Options{}), nil
+}
+
+func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printUsage(stdout)
+		return 0
+	}
+
+	switch args[0] {
+	case "run":
+		if err := runCommand(ctx, args[1:], stdout, stderr, newProvider); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	default:
+		fmt.Fprintf(stderr, "unknown command %q\n\n", args[0])
+		printUsage(stderr)
+		return 1
+	}
+}
+
+func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory) error {
+	flags := flag.NewFlagSet("glue run", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	id := flags.String("id", "default", "session id")
+	prompt := flags.String("prompt", "", "prompt text")
+	model := flags.String("model", defaultModel, "model id or gemini/<model>")
+	storeDir := flags.String("store", ".glue/sessions", "session store directory")
+	var envs envFiles
+	flags.Var(&envs, "env", "env file path; repeatable")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	agentName := "default"
+	if flags.NArg() > 0 {
+		agentName = flags.Arg(0)
+	}
+	if agentName != "default" && agentName != "gemini" {
+		return fmt.Errorf("unknown agent %q; only 'default' is available in this runner", agentName)
+	}
+	if strings.TrimSpace(*prompt) == "" {
+		return errors.New("missing required --prompt")
+	}
+	if err := loadEnvFiles(envs); err != nil {
+		return err
+	}
+
+	provider, err := newProvider()
+	if err != nil {
+		return err
+	}
+
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: provider,
+		Model:    normalizeModel(*model),
+		Store:    filestore.New(*storeDir),
+		WorkDir:  ".",
+	})
+	session, err := agent.Session(ctx, *id)
+	if err != nil {
+		return err
+	}
+
+	wroteDelta := false
+	response, err := session.Prompt(ctx, *prompt, glue.WithEvents(func(event glue.Event) {
+		if event.Type == glue.EventTextDelta && event.Delta != "" {
+			fmt.Fprint(stdout, event.Delta)
+			wroteDelta = true
+		}
+	}))
+	if err != nil {
+		if wroteDelta {
+			fmt.Fprintln(stdout)
+		}
+		return err
+	}
+	if wroteDelta {
+		fmt.Fprintln(stdout)
+		return nil
+	}
+	if response.Text != "" {
+		fmt.Fprintln(stdout, response.Text)
+	}
+	return nil
+}
+
+func normalizeModel(model string) string {
+	return strings.TrimPrefix(model, "gemini/")
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `Usage:
+  glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--env <path>]
+
+Commands:
+  run    Run the local Gemini-backed agent.
+
+Flags:
+  --id       Session id. Defaults to "default".
+  --prompt   Prompt text. Required.
+  --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
+  --store    File session store directory. Defaults to .glue/sessions.
+  --env      Load env vars from a .env file. Repeatable; shell env wins.
+`)
+}
+
+func loadEnvFiles(files []string) error {
+	shellEnv := map[string]struct{}{}
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			shellEnv[key] = struct{}{}
+		}
+	}
+
+	for _, path := range files {
+		if err := loadEnvFile(path, shellEnv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadEnvFile(path string, shellEnv map[string]struct{}) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return fmt.Errorf("%s:%d: expected KEY=VALUE", path, lineNumber)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("%s:%d: empty key", path, lineNumber)
+		}
+		if _, exists := shellEnv[key]; exists {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"glue"
+)
+
+type scriptedProvider struct {
+	turns    [][]glue.ProviderEvent
+	requests []glue.ProviderRequest
+	err      error
+}
+
+func (p *scriptedProvider) Stream(_ context.Context, req glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	if len(p.requests) >= len(p.turns) {
+		return nil, errors.New("scriptedProvider: unexpected call")
+	}
+	p.requests = append(p.requests, req)
+	events := p.turns[len(p.requests)-1]
+	ch := make(chan glue.ProviderEvent, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+func fakeFactory(provider glue.Provider) providerFactory {
+	return func() (glue.Provider, error) { return provider, nil }
+}
+
+func textTurn(text string) []glue.ProviderEvent {
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: text},
+		{Type: glue.ProviderEventDone},
+	}
+}
+
+func TestRunCLIHelp(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	code := runCLI(context.Background(), []string{"--help"}, &stdout, io.Discard, fakeFactory(nil))
+	if code != 0 {
+		t.Fatalf("code = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "glue run") {
+		t.Fatalf("help missing 'glue run': %q", stdout.String())
+	}
+}
+
+func TestRunCLINoArgsPrintsHelp(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	code := runCLI(context.Background(), nil, &stdout, io.Discard, fakeFactory(nil))
+	if code != 0 || !strings.Contains(stdout.String(), "glue run") {
+		t.Fatalf("code=%d stdout=%q", code, stdout.String())
+	}
+}
+
+func TestRunCLIUnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{"nope"}, &stdout, &stderr, fakeFactory(nil))
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero")
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("stderr = %q, want 'unknown command'", stderr.String())
+	}
+}
+
+func TestRunCLIStreamsOutputAndLoadsEnv(t *testing.T) {
+	// Not parallel: mutates process env.
+	t.Setenv("GLUE_TEST_ENV", "")
+	os.Unsetenv("GLUE_TEST_ENV")
+
+	envPath := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envPath, []byte("GLUE_TEST_ENV=from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: "hello"},
+		{Type: glue.ProviderEventTextDelta, Delta: " cli"},
+		{Type: glue.ProviderEventDone},
+	}}}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run",
+		"--prompt", "say hi",
+		"--store", t.TempDir(),
+		"--env", envPath,
+	}, &stdout, &stderr, fakeFactory(provider))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != "hello cli\n" {
+		t.Fatalf("stdout = %q, want streamed text", stdout.String())
+	}
+	if got := os.Getenv("GLUE_TEST_ENV"); got != "from-file" {
+		t.Fatalf("env GLUE_TEST_ENV = %q, want from-file", got)
+	}
+	t.Cleanup(func() { os.Unsetenv("GLUE_TEST_ENV") })
+}
+
+func TestRunCLIMultipleEnvFilesShellEnvWins(t *testing.T) {
+	t.Setenv("GLUE_TEST_FROM_SHELL", "shell-value")
+	os.Unsetenv("GLUE_TEST_FROM_FILE_A")
+	os.Unsetenv("GLUE_TEST_FROM_FILE_B")
+	t.Cleanup(func() {
+		os.Unsetenv("GLUE_TEST_FROM_FILE_A")
+		os.Unsetenv("GLUE_TEST_FROM_FILE_B")
+	})
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.env")
+	b := filepath.Join(dir, "b.env")
+	if err := os.WriteFile(a, []byte("GLUE_TEST_FROM_FILE_A=A\nGLUE_TEST_FROM_SHELL=ignored\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("GLUE_TEST_FROM_FILE_B=B\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{textTurn("ok")}}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run",
+		"--prompt", "go",
+		"--store", t.TempDir(),
+		"--env", a, "--env", b,
+	}, &stdout, &stderr, fakeFactory(provider))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if got := os.Getenv("GLUE_TEST_FROM_FILE_A"); got != "A" {
+		t.Fatalf("FILE_A = %q, want A", got)
+	}
+	if got := os.Getenv("GLUE_TEST_FROM_FILE_B"); got != "B" {
+		t.Fatalf("FILE_B = %q, want B", got)
+	}
+	if got := os.Getenv("GLUE_TEST_FROM_SHELL"); got != "shell-value" {
+		t.Fatalf("FROM_SHELL = %q, want shell-value (env file should not override)", got)
+	}
+}
+
+func TestRunCLIResumesSession(t *testing.T) {
+	t.Parallel()
+
+	storeDir := t.TempDir()
+
+	first := &scriptedProvider{turns: [][]glue.ProviderEvent{textTurn("first")}}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run", "--id", "same", "--prompt", "first", "--store", storeDir,
+	}, &stdout, &stderr, fakeFactory(first))
+	if code != 0 {
+		t.Fatalf("first code = %d stderr=%q", code, stderr.String())
+	}
+
+	second := &scriptedProvider{turns: [][]glue.ProviderEvent{textTurn("second")}}
+	stdout.Reset()
+	stderr.Reset()
+	code = runCLI(context.Background(), []string{
+		"run", "--id", "same", "--prompt", "second", "--store", storeDir,
+	}, &stdout, &stderr, fakeFactory(second))
+	if code != 0 {
+		t.Fatalf("second code = %d stderr=%q", code, stderr.String())
+	}
+	if len(second.requests) != 1 {
+		t.Fatalf("second provider calls = %d, want 1", len(second.requests))
+	}
+	if got := len(second.requests[0].Messages); got != 3 {
+		t.Fatalf("second request msg count = %d, want 3 (resumed user/assistant + new user)", got)
+	}
+}
+
+func TestRunCLIProviderErrorExit(t *testing.T) {
+	t.Parallel()
+
+	provider := &scriptedProvider{err: errors.New("provider failed")}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run", "--prompt", "fail", "--store", t.TempDir(),
+	}, &stdout, &stderr, fakeFactory(provider))
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero")
+	}
+	if !strings.Contains(stderr.String(), "provider failed") {
+		t.Fatalf("stderr = %q, want provider failed", stderr.String())
+	}
+}
+
+func TestRunCLIMissingPrompt(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{"run"}, &stdout, &stderr, fakeFactory(&scriptedProvider{}))
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero")
+	}
+	if !strings.Contains(stderr.String(), "missing required --prompt") {
+		t.Fatalf("stderr = %q, want missing prompt", stderr.String())
+	}
+}
+
+func TestRunCLIUnknownAgent(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{"run", "weird", "--prompt", "x"}, &stdout, &stderr, fakeFactory(&scriptedProvider{}))
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero")
+	}
+	if !strings.Contains(stderr.String(), "unknown agent") {
+		t.Fatalf("stderr = %q, want 'unknown agent'", stderr.String())
+	}
+}
+
+func TestRunCLIMissingGeminiAPIKey(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run", "--prompt", "go", "--store", t.TempDir(),
+	}, &stdout, &stderr, defaultGeminiFactory)
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero for missing GEMINI_API_KEY")
+	}
+	if !strings.Contains(stderr.String(), "GEMINI_API_KEY") {
+		t.Fatalf("stderr = %q, want GEMINI_API_KEY hint", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds `cmd/glue` with a single `run` subcommand built over the public `glue` library.

**Flags**

- `--id` — session id (default `"default"`)
- `--prompt` — prompt text (required)
- `--model` — model id or `gemini/<model>` (default `gemini-2.5-flash`)
- `--store` — file session store directory (default `.glue/sessions`)
- `--env` — env file to load; repeatable; shell env wins on conflict

The CLI is thin: it streams text deltas via `glue.WithEvents`, persists sessions through `stores/file`, and uses `WorkDir="."` so AGENTS.md, `.agents/skills`, and `roles/` discovery work from the invocation directory.

**`providerFactory func() (glue.Provider, error)`** — the default factory checks `GEMINI_API_KEY` *before* constructing the gemini provider so a missing key produces a clear startup error rather than a later API failure. Tests inject a fake factory wrapping a scripted provider.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	(cached)
ok  	glue/cmd/glue	0.012s
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	(cached)
$ go run ./cmd/glue --help
Usage:
  glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--env <path>]
...
```

10 tests in `cmd/glue/main_test.go`:

- `--help` and no-args print usage
- unknown command exits non-zero
- streaming output to stdout via `WithEvents`
- env file loading (single)
- env file loading (multiple, shell env wins on conflict)
- session resume across two CLI invocations sharing `--store`
- provider stream error exits non-zero with stderr containing the cause
- missing required `--prompt` exits non-zero
- unknown agent name exits non-zero
- missing `GEMINI_API_KEY` exits non-zero with clear stderr message

README adds a "CLI" section; roadmap paragraph updated to reflect P1 progress.

Closes #15.