### PR TITLE
Run live Gemini e2e tests in CI (closes #46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,32 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+  live:
+    name: live (gemini)
+    needs: test
+    # Run on pushes to main and on PRs that originate from this repo.
+    # PRs from forks cannot access secrets, so skip them entirely
+    # rather than have the job fail.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Live Gemini smoke
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [ -z "$GEMINI_API_KEY" ]; then
+            echo "GEMINI_API_KEY not configured; skipping live tests."
+            exit 0
+          fi
+          go test ./providers/gemini -run Live -count=1
+          go test ./examples/local-agent -run Live -count=1

--- a/docs/issue-automation.md
+++ b/docs/issue-automation.md
@@ -105,6 +105,38 @@ without removing one. If a future milestone has many similar issues
 calls out), a thin wrapper around `gh issue create` is a one-evening
 job; document it here when it exists.
 
+## CI: live Gemini job
+
+The CI workflow has two jobs:
+
+- **`test`** (always runs): `go build` + `go vet` + `go test ./...` on every
+  PR and push to `main`. This is the merge gate.
+- **`live (gemini)`** (runs after `test` succeeds, only on this repo's own
+  PRs and on `main` pushes): runs the gated live tests
+  `go test ./providers/gemini -run Live -count=1` and
+  `go test ./examples/local-agent -run Live -count=1` against the real
+  Gemini API. Reads the API key from the `GEMINI_API_KEY` repo secret.
+
+Forked PRs cannot read secrets, so the live job is guarded by
+
+```yaml
+if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+```
+
+and is simply not scheduled for fork PRs (rather than running and failing).
+For internal PRs where the secret is unset for any reason, the job's first
+step prints a notice and exits 0 — the existing tests already use
+`t.Skip` for the same path, so the result is a green no-op.
+
+Rotating the key:
+
+```sh
+gh secret set GEMINI_API_KEY --repo erain/glue
+```
+
+The live job costs a few tokens per run (≈2 seconds wall time). It is
+informational, not a merge gate — `test` is the only required check.
+
 ## Why so little automation
 
 Glue's discipline is "one issue per PR" with a human-readable closing


### PR DESCRIPTION
## Summary

Adds a second CI job that runs the gated live Gemini tests against the real API using the existing \`GEMINI_API_KEY\` repo secret.

**Changes**

- \`.github/workflows/ci.yml\` adds a \`live (gemini)\` job:
  - \`needs: test\` — only runs after the offline suite is green.
  - \`if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository\` — skips PRs from forks, where secrets are unavailable.
  - Reads \`GEMINI_API_KEY\` from \`secrets.GEMINI_API_KEY\` (already configured on the repo).
  - First step exits 0 if the secret is missing (matches the in-test \`t.Skip\` behavior).
  - When set, runs \`go test ./providers/gemini -run Live -count=1\` and \`go test ./examples/local-agent -run Live -count=1\`.
- \`docs/issue-automation.md\` adds a "CI: live Gemini job" section explaining the two jobs, the fork-PR skip, the no-secret skip, and the \`gh secret set\` command for rotation.

The live tests themselves already exist (\`TestLiveSmoke\`, \`TestLiveLocalAgent\`). This PR only changes *when* they run.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	github.com/erain/glue	(cached)
ok  	github.com/erain/glue/cmd/glue	(cached)
ok  	github.com/erain/glue/examples/echo-provider	(cached)
ok  	github.com/erain/glue/examples/local-agent	(cached)
ok  	github.com/erain/glue/loop	(cached)
ok  	github.com/erain/glue/providers/gemini	(cached)
ok  	github.com/erain/glue/stores/file	(cached)
```

After this PR opens, both \`test\` and \`live (gemini)\` should appear in the checks list. \`test\` is the merge gate; \`live\` is informational.

Closes #46.