### PR TITLE
Add context compaction design and first implementation (closes #18)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -35,6 +35,14 @@ type AgentOptions struct {
 	Skills       map[string]Skill
 	Roles        []Role
 	Role         string
+
+	// Compactor, if non-nil and CompactionThreshold > 0, is invoked
+	// before every prompt whenever the in-memory transcript has more
+	// than CompactionThreshold messages. The compactor's output replaces
+	// the in-memory transcript before [loop.Run] is called and is
+	// persisted by the next save.
+	Compactor           Compactor
+	CompactionThreshold int
 }
 
 // Agent owns shared configuration and an in-memory session map.
@@ -48,6 +56,9 @@ type Agent struct {
 	store        Store
 	workDir      string
 	role         string
+
+	compactor           Compactor
+	compactionThreshold int
 
 	agentsMD      string
 	skills        map[string]Skill
@@ -69,12 +80,14 @@ func NewAgent(options AgentOptions) *Agent {
 		tools:        cloneTools(options.Tools),
 		options:      cloneMap(options.Options),
 		maxTurns:     options.MaxTurns,
-		store:        options.Store,
-		workDir:      options.WorkDir,
-		skills:       cloneSkills(options.Skills),
-		roles:        rolesFromSlice(options.Roles),
-		role:         options.Role,
-		sessions:     make(map[string]*Session),
+		store:               options.Store,
+		workDir:             options.WorkDir,
+		skills:              cloneSkills(options.Skills),
+		roles:               rolesFromSlice(options.Roles),
+		role:                options.Role,
+		compactor:           options.Compactor,
+		compactionThreshold: options.CompactionThreshold,
+		sessions:            make(map[string]*Session),
 	}
 }
 

