### PR TITLE
Add provider plugin guide (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ The CLI streams text deltas to stdout, persists sessions through
 `roles/` discovery work from the invocation directory. Errors return a
 non-zero exit code; missing `GEMINI_API_KEY` produces a clear message.
 
+## Adding a provider
+
+Glue's `Provider` interface is small. See
+[`docs/provider-guide.md`](docs/provider-guide.md) for the contract and
+common pitfalls, and [`examples/echo-provider`](examples/echo-provider)
+for the shortest possible runnable implementation.
+
 ## Roadmap
 
 P2 covers parallel tool execution, context compaction, an opt-in shell/

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -1,0 +1,180 @@
+# Provider Plugin Guide
+
+Glue's provider abstraction is small on purpose: any backend that can
+stream a sequence of "text part / tool call / done" events into a
+language can satisfy it. This guide walks through what the [`Provider`]
+interface promises, what events to emit and in what order, and how to
+verify a new provider in tests.
+
+A complete, runnable reference implementation lives at
+[`../examples/echo-provider`](../examples/echo-provider). It compiles,
+passes tests, and is the shortest path from "I have a backend" to "Glue
+can drive it." Copy that package and replace the body of `stream()`
+with your network code.
+
+[`Provider`]: ../types.go
+
+## The interface
+
+```go
+type Provider interface {
+    Stream(ctx context.Context, req ProviderRequest) (<-chan ProviderEvent, error)
+}
+```
+
+`Stream` returns immediately with a channel; the goroutine that fills the
+channel does the work. The loop reads until the channel is closed.
+
+`ProviderRequest` carries everything the loop knows about the next
+assistant turn:
+
+| Field          | Type                | Notes                                                         |
+|----------------|---------------------|---------------------------------------------------------------|
+| `Model`        | `string`            | Either the agent default or a per-call `WithModel` override.   |
+| `SystemPrompt` | `string`            | Already includes any AGENTS.md, skill catalog, and role block. |
+| `Messages`     | `[]Message`         | Full transcript + the new user message; do not mutate.         |
+| `Tools`        | `[]ToolSpec`        | Specs only — no executor — for forwarding to the model.        |
+| `Options`      | `map[string]any`    | Provider-specific settings (e.g. `temperature`).               |
+
+## Event contract
+
+A correct provider emits exactly the following sequence:
+
+1. **Exactly one** `ProviderEventStart`. Optionally include a partially
+   populated `Message` so the loop has model/role context. The loop
+   handles both forms.
+2. **Zero or more** of:
+   - `ProviderEventTextDelta` with `Delta` set
+   - `ProviderEventThinkingDelta` with `Delta` set
+   - `ProviderEventToolCall` with `ToolCall` set
+3. **Exactly one** terminal event:
+   - `ProviderEventDone` with the final `Message` (the loop overwrites
+     its accumulated message with this one — make sure your message is
+     complete, including all content parts), **or**
+   - `ProviderEventError` with `Error` populated.
+4. Then **close the channel.**
+
+`ProviderEventStart` and `ProviderEventDone` are required because the
+loop's `runAssistantTurn` uses them to bracket text accumulation and to
+decide whether to keep streaming. Closing the channel without a Done
+event is treated as an error.
+
+## Required and optional behaviors
+
+**Required**
+
+- `req.Messages` is owned by the caller; do not mutate it. Clone before
+  rewriting.
+- Honor `ctx` cancellation when sending into the events channel —
+  otherwise a slow consumer plus a canceled context can deadlock. The
+  echo example uses a `select { case <-ctx.Done(): case events <- e: }`
+  helper.
+- Provide a stable role on the final `Message` (typically
+  `MessageRoleAssistant`) and a `CreatedAt` timestamp.
+- Map your backend's stop reason to `loop.StopReason` (use
+  `StopReasonStop`, `StopReasonLength`, `StopReasonToolUse`,
+  `StopReasonError`, or `StopReasonCanceled`).
+
+**Optional but recommended**
+
+- Populate `Message.Usage` with token counts when the backend reports
+  them.
+- Stash backend-specific identifiers under `Message.Metadata` (e.g.
+  `response_id`).
+- Convert `req.Tools` into your backend's native tool/function-call
+  format and emit `ProviderEventToolCall` for inbound calls.
+
+**Out of scope for the provider**
+
+- Tool execution. The loop runs tools; the provider only relays calls
+  and ferries back the resulting tool messages on the next turn.
+- Transcript accumulation across turns. The loop handles that.
+
+## Tool-call shape
+
+When the backend returns a tool/function call, emit:
+
+```go
+ProviderEvent{
+    Type:     ProviderEventToolCall,
+    ToolCall: &ToolCall{
+        ID:        "<provider-supplied or synthesized>",
+        Name:      "<matches a registered Tool's Name>",
+        Arguments: json.RawMessage(`{...}`),
+    },
+}
+```
+
+`Arguments` must be a JSON object (or `{}` for empty). The loop
+normalizes it before invoking the executor; non-object args become an
+error tool result.
+
+When you receive tool-result messages on the next turn, look for
+messages with `Role == MessageRoleTool` and convert them into the
+backend's tool-response shape. Glue groups consecutive tool-role
+messages logically per turn, so a single backend tool-response payload
+should be able to carry multiple `FunctionResponse`-shaped entries
+where applicable.
+
+## Testing a new provider
+
+A provider can be unit-tested without any network access. The pattern is:
+
+1. **Construct** the provider directly with whatever options it takes.
+2. **Drive** it through the public `glue` API by passing it as
+   `AgentOptions.Provider`. The loop's existing tests cover everything
+   that doesn't depend on your backend semantics; your tests only need
+   to cover the convert-in / convert-out logic.
+3. **Assert** at the assistant message: text, tool calls, stop reason.
+
+The echo example's tests demonstrate this:
+
+```go
+func TestEchoProviderRoundTripThroughAgent(t *testing.T) {
+    agent := glue.NewAgent(glue.AgentOptions{Provider: New()})
+    session, _ := agent.Session(context.Background(), "x")
+    res, _ := session.Prompt(context.Background(), "hello world")
+    if res.Text != "hello world" { ... }
+}
+```
+
+For backends with real network calls, gate live tests on an environment
+variable — see `providers/gemini/gemini_test.go`'s `TestLiveSmoke` for
+the convention. CI never sets the variable, so live tests must skip
+quietly there.
+
+## Where to put the package
+
+- **In a third-party module**: just import `glue` and put the package
+  wherever makes sense. Glue's public API is stable for re-export of
+  the message and event types.
+- **In this repo**: under `providers/<name>/`, following the layout of
+  `providers/gemini`. Update `docs/design.md`'s "Package Boundaries"
+  section to list the new package and confirm the dependency direction
+  (`providers/<name>` may import `glue/loop`, but the loop must not
+  import the provider).
+
+## Common mistakes
+
+- **Aliasing the same `Message` across `Start` and `Done`.** The loop
+  dereferences `event.Message` when it *reads* the event, not when you
+  send it. If you send `&output` in the `Start` event and continue to
+  mutate `output` (e.g., appending content as deltas arrive), the
+  loop's Start handler may see a partially-populated message and then
+  the subsequent `TextDelta` events will append to that content,
+  effectively double-writing the text. The echo example sidesteps this
+  by sending `Start` with no `Message` and constructing a fresh
+  `Message` on `Done`. If you do want a Start `Message` for metadata,
+  send a clone or a value-typed pointer to a separate struct, not an
+  alias to the buffer you'll keep mutating.
+- **Forgetting to close the channel.** The loop will hang if the
+  channel never closes. Use `defer close(events)` in the goroutine.
+- **Skipping the `Done` event.** Closing the channel without a Done is
+  an error path, not a quiet stop.
+- **Mutating `req.Messages`.** The loop and the session both keep
+  references to the same slice elements. Clone if you need to rewrite.
+- **Sending into the channel without watching ctx.** A canceled context
+  with a still-pending send leaks the goroutine.
+- **Returning errors from `Stream` for transient issues.** Prefer
+  `ProviderEventError` once the goroutine has started so the loop can
+  surface the error consistently with provider-internal failures.

