### PR TITLE
Rename module to github.com/erain/glue (closes #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ skills, roles, and a CLI runner are tracked under P1 in the project plan.
 ## Install
 
 ```sh
-go get glue
+go get github.com/erain/glue
 ```
 
-The module path is `glue`; subpackages are `glue/loop`, `glue/providers/gemini`,
-and `glue/stores/file`.
+The module path is `github.com/erain/glue`; subpackages are
+`github.com/erain/glue/loop`, `github.com/erain/glue/providers/gemini`, and
+`github.com/erain/glue/stores/file`.
 
 ## Quickstart: Gemini
 
@@ -50,8 +51,8 @@ import (
 	"fmt"
 	"log"
 
-	"glue"
-	"glue/providers/gemini"
+	"github.com/erain/glue"
+	"github.com/erain/glue/providers/gemini"
 )
 
 func main() {

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -18,9 +18,9 @@ import (
 	"os"
 	"strings"
 
-	"glue"
-	"glue/providers/gemini"
-	filestore "glue/stores/file"
+	"github.com/erain/glue"
+	"github.com/erain/glue/providers/gemini"
+	filestore "github.com/erain/glue/stores/file"
 )
 
 const defaultModel = "gemini-2.5-flash"

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"glue"
+	"github.com/erain/glue"
 )
 
 type scriptedProvider struct {

--- a/doc.go
+++ b/doc.go
@@ -8,5 +8,5 @@
 // stores/file).
 //
 // Normalized message and event types are re-exported here so that callers
-// only need to import "glue".
+// only need to import "github.com/erain/glue".
 package glue

--- a/docs/design.md
+++ b/docs/design.md
@@ -37,7 +37,7 @@ of truth for implementation order and status after the initial bootstrap.
 
 ## Package Boundaries
 
-The initial module path is `glue`.
+The module path is `github.com/erain/glue`.
 
 - `glue`: public library surface. Owns `Agent`, `Session`, options, tools,
   skills, roles, and store interfaces.

--- a/examples/echo-provider/README.md
+++ b/examples/echo-provider/README.md
@@ -29,8 +29,8 @@ No network access; nothing is gated.
 import (
     "context"
 
-    "glue"
-    echo "glue/examples/echo-provider"
+    "github.com/erain/glue"
+    echo "github.com/erain/glue/examples/echo-provider"
 )
 
 agent := glue.NewAgent(glue.AgentOptions{Provider: echo.New()})

--- a/examples/echo-provider/echo.go
+++ b/examples/echo-provider/echo.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"glue"
+	"github.com/erain/glue"
 )
 
 // Provider is a Glue provider that echoes the user's last text back.

--- a/examples/echo-provider/echo_test.go
+++ b/examples/echo-provider/echo_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"glue"
+	"github.com/erain/glue"
 )
 
 func TestEchoProviderRoundTripThroughAgent(t *testing.T) {

--- a/examples/local-agent/main.go
+++ b/examples/local-agent/main.go
@@ -16,9 +16,9 @@ import (
 	"os"
 	"time"
 
-	"glue"
-	"glue/providers/gemini"
-	filestore "glue/stores/file"
+	"github.com/erain/glue"
+	"github.com/erain/glue/providers/gemini"
+	filestore "github.com/erain/glue/stores/file"
 )
 
 func main() {

--- a/examples/local-agent/main_test.go
+++ b/examples/local-agent/main_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"glue"
-	"glue/providers/gemini"
+	"github.com/erain/glue"
+	"github.com/erain/glue/providers/gemini"
 )
 
 func TestLocalTimeToolHappyPath(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module glue
+module github.com/erain/glue
 
-go 1.24.5
+go 1.24
 
 require google.golang.org/genai v1.55.0
 

--- a/providers/gemini/convert.go
+++ b/providers/gemini/convert.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"glue/loop"
+	"github.com/erain/glue/loop"
 
 	"google.golang.org/genai"
 )

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"glue/loop"
+	"github.com/erain/glue/loop"
 
 	"google.golang.org/genai"
 )

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"glue/loop"
+	"github.com/erain/glue/loop"
 
 	"google.golang.org/genai"
 )

--- a/session.go
+++ b/session.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"glue/loop"
+	"github.com/erain/glue/loop"
 )
 
 // Session is an in-memory conversation with an [Agent]. Sessions are

--- a/stores/file/store.go
+++ b/stores/file/store.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"glue"
+	"github.com/erain/glue"
 )
 
 // Store persists Glue sessions as local JSON files.

--- a/stores/file/store_test.go
+++ b/stores/file/store_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"glue"
+	"github.com/erain/glue"
 )
 
 func newTempStore(t *testing.T) *Store {

--- a/types.go
+++ b/types.go
@@ -1,6 +1,6 @@
 package glue
 
-import "glue/loop"
+import "github.com/erain/glue/loop"
 
 // Re-export the loop package's normalized types as part of the public API so
 // callers only need to import `glue`.


### PR DESCRIPTION
## Summary

External Go programs cannot \`go get\` this library today because the module path is the bare name \`glue\`. That works for internal imports but not for any caller outside the repo. This PR fixes the single biggest reusability blocker.

**Changes**

- \`go.mod\`: module path \`glue\` → \`github.com/erain/glue\`.
- \`go.mod\`: \`go 1.24.5\` → \`go 1.24\` so consumers on any 1.24.x patch can use the module.
- All 15 internal Go files updated to import via the new path.
- README install snippet says \`go get github.com/erain/glue\`; the quickstart code block uses the real path.
- \`docs/design.md\` "Package Boundaries" updated.
- \`examples/echo-provider/README.md\` usage snippet updated.

**Out of scope (deliberately)**

- **No tag.** Pure rename does not require a release; tagging is a separate decision.
- **No API surface change.** Every public symbol keeps its name.
- **No identifier rename** — the package name is still \`glue\`, so \`glue.NewAgent\`, \`glue.SessionState\`, \`glue.Provider\`, etc. stay exactly the same.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	github.com/erain/glue	0.004s
ok  	github.com/erain/glue/cmd/glue	0.010s
ok  	github.com/erain/glue/examples/echo-provider	0.003s
ok  	github.com/erain/glue/examples/local-agent	0.009s
ok  	github.com/erain/glue/loop	0.085s
ok  	github.com/erain/glue/providers/gemini	0.007s
ok  	github.com/erain/glue/stores/file	0.006s

$ GEMINI_API_KEY=... go test ./providers/gemini -run Live -count=1
ok  	github.com/erain/glue/providers/gemini	0.620s

$ GEMINI_API_KEY=... go test ./examples/local-agent -run Live -count=1
ok  	github.com/erain/glue/examples/local-agent	1.370s

$ go run ./cmd/glue run --prompt "Reply with the single word: glue" --id rename --store /tmp/glue-e2e-rename
glue
```

All ~110 offline tests pass. Both gated live tests pass against real Gemini. The CLI streams output and persists sessions correctly under the new path.

Closes #44.