--- a/compactor.go
+++ b/compactor.go
@@ -1,0 +1,75 @@
+package glue
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Compactor rewrites a session transcript before it is sent to the
+// provider. Implementations should preserve the user's most recent intent
+// and the assistant context that depends on it; older turns can be
+// dropped, summarized, or replaced. Compactors must not mutate the input
+// slice; they return a new slice.
+type Compactor interface {
+	Compact(ctx context.Context, messages []Message) ([]Message, error)
+}
+
+// CompactorFunc adapts a function to the [Compactor] interface.
+type CompactorFunc func(ctx context.Context, messages []Message) ([]Message, error)
+
+// Compact implements [Compactor].
+func (f CompactorFunc) Compact(ctx context.Context, messages []Message) ([]Message, error) {
+	return f(ctx, messages)
+}
+
+// KeepRecentMessages returns a [Compactor] that keeps the last n messages
+// of a transcript and replaces everything older with a single
+// system-style summary message that records how many turns were dropped.
+//
+// This is the simplest useful compaction policy: it has no token model
+// and never calls a provider. It is appropriate when a session is allowed
+// to accumulate but the caller can tolerate losing older context past a
+// fixed window.
+//
+// n must be positive. If the input transcript has n or fewer messages,
+// the compactor returns it unchanged.
+func KeepRecentMessages(n int) Compactor {
+	return CompactorFunc(func(_ context.Context, messages []Message) ([]Message, error) {
+		if n <= 0 {
+			return nil, fmt.Errorf("glue: KeepRecentMessages: n must be positive, got %d", n)
+		}
+		if len(messages) <= n {
+			return messages, nil
+		}
+		dropped := len(messages) - n
+		summary := buildCompactionSummary(messages[:dropped])
+		summary.Metadata = map[string]any{"compaction": "keep_recent", "dropped": dropped}
+
+		out := make([]Message, 0, n+1)
+		out = append(out, summary)
+		out = append(out, messages[dropped:]...)
+		return out, nil
+	})
+}
+
+// buildCompactionSummary produces a short, role-assistant note describing
+// what was dropped. The intent is to give the model a stable signal that
+// older context existed without claiming to reproduce it.
+func buildCompactionSummary(dropped []Message) Message {
+	var b strings.Builder
+	b.WriteString("Earlier conversation context omitted by compaction (")
+	fmt.Fprintf(&b, "%d message", len(dropped))
+	if len(dropped) != 1 {
+		b.WriteString("s")
+	}
+	b.WriteString(" dropped). Continue from the messages that follow.")
+
+	return Message{
+		Role: MessageRoleAssistant,
+		Content: []ContentPart{{
+			Type: ContentTypeText,
+			Text: b.String(),
+		}},
+	}
+}

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -1,0 +1,221 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func textMessage(role MessageRole, body string) Message {
+	return Message{Role: role, Content: []ContentPart{{Type: ContentTypeText, Text: body}}}
+}
+
+func TestKeepRecentMessagesUnchangedBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	c := KeepRecentMessages(4)
+	in := []Message{
+		textMessage(MessageRoleUser, "u1"),
+		textMessage(MessageRoleAssistant, "a1"),
+	}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2 (no compaction expected)", len(out))
+	}
+}
+
+func TestKeepRecentMessagesDropsOlderAndInsertsSummary(t *testing.T) {
+	t.Parallel()
+
+	c := KeepRecentMessages(2)
+	in := []Message{
+		textMessage(MessageRoleUser, "u1"),
+		textMessage(MessageRoleAssistant, "a1"),
+		textMessage(MessageRoleUser, "u2"),
+		textMessage(MessageRoleAssistant, "a2"),
+		textMessage(MessageRoleUser, "u3"),
+	}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3 (summary + last 2)", len(out))
+	}
+	summary := out[0]
+	if summary.Role != MessageRoleAssistant {
+		t.Fatalf("summary role = %q, want assistant", summary.Role)
+	}
+	if !strings.Contains(summary.Content[0].Text, "3 messages") {
+		t.Fatalf("summary text = %q, want '3 messages dropped'", summary.Content[0].Text)
+	}
+	if summary.Metadata["compaction"] != "keep_recent" {
+		t.Fatalf("summary metadata = %v, want compaction=keep_recent", summary.Metadata)
+	}
+	if got := summary.Metadata["dropped"]; got != 3 {
+		t.Fatalf("summary dropped = %v (%T), want 3", got, got)
+	}
+	if out[1].Content[0].Text != "a2" || out[2].Content[0].Text != "u3" {
+		t.Fatalf("kept tail = %q/%q, want a2/u3", out[1].Content[0].Text, out[2].Content[0].Text)
+	}
+}
+
+func TestKeepRecentMessagesPositiveN(t *testing.T) {
+	t.Parallel()
+
+	if _, err := KeepRecentMessages(0).Compact(context.Background(), []Message{textMessage(MessageRoleUser, "x")}); err == nil {
+		t.Fatal("err = nil, want positive n required")
+	}
+}
+
+func TestSessionCompactsBeforePromptWhenThresholdExceeded(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok"), textTurn("ok2")}}
+	agent := NewAgent(AgentOptions{
+		Provider:            provider,
+		Compactor:           KeepRecentMessages(2),
+		CompactionThreshold: 4,
+	})
+	session, _ := agent.Session(context.Background(), "x")
+
+	// First prompt: builds a baseline transcript (1 user + 1 assistant).
+	if _, err := session.Prompt(context.Background(), "first"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject older messages directly to push the in-memory transcript
+	// past the threshold. (Simulating a long-running session.)
+	session.mu.Lock()
+	for i := 0; i < 4; i++ {
+		session.messages = append(session.messages, textMessage(MessageRoleUser, "older"))
+	}
+	preCount := len(session.messages)
+	session.mu.Unlock()
+
+	if preCount <= 4 {
+		t.Fatalf("setup invariant: in-memory transcript = %d, want > threshold 4", preCount)
+	}
+
+	// Second prompt should trigger compaction.
+	if _, err := session.Prompt(context.Background(), "second"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Provider's 2nd request should see compacted history (summary +
+	// last 2) plus the new user message — exactly 4 messages.
+	gotMessages := provider.requests[1].Messages
+	if len(gotMessages) != 4 {
+		t.Fatalf("2nd request len = %d, want 4 (summary + last 2 + new user)", len(gotMessages))
+	}
+	if gotMessages[0].Role != MessageRoleAssistant ||
+		!strings.Contains(gotMessages[0].Content[0].Text, "compaction") {
+		t.Fatalf("2nd request[0] = %#v, want compaction summary", gotMessages[0])
+	}
+	if gotMessages[len(gotMessages)-1].Role != MessageRoleUser ||
+		gotMessages[len(gotMessages)-1].Content[0].Text != "second" {
+		t.Fatalf("2nd request tail = %#v, want new user message", gotMessages[len(gotMessages)-1])
+	}
+
+	// Session.Messages should reflect compacted form too (summary + last 2 + new user + new assistant).
+	final := session.Messages()
+	if len(final) != 5 {
+		t.Fatalf("session.Messages() len = %d, want 5", len(final))
+	}
+}
+
+func TestSessionDoesNotCompactWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok"), textTurn("ok2")}}
+	agent := NewAgent(AgentOptions{Provider: provider}) // no compactor
+	session, _ := agent.Session(context.Background(), "x")
+
+	if _, err := session.Prompt(context.Background(), "first"); err != nil {
+		t.Fatal(err)
+	}
+	session.mu.Lock()
+	for i := 0; i < 5; i++ {
+		session.messages = append(session.messages, textMessage(MessageRoleUser, "older"))
+	}
+	session.mu.Unlock()
+
+	if _, err := session.Prompt(context.Background(), "second"); err != nil {
+		t.Fatal(err)
+	}
+	got := provider.requests[1].Messages
+	// 1 (first user) + 1 (first assistant) + 5 injected + 1 (second user) = 8 messages
+	if len(got) != 8 {
+		t.Fatalf("2nd request len = %d, want 8 (no compaction)", len(got))
+	}
+}
+
+type errorCompactor struct{ err error }
+
+func (e errorCompactor) Compact(_ context.Context, _ []Message) ([]Message, error) {
+	return nil, e.err
+}
+
+func TestSessionPromptSurfacesCompactorError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("compactor down")
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}
+	agent := NewAgent(AgentOptions{
+		Provider:            provider,
+		Compactor:           errorCompactor{err: wantErr},
+		CompactionThreshold: 1,
+	})
+	session, _ := agent.Session(context.Background(), "x")
+
+	// Inject enough messages to exceed threshold.
+	session.mu.Lock()
+	session.messages = []Message{textMessage(MessageRoleUser, "a"), textMessage(MessageRoleAssistant, "b")}
+	session.mu.Unlock()
+
+	_, err := session.Prompt(context.Background(), "next")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want compactor down", err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("provider was called despite compactor error: calls=%d", provider.calls)
+	}
+}
+
+func TestSessionCompactionPersistsViaStore(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+	provider := &recordingProvider{turns: [][]ProviderEvent{textTurn("first"), textTurn("second")}}
+	agent := NewAgent(AgentOptions{
+		Provider:            provider,
+		Store:               store,
+		Compactor:           KeepRecentMessages(2),
+		CompactionThreshold: 4,
+	})
+	session, _ := agent.Session(context.Background(), "x")
+
+	if _, err := session.Prompt(context.Background(), "first"); err != nil {
+		t.Fatal(err)
+	}
+	session.mu.Lock()
+	for i := 0; i < 5; i++ {
+		session.messages = append(session.messages, textMessage(MessageRoleUser, "older"))
+	}
+	session.mu.Unlock()
+
+	if _, err := session.Prompt(context.Background(), "second"); err != nil {
+		t.Fatal(err)
+	}
+	state := store.states["x"]
+	if len(state.Messages) != 5 {
+		t.Fatalf("persisted Messages = %d, want 5 (compacted)", len(state.Messages))
+	}
+	if state.Messages[0].Metadata["compaction"] != "keep_recent" {
+		t.Fatalf("persisted summary metadata = %v, want compaction=keep_recent", state.Messages[0].Metadata)
+	}
+}