--- a/examples/echo-provider/README.md
+++ b/examples/echo-provider/README.md
@@ -1,0 +1,40 @@
+# Echo Provider Example
+
+The smallest possible Glue provider. It echoes the user's most recent
+text back as the assistant's response.
+
+This package is the runnable reference implementation for the
+[Provider Plugin Guide](../../docs/provider-guide.md). Copy this layout
+when building a new provider; replace the body of `stream()` with your
+backend code.
+
+## Test it
+
+```sh
+go test ./examples/echo-provider
+```
+
+Four tests cover:
+
+- happy-path round trip through `glue.NewAgent` + `session.Prompt`
+- compile-time assertion that `*Provider` satisfies `glue.Provider`
+- empty transcript still emits a `Done` event (no panic, no hang)
+- `Prefix` field is applied to the echoed text
+
+No network access; nothing is gated.
+
+## Use it as a starting point
+
+```go
+import (
+    "context"
+
+    "glue"
+    echo "glue/examples/echo-provider"
+)
+
+agent := glue.NewAgent(glue.AgentOptions{Provider: echo.New()})
+session, _ := agent.Session(context.Background(), "demo")
+result, _ := session.Prompt(context.Background(), "ping")
+fmt.Println(result.Text) // -> "ping"
+```

--- a/examples/echo-provider/echo.go
+++ b/examples/echo-provider/echo.go
@@ -1,0 +1,111 @@
+// Package echo is a minimal example of a custom Glue provider.
+//
+// It implements the [glue.Provider] interface by echoing the most recent
+// user message back as the assistant's text. There is no model, no
+// network call, and no tool support — just the smallest amount of code
+// that satisfies the interface so a downstream package can be wired into
+// glue.NewAgent without importing providers/gemini.
+//
+// Use this as a template when adding a new production provider:
+//
+//   - copy the [Provider] type and [Provider.Stream] method shape
+//   - replace the body of stream() with your network code
+//   - emit ProviderEventStart, then any number of ProviderEventTextDelta
+//     / ProviderEventThinkingDelta / ProviderEventToolCall events,
+//     then exactly one ProviderEventDone or ProviderEventError
+//   - remember that the channel must be closed (the loop relies on a
+//     closed channel after Done to release the receive goroutine)
+package echo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"glue"
+)
+
+// Provider is a Glue provider that echoes the user's last text back.
+type Provider struct {
+	// Prefix is prepended to the echoed text. Optional.
+	Prefix string
+}
+
+// New constructs an echo provider.
+func New() *Provider { return &Provider{} }
+
+// Stream implements [glue.Provider].
+func (p *Provider) Stream(ctx context.Context, req glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	events := make(chan glue.ProviderEvent, 4)
+
+	go func() {
+		defer close(events)
+
+		// Note: do NOT include Message in the Start event when the
+		// goroutine will continue to mutate the same struct before
+		// emitting Done. The loop dereferences event.Message at read
+		// time, so an aliased pointer races against later mutations
+		// and causes content to be duplicated. Send a Start event
+		// without Message and let the loop synthesize a default
+		// assistant message; emit a fully-populated Message only on
+		// Done.
+		if !send(ctx, events, glue.ProviderEvent{Type: glue.ProviderEventStart}) {
+			return
+		}
+
+		text := lastUserText(req.Messages)
+		if p.Prefix != "" {
+			text = p.Prefix + text
+		}
+		if text != "" {
+			if !send(ctx, events, glue.ProviderEvent{Type: glue.ProviderEventTextDelta, Delta: text}) {
+				return
+			}
+		}
+
+		final := glue.Message{
+			Role:       glue.MessageRoleAssistant,
+			Provider:   "echo",
+			Model:      req.Model,
+			CreatedAt:  time.Now().UTC(),
+			StopReason: glue.StopReasonStop,
+		}
+		if text != "" {
+			final.Content = []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}}
+		}
+		send(ctx, events, glue.ProviderEvent{Type: glue.ProviderEventDone, Message: &final})
+	}()
+
+	return events, nil
+}
+
+// lastUserText returns the text of the most recent user message in the
+// transcript, or "" if there isn't one. A real provider would convert
+// the entire transcript into the backend's native shape.
+func lastUserText(messages []glue.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.Role != glue.MessageRoleUser {
+			continue
+		}
+		var b strings.Builder
+		for _, part := range m.Content {
+			if part.Type == glue.ContentTypeText {
+				b.WriteString(part.Text)
+			}
+		}
+		return b.String()
+	}
+	return ""
+}
+
+// send respects ctx cancellation so a provider stuck on a slow consumer
+// can still terminate when the loop's context is canceled.
+func send(ctx context.Context, events chan<- glue.ProviderEvent, event glue.ProviderEvent) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case events <- event:
+		return true
+	}
+}

