### PR TITLE
Add GitHub issue automation workflow (closes #21)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,3 +101,7 @@ copy-pasted. Each issue still requires its own real review and verification.
   tracker.
 - The CI workflow (issue #22) is the canonical verification surface; mirror
   its commands locally before opening a PR.
+- `scripts/check-tracker.sh` audits the "no close without merged PR" rule.
+  Run it locally after bulk operations or before merging a PR that closes
+  an issue. See [`docs/issue-automation.md`](docs/issue-automation.md) for
+  the full automation surface.

--- a/docs/issue-automation.md
+++ b/docs/issue-automation.md
@@ -1,0 +1,115 @@
+# Issue Automation
+
+The Glue project uses GitHub issues as its source of truth (see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) and the pinned tracker
+[`#1`](https://github.com/erain/glue/issues/1)). This document covers
+the small amount of automation we ship to keep that source of truth
+honest, plus the `gh` cheatsheet for the common operations.
+
+## `scripts/check-tracker.sh` — drift detector
+
+The contributor protocol's load-bearing invariant is:
+
+> **No issue is closed without a merged PR that references it.**
+
+`scripts/check-tracker.sh` audits that invariant by fetching every
+closed issue and checking that GitHub reports at least one merged PR in
+each issue's `closedByPullRequestsReferences`. Issues closed without a
+merged PR — whether by mistake, by human override, or by a prior agent
+that forgot to land code — are listed.
+
+```sh
+# Dry-run report (default):
+scripts/check-tracker.sh
+
+# Fail on any violation. Use this in CI once we want strict gating.
+scripts/check-tracker.sh --strict
+
+# Cap how many closed issues are scanned:
+scripts/check-tracker.sh --limit 100
+```
+
+Output shape:
+
+```
+Closed issues scanned: 20
+Violations (closed but no merged PR linked): 0
+```
+
+If there are violations, each is printed on its own line as
+`#<number> <title>`.
+
+The script is intentionally read-only. It does not reopen issues, post
+comments, or modify labels — those steps are deliberate and should be
+done with the operator's own judgement.
+
+Requirements: `gh` (authenticated) and `jq`.
+
+## When to run the script
+
+- **Locally, before merging a PR** that closes an issue: catches typos
+  in `Closes #N` references.
+- **After bulk operations** like the bootstrap reset that opened this
+  project — the original mess (issues closed without PRs) was exactly
+  what this checker would have flagged.
+- **As a CI cron** once we want strict enforcement. A weekly
+  `scripts/check-tracker.sh --strict` job is the obvious shape; not
+  wired up by default since it requires repo settings.
+
+## `gh` cheatsheet
+
+The recurring per-issue operations from `CONTRIBUTING.md`:
+
+```sh
+# Post the closing comment on an issue.
+gh issue comment 17 --body "$(cat closing-comment.md)"
+
+# Reopen an issue (e.g., the bootstrap reset).
+gh issue reopen 17
+
+# Edit the body of the pinned tracker after a PR merges. Reads from a
+# file so the heredoc-formatted body survives shell quoting.
+gh issue edit 1 --body "$(cat tracker.md)"
+
+# Confirm linkage on an issue you just closed via Closes #N.
+gh issue view 17 --json closedByPullRequestsReferences
+```
+
+For PRs:
+
+```sh
+# Open a PR with HEREDOC body.
+gh pr create --title "Add foo (closes #N)" --body "$(cat <<'EOF'
+## Summary
+...
+Closes #N.
+EOF
+)"
+
+# Watch CI on a PR and exit when it finishes.
+gh pr checks <num>
+
+# Squash-merge and delete the branch.
+gh pr merge <num> --squash --delete-branch
+```
+
+## Roadmap-from-docs sync (deferred)
+
+The original issue body for #21 also mentioned "create/update roadmap
+issues from docs". We considered shipping a YAML-driven script that
+reads a roadmap file and creates missing issues, but the project's
+actual workflow has been the opposite: humans write the issue, the
+tracker links to it. Inverting that to be docs-first would add a step
+without removing one. If a future milestone has many similar issues
+(e.g., the FileRead/FileWrite/Exec implementation issues that ADR 0003
+calls out), a thin wrapper around `gh issue create` is a one-evening
+job; document it here when it exists.
+
+## Why so little automation
+
+Glue's discipline is "one issue per PR" with a human-readable closing
+comment. The closing comment is the load-bearing artifact — it carries
+verification output and notes for the next session. Automating
+comment generation would erode the value of the comment by making it
+boilerplate. The drift detector is the right amount of automation: it
+catches operator mistakes without taking over the operator's job.

--- a/scripts/check-tracker.sh
+++ b/scripts/check-tracker.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# scripts/check-tracker.sh — verify every closed issue has a merged PR.
+#
+# The Glue contributor protocol (CONTRIBUTING.md) requires "no issue is
+# closed without a merged PR that references it." This script audits
+# that invariant: for each closed issue in the repo, it queries GitHub
+# for the closing-PR linkage and reports any closed issue whose
+# closedByPullRequestsReferences does not include a merged PR.
+#
+# By default the script is dry-run only — it prints a report and exits 0
+# even when violations are found. Pass --strict to make violations exit
+# non-zero so the script can be wired into CI.
+#
+# Usage:
+#   scripts/check-tracker.sh                  # report-only, exit 0
+#   scripts/check-tracker.sh --strict         # fail on any violation
+#   scripts/check-tracker.sh --limit 100      # cap closed issues fetched
+#
+# Requires: gh, jq.
+set -euo pipefail
+
+strict=false
+limit=200
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict) strict=true ;;
+    --limit) shift; limit="$1" ;;
+    -h|--help)
+      sed -n '2,/^set/p' "$0" | sed 's/^# \{0,1\}//;/^set/d'
+      exit 0
+      ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if ! command -v gh >/dev/null; then
+  echo "error: gh is required" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null; then
+  echo "error: jq is required" >&2
+  exit 2
+fi
+
+# 1. List closed issue numbers (not PRs).
+numbers="$(gh issue list --state closed --limit "$limit" --json number --jq '.[].number')"
+
+# 2. For each one, fetch the closing-PR linkage. The
+#    closedByPullRequestsReferences field is on `gh issue view`, not
+#    `gh issue list`.
+violations=()
+total=0
+for n in $numbers; do
+  total=$((total + 1))
+  view="$(gh issue view "$n" --json number,title,closedByPullRequestsReferences 2>/dev/null || true)"
+  [[ -z "$view" ]] && continue
+
+  merged_count="$(jq '
+    (.closedByPullRequestsReferences // []) | map(select(.state == "MERGED")) | length
+  ' <<<"$view")"
+  if [[ "$merged_count" -eq 0 ]]; then
+    title="$(jq -r '.title' <<<"$view")"
+    violations+=("#$n $title")
+  fi
+done
+
+echo "Closed issues scanned: $total"
+echo "Violations (closed but no merged PR linked): ${#violations[@]}"
+if [[ "${#violations[@]}" -gt 0 ]]; then
+  printf '\n%s\n' "${violations[@]}"
+fi
+
+if [[ "$strict" == "true" ]] && [[ "${#violations[@]}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Small, deliberately-scoped automation surface — exactly the kind that would have caught the bootstrap reset.

**`scripts/check-tracker.sh`** — audits the contributor protocol's load-bearing invariant: *every closed issue must have a merged PR linked.* Scans `closedByPullRequestsReferences` per closed issue.

- Default: dry-run report; exits 0 even on violations.
- `--strict`: exit non-zero when violations exist (CI gate shape).
- `--limit N`: cap how many closed issues are scanned.
- Read-only by design. Never reopens issues, posts comments, or modifies labels.
- Requires `gh` + `jq`.

Live-tested against this repo:

```
$ scripts/check-tracker.sh --limit 30
Closed issues scanned: 20
Violations (closed but no merged PR linked): 0
```

**`docs/issue-automation.md`** — documents the script and adds a `gh` cheatsheet for the recurring per-issue operations from `CONTRIBUTING.md` (close-with-comment, reopen, edit body, view linkage, PR create, checks, squash-merge). Explicitly *defers* the original "create/update roadmap issues from docs" piece — the project's workflow is human-authored issues + tracker linkage; inverting it would add a step without removing one. A thin `gh` wrapper can be added later if a future milestone needs many similar issues created at once. Explains why the automation surface is small: closing comments are the load-bearing artifact and should not become boilerplate.

**`CONTRIBUTING.md`** — short pointer to the script and the doc under "Tooling Requirements".

This is the **last P2 issue**.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	glue	(cached)
ok  	glue/cmd/glue	(cached)
ok  	glue/examples/echo-provider	(cached)
ok  	glue/examples/local-agent	(cached)
ok  	glue/loop	(cached)
ok  	glue/providers/gemini	(cached)
ok  	glue/stores/file	(cached)
$ bash -n scripts/check-tracker.sh && echo "syntax OK"
syntax OK
$ scripts/check-tracker.sh --limit 30
Closed issues scanned: 20
Violations (closed but no merged PR linked): 0
```

Closes #21.