### PR TITLE
Add NVIDIA build OpenAI-compatible provider (closes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ func main() {
 The session keeps an in-memory transcript, so a second `session.Prompt(...)`
 continues the conversation. File-backed sessions land in P1.
 
+## Quickstart: NVIDIA build (Kimi K2 and friends)
+
+The `providers/nvidia` package speaks the OpenAI-compatible API exposed at
+[`build.nvidia.com`](https://build.nvidia.com), so any model listed there
+(Kimi K2 family, Llama, Qwen, etc.) can be driven through Glue without a
+separate SDK.
+
+```sh
+export NVIDIA_API_KEY=nvapi-...
+```
+
+```go
+import (
+	"github.com/erain/glue"
+	"github.com/erain/glue/providers/nvidia"
+)
+
+agent := glue.NewAgent(glue.AgentOptions{
+	Provider: nvidia.New(nvidia.Options{}),
+	Model:    "moonshotai/kimi-k2.6",
+})
+```
+
+The model id matches the `org/name` path on build.nvidia.com (e.g.
+`moonshotai/kimi-k2.6`, `meta/llama-3.3-70b-instruct`). Cold-start latency
+on Kimi K2 can reach tens of seconds for the first chunk; configure your
+HTTP client and context timeouts accordingly.
+
 ### Streaming events
 
 `Session.Subscribe` registers a session-scoped handler that fires on every

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,6 +45,9 @@ The module path is `github.com/erain/glue`.
   consumption, tool execution, transcript append behavior, and loop events.
 - `providers/gemini`: Gemini provider implementation using
   `google.golang.org/genai`.
+- `providers/nvidia`: OpenAI-compatible provider for the NVIDIA build
+  inference API (`integrate.api.nvidia.com`), implemented over `net/http`
+  with no third-party SDK dependency.
 - `stores/file`: file-backed JSON session store with atomic writes.
 - `cmd/glue`: local CLI runner built on top of the public library.
 
@@ -53,6 +56,7 @@ The dependency direction is intentionally narrow:
 ```text
 cmd/glue -> glue -> loop
 glue    -> providers/gemini only through explicit user construction
+glue    -> providers/nvidia only through explicit user construction
 glue    -> stores/file only through explicit user construction
 loop    -> no dependency on glue, providers, stores, CLI, or docs
 ```

--- a/providers/nvidia/convert.go
+++ b/providers/nvidia/convert.go
@@ -1,0 +1,297 @@
+package nvidia
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/erain/glue/loop"
+)
+
+// chatMessage is the OpenAI-compatible request message shape.
+type chatMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
+}
+
+type chatToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function chatToolFunction `json:"function"`
+}
+
+type chatToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type chatTool struct {
+	Type     string       `json:"type"`
+	Function chatFuncSpec `json:"function"`
+}
+
+type chatFuncSpec struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// chatRequest is the JSON body sent to /v1/chat/completions.
+type chatRequest struct {
+	Model          string            `json:"model"`
+	Messages       []chatMessage     `json:"messages"`
+	Tools          []chatTool        `json:"tools,omitempty"`
+	Stream         bool              `json:"stream"`
+	StreamOptions  *streamOptions    `json:"stream_options,omitempty"`
+	Temperature    *float64          `json:"temperature,omitempty"`
+	MaxTokens      *int              `json:"max_tokens,omitempty"`
+	TopP           *float64          `json:"top_p,omitempty"`
+	ResponseFormat json.RawMessage   `json:"response_format,omitempty"`
+	Extra          map[string]any    `json:"-"`
+}
+
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+// MarshalJSON encodes the request including any keys carried in Extra.
+// Extra wins on collision, allowing callers to pass through provider-specific
+// options not represented as struct fields.
+func (r chatRequest) MarshalJSON() ([]byte, error) {
+	type alias chatRequest
+	base, err := json.Marshal(alias(r))
+	if err != nil {
+		return nil, err
+	}
+	if len(r.Extra) == 0 {
+		return base, nil
+	}
+	merged := map[string]any{}
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return nil, err
+	}
+	for k, v := range r.Extra {
+		merged[k] = v
+	}
+	return json.Marshal(merged)
+}
+
+// buildChatRequest converts a Glue ProviderRequest into the OpenAI-compatible
+// request body. The caller fills in Model and Stream separately.
+func buildChatRequest(req loop.ProviderRequest) (chatRequest, error) {
+	messages, err := convertMessages(req.SystemPrompt, req.Messages)
+	if err != nil {
+		return chatRequest{}, err
+	}
+	tools, err := convertTools(req.Tools)
+	if err != nil {
+		return chatRequest{}, err
+	}
+	body := chatRequest{
+		Messages: messages,
+		Tools:    tools,
+	}
+	if err := applyOptions(&body, req.Options); err != nil {
+		return chatRequest{}, err
+	}
+	return body, nil
+}
+
+func convertMessages(systemPrompt string, messages []loop.Message) ([]chatMessage, error) {
+	out := make([]chatMessage, 0, len(messages)+1)
+	if systemPrompt != "" {
+		out = append(out, chatMessage{Role: "system", Content: systemPrompt})
+	}
+	for _, message := range messages {
+		converted, err := convertMessage(message)
+		if err != nil {
+			return nil, err
+		}
+		if converted != nil {
+			out = append(out, *converted)
+		}
+	}
+	return out, nil
+}
+
+func convertMessage(message loop.Message) (*chatMessage, error) {
+	switch message.Role {
+	case loop.MessageRoleUser:
+		text := joinText(message.Content)
+		return &chatMessage{Role: "user", Content: text}, nil
+	case loop.MessageRoleAssistant:
+		out := chatMessage{Role: "assistant"}
+		text := ""
+		for _, part := range message.Content {
+			switch part.Type {
+			case loop.ContentTypeText:
+				text += part.Text
+			case loop.ContentTypeThinking:
+				// reasoning_content does not round-trip in OpenAI request
+				// schema; drop on replay rather than fail.
+			case loop.ContentTypeToolCall:
+				if part.ToolCall == nil {
+					return nil, fmt.Errorf("nvidia: tool call content missing payload")
+				}
+				args := string(part.ToolCall.Arguments)
+				if args == "" {
+					args = "{}"
+				}
+				out.ToolCalls = append(out.ToolCalls, chatToolCall{
+					ID:   part.ToolCall.ID,
+					Type: "function",
+					Function: chatToolFunction{
+						Name:      part.ToolCall.Name,
+						Arguments: args,
+					},
+				})
+			case loop.ContentTypeImage:
+				return nil, fmt.Errorf("nvidia: image content not yet supported")
+			default:
+				return nil, fmt.Errorf("nvidia: unsupported content type %q", part.Type)
+			}
+		}
+		out.Content = text
+		if out.Content == "" && len(out.ToolCalls) == 0 {
+			return nil, nil
+		}
+		return &out, nil
+	case loop.MessageRoleTool:
+		if message.ToolCallID == "" {
+			return nil, fmt.Errorf("nvidia: tool message missing tool_call_id")
+		}
+		return &chatMessage{
+			Role:       "tool",
+			ToolCallID: message.ToolCallID,
+			Content:    joinText(message.Content),
+		}, nil
+	default:
+		return nil, fmt.Errorf("nvidia: unsupported message role %q", message.Role)
+	}
+}
+
+func joinText(parts []loop.ContentPart) string {
+	var text string
+	for _, part := range parts {
+		if part.Type == loop.ContentTypeText {
+			text += part.Text
+		}
+	}
+	return text
+}
+
+func convertTools(tools []loop.ToolSpec) ([]chatTool, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	out := make([]chatTool, 0, len(tools))
+	for _, tool := range tools {
+		spec := chatFuncSpec{
+			Name:        tool.Name,
+			Description: tool.Description,
+		}
+		if len(tool.Parameters) > 0 {
+			// Validate that parameters is a JSON object (or null) so the
+			// upstream API does not reject the entire request.
+			var probe any
+			if err := json.Unmarshal(tool.Parameters, &probe); err != nil {
+				return nil, fmt.Errorf("nvidia: tool %q parameters: %w", tool.Name, err)
+			}
+			spec.Parameters = append(json.RawMessage(nil), tool.Parameters...)
+		}
+		out = append(out, chatTool{Type: "function", Function: spec})
+	}
+	return out, nil
+}
+
+func applyOptions(body *chatRequest, options map[string]any) error {
+	if len(options) == 0 {
+		return nil
+	}
+	for key, value := range options {
+		switch key {
+		case "temperature":
+			f, ok := numberAsFloat64(value)
+			if !ok {
+				return fmt.Errorf("nvidia: temperature must be numeric")
+			}
+			body.Temperature = &f
+		case "top_p":
+			f, ok := numberAsFloat64(value)
+			if !ok {
+				return fmt.Errorf("nvidia: top_p must be numeric")
+			}
+			body.TopP = &f
+		case "max_tokens", "max_output_tokens":
+			n, ok := numberAsInt(value)
+			if !ok {
+				return fmt.Errorf("nvidia: %s must be numeric", key)
+			}
+			body.MaxTokens = &n
+		case "response_format":
+			raw, err := json.Marshal(value)
+			if err != nil {
+				return fmt.Errorf("nvidia: response_format: %w", err)
+			}
+			body.ResponseFormat = raw
+		default:
+			if body.Extra == nil {
+				body.Extra = map[string]any{}
+			}
+			body.Extra[key] = value
+		}
+	}
+	return nil
+}
+
+func numberAsFloat64(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func numberAsInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+// mapFinishReason maps an OpenAI-shape finish_reason onto a Glue StopReason.
+func mapFinishReason(reason string) loop.StopReason {
+	switch reason {
+	case "", "stop":
+		return loop.StopReasonStop
+	case "length":
+		return loop.StopReasonLength
+	case "tool_calls", "function_call":
+		return loop.StopReasonToolUse
+	case "content_filter":
+		return loop.StopReasonError
+	default:
+		return loop.StopReasonStop
+	}
+}

--- a/providers/nvidia/doc.go
+++ b/providers/nvidia/doc.go
@@ -1,0 +1,8 @@
+// Package nvidia implements a Glue provider for the NVIDIA build inference
+// API (https://build.nvidia.com), which exposes an OpenAI-compatible
+// chat-completions endpoint at https://integrate.api.nvidia.com/v1.
+//
+// It supports text streaming, OpenAI-shape tool calling, and reasoning
+// content deltas. Models are addressed by their build.nvidia.com path,
+// for example "moonshotai/kimi-k2.6" or "meta/llama-3.3-70b-instruct".
+package nvidia

--- a/providers/nvidia/nvidia.go
+++ b/providers/nvidia/nvidia.go
@@ -1,0 +1,376 @@
+package nvidia
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/erain/glue/loop"
+)
+
+const (
+	providerName   = "nvidia"
+	defaultBaseURL = "https://integrate.api.nvidia.com/v1"
+)
+
+// Options configures the NVIDIA provider.
+//
+// APIKey is consulted first; when empty the NVIDIA_API_KEY environment
+// variable is used. DefaultModel applies when [loop.ProviderRequest.Model]
+// is empty. BaseURL defaults to https://integrate.api.nvidia.com/v1 and may
+// be overridden to point at any OpenAI-compatible endpoint. HTTPClient and
+// Headers are optional; Headers are merged into every outgoing request.
+type Options struct {
+	APIKey       string
+	DefaultModel string
+	BaseURL      string
+	HTTPClient   *http.Client
+	Headers      map[string]string
+}
+
+// Provider streams responses from an OpenAI-compatible NVIDIA build endpoint
+// into Glue's normalized provider events.
+type Provider struct {
+	apiKey       string
+	defaultModel string
+	baseURL      string
+	httpClient   *http.Client
+	headers      map[string]string
+}
+
+// New creates an NVIDIA provider. The HTTP client is created lazily on the
+// first [Provider.Stream] call so that constructing a provider does not
+// require credentials.
+func New(options Options) *Provider {
+	baseURL := strings.TrimRight(options.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	headers := map[string]string{}
+	for k, v := range options.Headers {
+		headers[k] = v
+	}
+	return &Provider{
+		apiKey:       options.APIKey,
+		defaultModel: options.DefaultModel,
+		baseURL:      baseURL,
+		httpClient:   options.HTTPClient,
+		headers:      headers,
+	}
+}
+
+// Stream implements [loop.Provider]. It posts to /chat/completions with
+// stream=true and translates the SSE response into provider events.
+func (p *Provider) Stream(ctx context.Context, req loop.ProviderRequest) (<-chan loop.ProviderEvent, error) {
+	if p == nil {
+		return nil, errors.New("nvidia: nil provider")
+	}
+
+	model := req.Model
+	if model == "" {
+		model = p.defaultModel
+	}
+	if model == "" {
+		return nil, errors.New("nvidia: model is required")
+	}
+
+	body, err := buildChatRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	body.Model = model
+	body.Stream = true
+	body.StreamOptions = &streamOptions{IncludeUsage: true}
+
+	apiKey := p.apiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("NVIDIA_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, errors.New("nvidia: API key is required (set NVIDIA_API_KEY or Options.APIKey)")
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("nvidia: marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("nvidia: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	for k, v := range p.headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	client := p.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("nvidia: send request: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		defer httpResp.Body.Close()
+		snippet, _ := io.ReadAll(io.LimitReader(httpResp.Body, 4096))
+		return nil, fmt.Errorf("nvidia: http %d: %s", httpResp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	events := make(chan loop.ProviderEvent)
+	go p.stream(ctx, httpResp, model, events)
+	return events, nil
+}
+
+// streamingChunk is a single SSE chat.completion.chunk frame.
+type streamingChunk struct {
+	ID      string         `json:"id"`
+	Model   string         `json:"model"`
+	Choices []streamChoice `json:"choices"`
+	Usage   *streamUsage   `json:"usage"`
+}
+
+type streamChoice struct {
+	Index        int         `json:"index"`
+	Delta        streamDelta `json:"delta"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type streamDelta struct {
+	Role             string                 `json:"role"`
+	Content          string                 `json:"content"`
+	ReasoningContent string                 `json:"reasoning_content"`
+	ToolCalls        []streamingToolCallDel `json:"tool_calls"`
+}
+
+type streamingToolCallDel struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type streamUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+	ReasoningTokens  int `json:"reasoning_tokens"`
+}
+
+func (p *Provider) stream(ctx context.Context, resp *http.Response, model string, events chan<- loop.ProviderEvent) {
+	defer close(events)
+	defer resp.Body.Close()
+
+	output := loop.Message{
+		Role:      loop.MessageRoleAssistant,
+		Provider:  providerName,
+		Model:     model,
+		CreatedAt: time.Now().UTC(),
+		Metadata:  map[string]any{},
+	}
+	if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventStart, Message: &output}) {
+		return
+	}
+
+	pendingCalls := map[int]*pendingToolCall{}
+	emittedCallIDs := map[int]string{}
+	finishReason := ""
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "[DONE]" {
+			if data == "[DONE]" {
+				break
+			}
+			continue
+		}
+
+		var chunk streamingChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: fmt.Sprintf("nvidia: parse chunk: %v", err)})
+			return
+		}
+		if chunk.ID != "" {
+			output.Metadata["response_id"] = chunk.ID
+		}
+		if chunk.Model != "" {
+			output.Model = chunk.Model
+		}
+		if chunk.Usage != nil {
+			output.Usage = &loop.Usage{
+				InputTokens:  int64(chunk.Usage.PromptTokens),
+				OutputTokens: int64(chunk.Usage.CompletionTokens),
+				TotalTokens:  int64(chunk.Usage.TotalTokens),
+			}
+		}
+		for _, choice := range chunk.Choices {
+			if choice.Delta.Content != "" {
+				appendText(&output, choice.Delta.Content)
+				if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventTextDelta, Delta: choice.Delta.Content}) {
+					return
+				}
+			}
+			if choice.Delta.ReasoningContent != "" {
+				appendThinking(&output, choice.Delta.ReasoningContent)
+				if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventThinkingDelta, Delta: choice.Delta.ReasoningContent}) {
+					return
+				}
+			}
+			for _, tc := range choice.Delta.ToolCalls {
+				p := pendingCalls[tc.Index]
+				if p == nil {
+					p = &pendingToolCall{}
+					pendingCalls[tc.Index] = p
+				}
+				if tc.ID != "" {
+					p.id = tc.ID
+				}
+				if tc.Function.Name != "" {
+					p.name = tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					p.arguments.WriteString(tc.Function.Arguments)
+				}
+			}
+			if choice.FinishReason != "" {
+				finishReason = choice.FinishReason
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: fmt.Sprintf("nvidia: read stream: %v", err)})
+		return
+	}
+
+	for _, index := range sortedIndices(pendingCalls) {
+		call := pendingCalls[index]
+		if _, already := emittedCallIDs[index]; already {
+			continue
+		}
+		emittedCallIDs[index] = call.id
+		toolCall, err := call.finalize(index)
+		if err != nil {
+			send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: err.Error()})
+			return
+		}
+		output.Content = append(output.Content, loop.ContentPart{Type: loop.ContentTypeToolCall, ToolCall: &toolCall})
+		if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventToolCall, ToolCall: &toolCall}) {
+			return
+		}
+	}
+
+	switch {
+	case len(pendingCalls) > 0:
+		output.StopReason = loop.StopReasonToolUse
+	case finishReason != "":
+		output.StopReason = mapFinishReason(finishReason)
+	default:
+		output.StopReason = loop.StopReasonStop
+	}
+	if len(output.Metadata) == 0 {
+		output.Metadata = nil
+	}
+	send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventDone, Message: &output})
+}
+
+type pendingToolCall struct {
+	id        string
+	name      string
+	arguments strings.Builder
+}
+
+func (p *pendingToolCall) finalize(index int) (loop.ToolCall, error) {
+	if p.name == "" {
+		return loop.ToolCall{}, fmt.Errorf("nvidia: tool call at index %d missing name", index)
+	}
+	args := p.arguments.String()
+	if args == "" {
+		args = "{}"
+	}
+	if !json.Valid([]byte(args)) {
+		return loop.ToolCall{}, fmt.Errorf("nvidia: tool call %q invalid JSON arguments", p.name)
+	}
+	id := p.id
+	if id == "" {
+		id = fmt.Sprintf("%s_%d", p.name, index)
+	}
+	return loop.ToolCall{ID: id, Name: p.name, Arguments: json.RawMessage(args)}, nil
+}
+
+// sortedIndices returns pending tool-call indices in ascending order so the
+// emitted ContentParts are deterministic regardless of map iteration order.
+func sortedIndices(calls map[int]*pendingToolCall) []int {
+	indices := make([]int, 0, len(calls))
+	for index := range calls {
+		indices = append(indices, index)
+	}
+	for i := 1; i < len(indices); i++ {
+		for j := i; j > 0 && indices[j-1] > indices[j]; j-- {
+			indices[j-1], indices[j] = indices[j], indices[j-1]
+		}
+	}
+	return indices
+}
+
+func send(ctx context.Context, events chan<- loop.ProviderEvent, event loop.ProviderEvent) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case events <- event:
+		return true
+	}
+}
+
+func appendText(message *loop.Message, delta string) {
+	appendPart(message, loop.ContentTypeText, delta)
+}
+
+func appendThinking(message *loop.Message, delta string) {
+	appendPart(message, loop.ContentTypeThinking, delta)
+}
+
+func appendPart(message *loop.Message, kind loop.ContentType, delta string) {
+	last := len(message.Content) - 1
+	if last >= 0 && message.Content[last].Type == kind {
+		switch kind {
+		case loop.ContentTypeText:
+			message.Content[last].Text += delta
+		case loop.ContentTypeThinking:
+			message.Content[last].Thinking += delta
+		}
+		return
+	}
+	part := loop.ContentPart{Type: kind}
+	switch kind {
+	case loop.ContentTypeText:
+		part.Text = delta
+	case loop.ContentTypeThinking:
+		part.Thinking = delta
+	}
+	message.Content = append(message.Content, part)
+}

--- a/providers/nvidia/nvidia_test.go
+++ b/providers/nvidia/nvidia_test.go
@@ -1,0 +1,441 @@
+package nvidia
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erain/glue/loop"
+)
+
+// captureProviderEvents drains every event from the provider stream into a
+// slice for assertion, with a generous safety timeout so a hung test fails
+// loudly instead of blocking CI.
+func captureProviderEvents(t *testing.T, ch <-chan loop.ProviderEvent) []loop.ProviderEvent {
+	t.Helper()
+	var out []loop.ProviderEvent
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out reading provider events; got %d so far", len(out))
+		case event, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, event)
+		}
+	}
+}
+
+// fakeServer wraps an httptest.Server and captures the last request body so
+// tests can assert against the on-the-wire payload.
+type fakeServer struct {
+	*httptest.Server
+	lastBody []byte
+}
+
+func newFakeServer(t *testing.T, body string) *fakeServer {
+	t.Helper()
+	fs := &fakeServer{}
+	fs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		fs.lastBody = raw
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(fs.Close)
+	return fs
+}
+
+func newProvider(t *testing.T, server *httptest.Server) *Provider {
+	t.Helper()
+	return New(Options{
+		APIKey:     "test-key",
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	})
+}
+
+func TestStreamEmitsTextDeltasAndDone(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"abc","model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	server := newFakeServer(t, body)
+
+	provider := newProvider(t, server.Server)
+	ch, err := provider.Stream(context.Background(), loop.ProviderRequest{
+		Model:    "test",
+		Messages: []loop.Message{{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := captureProviderEvents(t, ch)
+
+	var deltas []string
+	var done *loop.Message
+	var sawStart bool
+	for _, e := range events {
+		switch e.Type {
+		case loop.ProviderEventStart:
+			sawStart = true
+		case loop.ProviderEventTextDelta:
+			deltas = append(deltas, e.Delta)
+		case loop.ProviderEventDone:
+			done = e.Message
+		case loop.ProviderEventError:
+			t.Fatalf("unexpected error event: %s", e.Error)
+		}
+	}
+	if !sawStart {
+		t.Fatalf("missing Start event")
+	}
+	if got, want := strings.Join(deltas, ""), "Hello world"; got != want {
+		t.Fatalf("text delta concat: got %q want %q", got, want)
+	}
+	if done == nil {
+		t.Fatalf("missing Done event")
+	}
+	if done.StopReason != loop.StopReasonStop {
+		t.Fatalf("StopReason: got %q want stop", done.StopReason)
+	}
+	if done.Usage == nil || done.Usage.InputTokens != 3 || done.Usage.OutputTokens != 2 || done.Usage.TotalTokens != 5 {
+		t.Fatalf("Usage: got %+v", done.Usage)
+	}
+	if done.Metadata["response_id"] != "abc" {
+		t.Fatalf("response_id metadata: %+v", done.Metadata)
+	}
+}
+
+func TestStreamEmitsThinkingDeltas(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"reasoning_content":"thinking..."},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	server := newFakeServer(t, body)
+
+	ch, err := newProvider(t, server.Server).Stream(context.Background(), loop.ProviderRequest{Model: "x"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := captureProviderEvents(t, ch)
+
+	var thinking string
+	for _, e := range events {
+		if e.Type == loop.ProviderEventThinkingDelta {
+			thinking += e.Delta
+		}
+	}
+	if thinking != "thinking..." {
+		t.Fatalf("thinking delta: got %q", thinking)
+	}
+}
+
+func TestStreamAccumulatesToolCalls(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"add"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"a\":"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1,\"b\":2}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"a","model":"x","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	server := newFakeServer(t, body)
+
+	ch, err := newProvider(t, server.Server).Stream(context.Background(), loop.ProviderRequest{Model: "x"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := captureProviderEvents(t, ch)
+
+	var toolCalls []*loop.ToolCall
+	var done *loop.Message
+	for _, e := range events {
+		if e.Type == loop.ProviderEventToolCall {
+			toolCalls = append(toolCalls, e.ToolCall)
+		}
+		if e.Type == loop.ProviderEventDone {
+			done = e.Message
+		}
+	}
+	if len(toolCalls) != 1 {
+		t.Fatalf("tool calls: got %d want 1", len(toolCalls))
+	}
+	tc := toolCalls[0]
+	if tc.ID != "call_1" || tc.Name != "add" {
+		t.Fatalf("tool call identity: %+v", tc)
+	}
+	var args struct{ A, B int }
+	if err := json.Unmarshal(tc.Arguments, &args); err != nil || args.A != 1 || args.B != 2 {
+		t.Fatalf("tool args: %s err=%v", string(tc.Arguments), err)
+	}
+	if done == nil || done.StopReason != loop.StopReasonToolUse {
+		t.Fatalf("StopReason: got %+v", done)
+	}
+}
+
+func TestStreamPropagatesHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"bad key"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(Options{APIKey: "x", BaseURL: server.URL, HTTPClient: server.Client()})
+	_, err := provider.Stream(context.Background(), loop.ProviderRequest{Model: "x"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("error should mention status: %v", err)
+	}
+}
+
+func TestStreamMissingModel(t *testing.T) {
+	provider := New(Options{APIKey: "x"})
+	_, err := provider.Stream(context.Background(), loop.ProviderRequest{})
+	if err == nil || !strings.Contains(err.Error(), "model") {
+		t.Fatalf("expected model error, got %v", err)
+	}
+}
+
+func TestStreamMissingAPIKey(t *testing.T) {
+	t.Setenv("NVIDIA_API_KEY", "")
+	provider := New(Options{})
+	_, err := provider.Stream(context.Background(), loop.ProviderRequest{Model: "x"})
+	if err == nil || !strings.Contains(err.Error(), "API key") {
+		t.Fatalf("expected API key error, got %v", err)
+	}
+}
+
+func TestRequestBodyIncludesMessagesAndTools(t *testing.T) {
+	server := newFakeServer(t, "data: [DONE]\n\n")
+	provider := newProvider(t, server.Server)
+	ch, err := provider.Stream(context.Background(), loop.ProviderRequest{
+		Model:        "x",
+		SystemPrompt: "be concise",
+		Messages: []loop.Message{
+			{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "hi"}}},
+		},
+		Tools: []loop.ToolSpec{{
+			Name:        "add",
+			Description: "add two ints",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"a":{"type":"integer"}}}`),
+		}},
+		Options: map[string]any{"temperature": 0.4, "max_tokens": 16},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	captureProviderEvents(t, ch)
+
+	var got map[string]any
+	if err := json.Unmarshal(server.lastBody, &got); err != nil {
+		t.Fatalf("decode body: %v\n%s", err, string(server.lastBody))
+	}
+	if got["model"] != "x" {
+		t.Fatalf("model: %v", got["model"])
+	}
+	if got["stream"] != true {
+		t.Fatalf("stream flag missing: %v", got["stream"])
+	}
+	messages, _ := got["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("expected system + user message, got %d: %v", len(messages), messages)
+	}
+	system, _ := messages[0].(map[string]any)
+	if system["role"] != "system" || system["content"] != "be concise" {
+		t.Fatalf("system message: %+v", system)
+	}
+	tools, _ := got["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools: %+v", tools)
+	}
+	tool0, _ := tools[0].(map[string]any)
+	fn, _ := tool0["function"].(map[string]any)
+	if fn["name"] != "add" {
+		t.Fatalf("tool name: %+v", fn)
+	}
+	if got["temperature"].(float64) != 0.4 {
+		t.Fatalf("temperature: %+v", got["temperature"])
+	}
+	if got["max_tokens"].(float64) != 16 {
+		t.Fatalf("max_tokens: %+v", got["max_tokens"])
+	}
+}
+
+func TestStreamCancelStopsCleanly(t *testing.T) {
+	// Server that sends one chunk, then blocks until the request context is
+	// canceled. Verifies the goroutine exits without leaking when the caller
+	// cancels mid-stream.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"id":"a","model":"x","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`+"\n\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	provider := New(Options{APIKey: "x", BaseURL: server.URL, HTTPClient: server.Client()})
+	ch, err := provider.Stream(ctx, loop.ProviderRequest{Model: "x"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Drain the first text delta then cancel.
+	var sawText bool
+	for {
+		select {
+		case e, ok := <-ch:
+			if !ok {
+				if !sawText {
+					t.Fatalf("channel closed before any event")
+				}
+				return
+			}
+			if e.Type == loop.ProviderEventTextDelta {
+				sawText = true
+				cancel()
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("provider did not close channel after cancel")
+		}
+	}
+}
+
+// TestLiveSmoke runs against the real NVIDIA endpoint when NVIDIA_API_KEY is
+// set. It calls moonshotai/kimi-k2.6 with a single non-streaming-style prompt
+// and asserts that we get any text back. Skipped quietly otherwise.
+func TestLiveSmoke(t *testing.T) {
+	apiKey := os.Getenv("NVIDIA_API_KEY")
+	if apiKey == "" {
+		t.Skip("NVIDIA_API_KEY not set; skipping live smoke")
+	}
+
+	model := os.Getenv("NVIDIA_LIVE_MODEL")
+	if model == "" {
+		model = "moonshotai/kimi-k2.6"
+	}
+
+	// Cold-start latency on kimi-k2.6 can be ~30s.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	provider := New(Options{APIKey: apiKey, HTTPClient: &http.Client{Timeout: 240 * time.Second}})
+	ch, err := provider.Stream(ctx, loop.ProviderRequest{
+		Model: model,
+		Messages: []loop.Message{
+			{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "Reply with the single word: glue."}}},
+		},
+		Options: map[string]any{"max_tokens": 16, "temperature": 0.0},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var text strings.Builder
+	var done *loop.Message
+	deadline := time.After(240 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("live smoke timed out; partial=%q", text.String())
+		case event, ok := <-ch:
+			if !ok {
+				if done == nil {
+					t.Fatalf("channel closed without Done event; partial=%q", text.String())
+				}
+				if strings.TrimSpace(text.String()) == "" {
+					t.Fatalf("expected non-empty assistant text; got %q", text.String())
+				}
+				t.Logf("kimi-k2.6 reply: %q (usage=%+v)", text.String(), done.Usage)
+				return
+			}
+			switch event.Type {
+			case loop.ProviderEventTextDelta:
+				text.WriteString(event.Delta)
+			case loop.ProviderEventDone:
+				done = event.Message
+			case loop.ProviderEventError:
+				t.Fatalf("provider error: %s", event.Error)
+			}
+		}
+	}
+}
+
+// sanity: make sure the default base URL is exposed for reference docs.
+func TestDefaultBaseURL(t *testing.T) {
+	if defaultBaseURL != "https://integrate.api.nvidia.com/v1" {
+		t.Fatalf("defaultBaseURL drift: %s", defaultBaseURL)
+	}
+}
+
+// sanity: tool message round-trips through convert layer without panicking.
+func TestConvertToolMessageRequiresID(t *testing.T) {
+	_, err := convertMessage(loop.Message{Role: loop.MessageRoleTool, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "out"}}})
+	if err == nil {
+		t.Fatalf("expected error for missing tool_call_id")
+	}
+	got, err := convertMessage(loop.Message{
+		Role:       loop.MessageRoleTool,
+		ToolCallID: "id-1",
+		ToolName:   "add",
+		Content:    []loop.ContentPart{{Type: loop.ContentTypeText, Text: "42"}},
+	})
+	if err != nil {
+		t.Fatalf("convert tool message: %v", err)
+	}
+	if got.Role != "tool" || got.ToolCallID != "id-1" || got.Content != "42" {
+		t.Fatalf("converted tool message: %+v", got)
+	}
+}
+
+// guard against accidental change to mapFinishReason.
+func TestMapFinishReason(t *testing.T) {
+	cases := map[string]loop.StopReason{
+		"":               loop.StopReasonStop,
+		"stop":           loop.StopReasonStop,
+		"length":         loop.StopReasonLength,
+		"tool_calls":     loop.StopReasonToolUse,
+		"function_call":  loop.StopReasonToolUse,
+		"content_filter": loop.StopReasonError,
+	}
+	for input, want := range cases {
+		if got := mapFinishReason(input); got != want {
+			t.Fatalf("mapFinishReason(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds `providers/nvidia`, a Glue provider for the [build.nvidia.com](https://build.nvidia.com) inference API (`integrate.api.nvidia.com/v1/chat/completions`).
- Self-contained `net/http` client — no third-party SDK dependency, no new entries in `go.mod`.
- Supports streaming text deltas, `reasoning_content` → `ProviderEventThinkingDelta`, OpenAI-shape `tool_calls` delta accumulation, usage, and `finish_reason` → `StopReason` mapping.
- Honors `temperature`, `max_tokens`, `top_p`, `response_format` options; unknown keys passthrough via `Extra`.
- README quickstart for `moonshotai/kimi-k2.6` and design.md package boundary entry.

Initial target was running Kimi K2.6 through Glue for testing. Verified end-to-end through `glue.Agent` / `Session.Prompt` and via `TestLiveSmoke`.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...` (without `NVIDIA_API_KEY`) — all packages pass
- [x] `NVIDIA_API_KEY=… go test ./providers/nvidia/ -run TestLiveSmoke -timeout 300s` — kimi-k2.6 returns "glue", usage reported
- [x] End-to-end smoke through `glue.NewAgent` + `nvidia.New` — provider drives a full session
- [ ] Optional follow-up: add a manual-only CI workflow mirroring #50 for live NVIDIA smoke (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)