--- a/docs/adr/0002-context-compaction.md
+++ b/docs/adr/0002-context-compaction.md
@@ -1,0 +1,66 @@
+# ADR 0002: Explicit, Caller-Owned Context Compaction
+
+## Status
+
+Accepted.
+
+## Context
+
+Long-running Glue sessions accumulate transcript messages indefinitely.
+Eventually the transcript grows past what a provider's context window can
+accept, or simply becomes wasteful to send on every turn. We need a way to
+trim or summarize older context.
+
+Two design axes:
+
+1. **Trigger.** Token-based ("compact when prompt would exceed N tokens")
+   vs. message-count-based ("compact when transcript has more than N
+   messages"). Token-based is more accurate but requires per-provider
+   token counting that we explicitly listed as out of scope for the first
+   compaction implementation.
+2. **Replacement strategy.** Drop older messages, summarize them via the
+   model, or replace them with a small structured note. Calling the model
+   to summarize gives the highest fidelity but is heavy and asynchronous;
+   simple drop-with-note is fast and predictable.
+
+## Decision
+
+Compaction is an explicit, caller-owned policy. Glue defines:
+
+- `Compactor` interface: `Compact(ctx, []Message) ([]Message, error)`. It
+  receives a clone of the current transcript and returns the new
+  transcript. Implementations must not mutate the input.
+- `AgentOptions.Compactor` and `AgentOptions.CompactionThreshold`. The
+  agent runs the compactor before every prompt whenever the in-memory
+  transcript has more than `CompactionThreshold` messages.
+- A built-in `KeepRecentMessages(n)` policy that keeps the last `n`
+  messages and replaces everything older with a single assistant-role
+  marker message recording how many turns were dropped.
+
+When a compactor returns a new (shorter) transcript, the session's
+in-memory state is replaced before `loop.Run` is called, and the next
+save persists the compacted state.
+
+## Why message-count for the first cut
+
+- Provider-neutral: no token model required.
+- Predictable for tests and operators.
+- Easy to reason about in combination with the file store: the on-disk
+  state is exactly what gets sent to the provider.
+- Token-aware compaction can be added later as a separate `Compactor`
+  implementation without changing the agent or session API.
+
+## Consequences
+
+- Callers opt in. The default behavior is unchanged: transcripts grow
+  forever in memory until the caller decides what to do.
+- Compaction summaries are visible in the transcript. The marker message
+  carries `Metadata["compaction"]` so observers can filter or render it
+  specially.
+- The first marker is intentionally lossy: a fancier summarizer can be
+  written as a different `Compactor` and slotted in by changing
+  `AgentOptions.Compactor`.
+- Persistent stores see compacted state on the next `Session.Prompt`
+  save. Resuming a session in a new process sees the compacted form.
+- Compaction happens inside the same `runMu`-locked region as the prompt,
+  so concurrent `Session.Prompt` calls cannot interleave with compaction.

--- a/docs/design.md
+++ b/docs/design.md
@@ -241,6 +241,22 @@ Persisted data includes:
 - tool calls and tool results inside messages
 - usage inside messages when available
 
+## Context Compaction
+
+Long-running sessions can exceed provider context windows. Glue exposes an
+explicit, opt-in [`Compactor`](compactor.go) interface that callers wire
+through `AgentOptions.Compactor` and `AgentOptions.CompactionThreshold`.
+The agent runs the compactor before every prompt whenever the in-memory
+transcript has more than the threshold number of messages; the compactor's
+output replaces the in-memory transcript before the loop runs and is
+persisted by the next save.
+
+The first built-in policy is `KeepRecentMessages(n)`, which keeps the last
+`n` messages and replaces everything older with a single assistant-role
+marker carrying `Metadata["compaction"] = "keep_recent"`. Token-aware
+compaction can be added later as a separate `Compactor` implementation;
+see [`adr/0002-context-compaction.md`](adr/0002-context-compaction.md).
+
 ## Verification Policy
 
 Every issue must specify verification before work starts. At minimum:

--- a/session.go
+++ b/session.go
@@ -180,6 +180,16 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 	s.mu.Lock()
 	base := cloneMessages(s.messages)
 	s.mu.Unlock()
+
+	if compacted, did, err := s.maybeCompact(ctx, base); err != nil {
+		return PromptResult{}, err
+	} else if did {
+		s.mu.Lock()
+		s.messages = cloneMessages(compacted)
+		s.updatedAt = time.Now().UTC()
+		s.mu.Unlock()
+		base = compacted
+	}
 	runMessages := append(base, userMessage)
 
 	result, runErr := loop.Run(ctx, loop.RunRequest{
@@ -239,6 +249,29 @@ func (s *Session) stateLocked() SessionState {
 		CreatedAt: s.createdAt,
 		UpdatedAt: s.updatedAt,
 	}
+}
+
+// maybeCompact runs the agent's configured Compactor against the current
+// transcript when the message count exceeds the configured threshold. It
+// returns the (possibly new) transcript, a flag indicating whether a
+// compaction actually replaced messages, and any error.
+func (s *Session) maybeCompact(ctx context.Context, messages []Message) ([]Message, bool, error) {
+	if s.agent.compactor == nil || s.agent.compactionThreshold <= 0 {
+		return messages, false, nil
+	}
+	if len(messages) <= s.agent.compactionThreshold {
+		return messages, false, nil
+	}
+	out, err := s.agent.compactor.Compact(ctx, cloneMessages(messages))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(out) == len(messages) {
+		// No-op compactor; do not invalidate persistence with a no-op
+		// rewrite.
+		return messages, false, nil
+	}
+	return out, true, nil
 }
 
 func (s *Session) save(ctx context.Context, state SessionState) error {


### PR DESCRIPTION
## Summary

Opt-in, message-count-triggered context compaction with a built-in `KeepRecentMessages` policy and an ADR explaining the design.

**`glue/compactor.go` (new)**

- `Compactor` interface — `Compact(ctx, []Message) ([]Message, error)`.
- `CompactorFunc` adapter.
- `KeepRecentMessages(n)` — drops everything older than the last `n` messages and replaces it with an assistant-role marker carrying `Metadata["compaction"]="keep_recent"` and `Metadata["dropped"]=N`. No token counting; no provider call. Errors on `n <= 0`.

**`glue/agent.go`** — `AgentOptions.Compactor` and `AgentOptions.CompactionThreshold` wired onto the `Agent`.

**`glue/session.go`** — `Session.Prompt` calls `maybeCompact` under `runMu`, before `loop.Run`. When threshold is exceeded *and* the compactor returns a different-length result, the new transcript replaces the in-memory one and the next save persists it. Compactor errors propagate before any provider call.

**`docs/adr/0002-context-compaction.md`** explains the trigger axis (token vs message-count) and replacement axis (drop / summarize / mark) trade-offs and locks message-count-with-marker as the first implementation. Token-aware compaction can land later as another `Compactor` without changing the public type.

`docs/design.md` adds a "Context Compaction" section.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	0.007s
ok  	glue/cmd/glue	(cached)
ok  	glue/examples/local-agent	(cached)
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	(cached)
```

7 new tests in `compactor_test.go`:

- `KeepRecentMessages` returns input unchanged below threshold
- drops older + inserts summary with metadata + dropped count when above threshold
- errors when `n <= 0`
- session compacts pre-prompt; provider sees `[summary, last n, new user]`
- session does not compact when no compactor is configured
- compactor errors surface before provider is called
- compaction persists via `Store` on next save

Closes #18.