### PR TITLE
Make live Gemini CI job manual-only (closes #49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_live:
+        description: "Run live provider tests (consumes API tokens)"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -35,10 +41,10 @@ jobs:
   live:
     name: live (gemini)
     needs: test
-    # Run on pushes to main and on PRs that originate from this repo.
-    # PRs from forks cannot access secrets, so skip them entirely
-    # rather than have the job fail.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Manual-only: triggered via the "Run workflow" button (workflow_dispatch)
+    # to avoid spending API tokens on every push/PR. Run locally for routine
+    # verification; dispatch in GitHub when you want CI-side confirmation.
+    if: github.event_name == 'workflow_dispatch' && inputs.run_live
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/issue-automation.md
+++ b/docs/issue-automation.md
@@ -111,31 +111,28 @@ The CI workflow has two jobs:
 
 - **`test`** (always runs): `go build` + `go vet` + `go test ./...` on every
   PR and push to `main`. This is the merge gate.
-- **`live (gemini)`** (runs after `test` succeeds, only on this repo's own
-  PRs and on `main` pushes): runs the gated live tests
-  `go test ./providers/gemini -run Live -count=1` and
+- **`live (gemini)`** (manual only, via `workflow_dispatch`): runs the gated
+  live tests `go test ./providers/gemini -run Live -count=1` and
   `go test ./examples/local-agent -run Live -count=1` against the real
   Gemini API. Reads the API key from the `GEMINI_API_KEY` repo secret.
 
-Forked PRs cannot read secrets, so the live job is guarded by
+The live job does not run on push or PR — it would burn API tokens on
+every commit for a check that is not a merge gate. Trigger it manually
+when you want CI-side confirmation:
 
-```yaml
-if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+```sh
+gh workflow run ci.yml --ref <branch>
 ```
 
-and is simply not scheduled for fork PRs (rather than running and failing).
-For internal PRs where the secret is unset for any reason, the job's first
-step prints a notice and exits 0 — the existing tests already use
-`t.Skip` for the same path, so the result is a green no-op.
+or use the "Run workflow" button on the Actions tab. For routine
+verification, run the same `go test -run Live` commands locally with
+`GEMINI_API_KEY` exported.
 
 Rotating the key:
 
 ```sh
 gh secret set GEMINI_API_KEY --repo erain/glue
 ```
-
-The live job costs a few tokens per run (≈2 seconds wall time). It is
-informational, not a merge gate — `test` is the only required check.
 
 ## Why so little automation
 


### PR DESCRIPTION
## Summary

The `live (gemini)` job currently runs on every push to `main` and every same-repo PR, consuming Gemini API tokens for an informational check. `test` is the merge gate; the live job is not. Switch it to `workflow_dispatch` so it only runs when explicitly triggered, saving tokens on routine commits.

**Changes**

- \`.github/workflows/ci.yml\`:
  - Add \`workflow_dispatch\` trigger with a \`run_live\` boolean input (default true), so the job can be skipped on dispatch if desired.
  - Replace the job's \`if:\` (push or same-repo PR) with \`github.event_name == 'workflow_dispatch' && inputs.run_live\`.
  - \`test\` is unchanged and still runs on every push/PR.
- \`docs/issue-automation.md\`: rewrite the \"CI: live Gemini job\" section to describe manual invocation (\`gh workflow run ci.yml --ref <branch>\` or the \"Run workflow\" button), and remove the fork-PR / no-secret guards that no longer apply.

## How to run live tests now

Locally (preferred for routine verification):

\`\`\`sh
GEMINI_API_KEY=... go test ./providers/gemini -run Live -count=1
GEMINI_API_KEY=... go test ./examples/local-agent -run Live -count=1
\`\`\`

In CI, when needed:

\`\`\`sh
gh workflow run ci.yml --ref <branch>
\`\`\`

## Verification

\`\`\`
\$ go build ./...
\$ go vet ./...
\$ go test ./...
\`\`\`

Workflow YAML parses (no \`actionlint\` configured in repo; the dispatch input + \`inputs.run_live\` reference is the standard pattern).

Closes #49.