--- a/examples/echo-provider/echo_test.go
+++ b/examples/echo-provider/echo_test.go
@@ -1,0 +1,67 @@
+package echo
+
+import (
+	"context"
+	"testing"
+
+	"glue"
+)
+
+func TestEchoProviderRoundTripThroughAgent(t *testing.T) {
+	t.Parallel()
+
+	agent := glue.NewAgent(glue.AgentOptions{Provider: New(), Model: "echo-v1"})
+	session, err := agent.Session(context.Background(), "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := session.Prompt(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if res.Text != "hello world" {
+		t.Fatalf("Text = %q, want hello world", res.Text)
+	}
+	if res.Message == nil || res.Message.StopReason != glue.StopReasonStop {
+		t.Fatalf("StopReason = %v, want stop", res.Message)
+	}
+}
+
+func TestEchoProviderImplementsProviderInterface(t *testing.T) {
+	t.Parallel()
+
+	var _ glue.Provider = New()
+}
+
+func TestEchoProviderEmptyTranscriptDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	p := New()
+	events, err := p.Stream(context.Background(), glue.ProviderRequest{Model: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawDone bool
+	for ev := range events {
+		if ev.Type == glue.ProviderEventDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatal("never saw ProviderEventDone")
+	}
+}
+
+func TestEchoProviderPrefixIsApplied(t *testing.T) {
+	t.Parallel()
+
+	agent := glue.NewAgent(glue.AgentOptions{Provider: &Provider{Prefix: "echo: "}, Model: "echo-v1"})
+	session, _ := agent.Session(context.Background(), "x")
+	res, err := session.Prompt(context.Background(), "hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "echo: hi" {
+		t.Fatalf("Text = %q, want echo: hi", res.Text)
+	}
+}


### PR DESCRIPTION
## Summary

Documents what a Glue provider must implement and ships a runnable reference example.

**`docs/provider-guide.md` (new)**

- `ProviderRequest` field reference and `Stream(ctx, req)` shape.
- Event contract: **exactly one** `Start`, zero-or-more delta/tool-call events, **exactly one** `Done` or `Error`, then close.
- Required vs optional behaviors, plus the "out of scope for the provider" boundary (no tool execution, no transcript accumulation).
- Tool-call event shape and how tool-result messages flow back on the next turn.
- Testing pattern: drive the provider through `glue.NewAgent` + `Session.Prompt` with a fake-data round trip; live tests gated by env var.
- "Common mistakes" list — including a new entry for the aliasing pitfall I hit while building the echo example: the loop dereferences `event.Message` at read time, so passing the same `&output` in `Start` and `Done` while mutating `output` in between races and double-writes content.

**`examples/echo-provider/` (new)**

- `echo.go` (~70 LOC) — `Provider` that echoes the user's last text back. Includes a `Prefix` option so the example shows non-trivial behavior.
- `echo_test.go` — 4 tests:
  - round trip through `glue.NewAgent` + `Session.Prompt`
  - compile-time `glue.Provider` interface assertion
  - empty transcript still emits `Done`
  - `Prefix` is applied
- `README.md` — how to run and how to use as a starting point.

**`README.md`** — new "Adding a provider" section.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	(cached)
ok  	glue/cmd/glue	(cached)
ok  	glue/examples/echo-provider	0.003s
ok  	glue/examples/local-agent	(cached)
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	(cached)
```

Closes #20.