### PR TITLE
agents/glue-review: wrap as composite GitHub Action (closes #63)

### DIFF
--- a/.github/workflows/glue-review.yml
+++ b/.github/workflows/glue-review.yml
@@ -1,12 +1,13 @@
 name: glue-review
 
-# Dogfoods agents/glue-review on every PR opened against this repo.
-# - Posts/updates a sticky comment (find-by-marker, edit-or-create).
-# - Soft-fails: if the agent or upstream model errors, the comment becomes
-#   a "review unavailable, re-run to retry" message instead of failing CI.
-# - Fork PRs do not receive secrets on `pull_request`; the workflow detects
-#   that and skips quietly. A `/glue-review` comment trigger (#64) will
-#   cover the fork-PR path in a follow-up.
+# Dogfoods agents/glue-review on every PR opened against this repo by
+# consuming the same composite Action external repos use. The Action
+# itself lives at agents/glue-review/action.yml — see that file for the
+# full input/output contract.
+#
+# Fork PRs do not receive secrets on `pull_request`; the workflow detects
+# that and skips quietly. The `/glue-review` comment trigger (#64) will
+# cover the fork-PR path in a follow-up.
 
 on:
   pull_request:
@@ -17,7 +18,6 @@ permissions:
   pull-requests: write
 
 concurrency:
-  # One review per PR at a time; pushing a new commit cancels the prior run.
   group: glue-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
@@ -34,16 +34,10 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          # Pin to the resolved head SHA to neutralize any push-after-trigger
-          # race; fetch-depth: 0 is required for `git diff origin/<base>...HEAD`.
+          # Pin to the resolved head SHA to neutralize push-after-trigger races;
+          # fetch-depth: 0 is required for `git diff origin/<base>...HEAD`.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          cache: true
 
       - name: Gate on provider key
         id: gate
@@ -51,7 +45,7 @@ jobs:
           KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           if [ -z "$KEY" ]; then
-            echo "NVIDIA_API_KEY is not set in this run (fork PR or missing secret); skipping review."
+            echo "NVIDIA_API_KEY not set (fork PR or missing secret); skipping review."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -64,7 +58,6 @@ jobs:
           base="origin/${{ github.event.pull_request.base.ref }}"
           changed=$(git diff --name-only "$base"...HEAD || true)
           if [ -z "$changed" ]; then
-            echo "No changed files reported; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -73,108 +66,19 @@ jobs:
             echo "All changed files are docs/markdown; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Code changes detected; running review."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build glue-review
-        if: steps.gate.outputs.skip == 'false' && steps.scope.outputs.skip == 'false'
-        run: go build -o /tmp/glue-review ./agents/glue-review
-
       - name: Run glue-review
         if: steps.gate.outputs.skip == 'false' && steps.scope.outputs.skip == 'false'
-        id: review
-        env:
-          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-        # Capture both streams. continue-on-error so a model 429 doesn't fail
-        # the workflow — the comment step posts a soft-fail message instead.
-        continue-on-error: true
-        run: |
-          set +e
-          /tmp/glue-review \
-            --provider nvidia \
-            --model moonshotai/kimi-k2.6 \
-            --base "origin/${{ github.event.pull_request.base.ref }}" \
-            --max-turns 12 \
-            --id "pr-${{ github.event.pull_request.number }}" \
-            --store ".glue/ci-review-sessions" \
-            > /tmp/glue-review.md 2> /tmp/glue-review.err
-          rc=$?
-          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
-          echo "review bytes: $(wc -c < /tmp/glue-review.md)"
-          echo "----stderr----"
-          tail -c 4096 /tmp/glue-review.err || true
-
-      - name: Post or update sticky comment
-        if: steps.gate.outputs.skip == 'false' && steps.scope.outputs.skip == 'false'
-        uses: actions/github-script@v7
+        uses: ./agents/glue-review
         with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            // Marker is hidden in the comment HTML so we can find this bot's
-            // comment on re-runs. Bump the version when we change the comment
-            // shape so old comments don't get edited into a new format.
-            const marker = '<!-- glue-review:v1:do-not-edit -->';
-
-            const exitCode = '${{ steps.review.outputs.exit_code }}';
-            const reviewPath = '/tmp/glue-review.md';
-            const errPath = '/tmp/glue-review.err';
-
-            const safeRead = p => fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
-            const reviewMd = safeRead(reviewPath).trim();
-            const errLog = safeRead(errPath).trim();
-
-            const ok = exitCode === '0' && reviewMd.length > 0;
-
-            const footer = [
-              '',
-              '---',
-              '*🤖 Posted by [glue-review](https://github.com/erain/glue/tree/main/agents/glue-review).',
-              'Powered by NVIDIA Kimi K2.6 via the free build.nvidia.com API.',
-              'Add `[skip-review]` to the PR body to suppress.*',
-            ].join('\n');
-
-            let body;
-            if (ok) {
-              body = `${marker}\n${reviewMd}${footer}`;
-            } else {
-              const errSnippet = errLog ? errLog.slice(-3500) : '(no stderr captured)';
-              body = [
-                marker,
-                '⚠️ **glue-review could not produce a review.**',
-                '',
-                `Exit code: \`${exitCode}\`. Re-run the workflow to retry.`,
-                '',
-                '<details><summary>Failure log (last 3.5 KiB of stderr)</summary>',
-                '',
-                '```',
-                errSnippet,
-                '```',
-                '',
-                '</details>',
-                footer,
-              ].join('\n');
-            }
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-
-            // Find existing sticky.
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id, body,
-              });
-              core.info(`Updated sticky comment ${existing.id}`);
-            } else {
-              const created = await github.rest.issues.createComment({
-                owner, repo, issue_number, body,
-              });
-              core.info(`Created sticky comment ${created.data.id}`);
-            }
+          provider: nvidia
+          model: moonshotai/kimi-k2.6
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          max-turns: '12'
+          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+          # `glue-ref` defaults to the action's ref. For local-path uses
+          # there is no action ref, so pin to main; consumers of the
+          # remote Action get the action's own ref automatically.
+          glue-ref: main

--- a/agents/glue-review/README.md
+++ b/agents/glue-review/README.md
@@ -4,6 +4,35 @@ A free, local pre-push branch reviewer built on the Glue agent harness. Run
 it before opening a PR and get structured review notes from a real LLM, no
 cloud account required beyond a free API key.
 
+## Use it as a GitHub Action
+
+```yaml
+# .github/workflows/glue-review.yml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: erain/glue/agents/glue-review@main  # pin to a tag in production
+        with:
+          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+```
+
+That posts a sticky review comment on every PR. Use `provider: openrouter` or
+`provider: gemini` (with the matching `*-api-key` input) to swap backends.
+
+Inputs and outputs are documented in [`action.yml`](action.yml). Re-runs
+update the existing sticky comment instead of stacking duplicates.
+
 ## What it does
 
 Given a Git working directory, the agent:

--- a/agents/glue-review/action.yml
+++ b/agents/glue-review/action.yml
@@ -1,0 +1,200 @@
+name: glue-review
+description: |
+  Free, local pre-PR branch reviewer. Reads the diff against a base ref,
+  deep-reads files when context demands it, and posts (or updates) a
+  sticky review comment via GitHub's Issues API.
+author: erain
+
+# Branding for Marketplace listings (effective once published).
+branding:
+  icon: 'check-circle'
+  color: 'purple'
+
+inputs:
+  provider:
+    description: |
+      Provider name: `nvidia`, `openrouter`, or `gemini`. Defaults to
+      `nvidia` for the strongest free model (Kimi K2.6).
+    required: false
+    default: nvidia
+  model:
+    description: |
+      Model id. When empty, uses the provider-specific default
+      (NVIDIA: moonshotai/kimi-k2.6, OpenRouter:
+      inclusionai/ling-2.6-1t:free, Gemini: gemini-2.5-flash).
+    required: false
+    default: ''
+  base-ref:
+    description: |
+      Ref to diff against. Default is the PR's base branch
+      (`github.base_ref`). Override for non-PR contexts.
+    required: false
+    default: ${{ github.base_ref }}
+  max-turns:
+    description: Loop budget (cap on assistant turns).
+    required: false
+    default: '12'
+  github-token:
+    description: |
+      Token used to post the sticky comment. Default is the workflow's
+      automatic GITHUB_TOKEN; override with a PAT if you need cross-repo
+      commenting.
+    required: false
+    default: ${{ github.token }}
+  nvidia-api-key:
+    description: NVIDIA build API key (used when provider=nvidia).
+    required: false
+    default: ''
+  openrouter-api-key:
+    description: OpenRouter API key (used when provider=openrouter).
+    required: false
+    default: ''
+  gemini-api-key:
+    description: Gemini API key (used when provider=gemini).
+    required: false
+    default: ''
+  go-version:
+    description: Go toolchain version for `setup-go`.
+    required: false
+    default: stable
+  glue-ref:
+    description: |
+      Tag, branch, or SHA in github.com/erain/glue to install
+      glue-review from. Defaults to the action's own ref so consumers
+      pin once and the binary follows.
+    required: false
+    default: ${{ github.action_ref || 'main' }}
+  pr-number:
+    description: |
+      PR number to comment on. Defaults to
+      `github.event.pull_request.number` so the action just works in
+      `pull_request` workflows; override when triggering from
+      `issue_comment` or `workflow_dispatch`.
+    required: false
+    default: ${{ github.event.pull_request.number }}
+
+outputs:
+  review-markdown-path:
+    description: |
+      Path on the runner filesystem where the raw review markdown was
+      written; useful for follow-up steps that want to post-process the
+      review (extract sections, lint structure, etc.).
+    value: ${{ steps.run.outputs.review-path }}
+  comment-url:
+    description: API URL of the sticky comment that was created or updated.
+    value: ${{ steps.post.outputs.comment-url }}
+  exit-code:
+    description: |
+      Exit code from the agent invocation. Non-zero indicates the
+      sticky comment carries a soft-fail message rather than a real
+      review.
+    value: ${{ steps.run.outputs.exit-code }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: true
+
+    - name: Install glue-review
+      shell: bash
+      run: |
+        # Pin the binary to the action's ref so the consumer's `uses:`
+        # version controls the binary version too.
+        go install "github.com/erain/glue/agents/glue-review@${{ inputs.glue-ref }}"
+        echo "GOBIN=$(go env GOPATH)/bin" >> "$GITHUB_ENV"
+
+    - name: Run glue-review
+      id: run
+      shell: bash
+      env:
+        NVIDIA_API_KEY: ${{ inputs.nvidia-api-key }}
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+      run: |
+        set +e
+        review_path="${RUNNER_TEMP}/glue-review.md"
+        err_path="${RUNNER_TEMP}/glue-review.err"
+        bin="$(go env GOPATH)/bin/glue-review"
+
+        args=(
+          --provider "${{ inputs.provider }}"
+          --base "origin/${{ inputs.base-ref }}"
+          --max-turns "${{ inputs.max-turns }}"
+          --id "pr-${{ inputs.pr-number }}"
+          --store ".glue/action-sessions"
+        )
+        if [ -n "${{ inputs.model }}" ]; then
+          args+=(--model "${{ inputs.model }}")
+        fi
+
+        "$bin" "${args[@]}" > "$review_path" 2> "$err_path"
+        rc=$?
+
+        echo "review-path=$review_path" >> "$GITHUB_OUTPUT"
+        echo "err-path=$err_path"       >> "$GITHUB_OUTPUT"
+        echo "exit-code=$rc"            >> "$GITHUB_OUTPUT"
+        echo "review bytes: $(wc -c < "$review_path")"
+        echo "----stderr (last 4k)----"
+        tail -c 4096 "$err_path" || true
+
+    - name: Post or update sticky comment
+      id: post
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REVIEW_PATH: ${{ steps.run.outputs.review-path }}
+        ERR_PATH: ${{ steps.run.outputs.err-path }}
+        EXIT_CODE: ${{ steps.run.outputs.exit-code }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPO: ${{ github.repository }}
+      run: |
+        # Marker is hidden in the comment HTML so we can find this bot's
+        # comment on re-runs. Bump the version when the comment shape
+        # changes so old comments don't get edited into a new format.
+        MARKER='<!-- glue-review:v1:do-not-edit -->'
+        FOOTER=$'\n---\n*🤖 Posted by [glue-review](https://github.com/erain/glue/tree/main/agents/glue-review).*'
+
+        # Build the comment body in a temp file so we never have to embed
+        # heredocs inside this YAML block (block-scalar indentation makes
+        # heredocs awkward). gh api -F body=@file reads the file as-is.
+        BODY_PATH="${RUNNER_TEMP}/glue-review-body.md"
+
+        if [ "$EXIT_CODE" = "0" ] && [ -s "$REVIEW_PATH" ]; then
+          {
+            printf '%s\n' "$MARKER"
+            cat "$REVIEW_PATH"
+            printf '%s' "$FOOTER"
+          } > "$BODY_PATH"
+        else
+          {
+            printf '%s\n' "$MARKER"
+            printf '%s\n\n' '⚠️ **glue-review could not produce a review.**'
+            printf 'Exit code: `%s`. Re-run the workflow to retry.\n\n' "$EXIT_CODE"
+            printf '<details><summary>Failure log (last 3.5 KiB of stderr)</summary>\n\n'
+            printf '```\n'
+            tail -c 3500 "$ERR_PATH" 2>/dev/null || echo '(no stderr captured)'
+            printf '\n```\n\n</details>'
+            printf '%s' "$FOOTER"
+          } > "$BODY_PATH"
+        fi
+
+        existing_id=$(
+          gh api --paginate \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | first | .id"
+        )
+
+        if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
+          url=$(gh api -X PATCH "repos/$REPO/issues/comments/$existing_id" \
+            -F body="@$BODY_PATH" --jq '.url')
+          echo "Updated comment $existing_id"
+        else
+          url=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            -F body="@$BODY_PATH" --jq '.url')
+          echo "Created new sticky comment"
+        fi
+        echo "comment-url=$url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Phase 2 of the productionization roadmap (#70). Adds `agents/glue-review/action.yml` so other repos can adopt glue-review with a single workflow line:

```yaml
- uses: erain/glue/agents/glue-review@main
  with:
    nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
```

The dogfood workflow added in #62 is rewritten to consume this Action via `uses: ./agents/glue-review` — same surface external users will hit, so this PR also serves as the live integration test.

## What's in the Action

- Composite (no Docker): `setup-go` → `go install glue-review` pinned to the action's own ref → run binary → post sticky comment via `gh api`. No `actions/github-script` dependency in third-party repos.
- Inputs: `provider`, `model`, `base-ref`, `max-turns`, `pr-number`, plus per-provider API keys and `github-token`.
- Outputs: `review-markdown-path`, `comment-url`, `exit-code` for follow-up steps.
- Branding (`check-circle`, purple) for an eventual Marketplace listing.

## Self-test

Same as #62: this PR triggers the new workflow on its own `pull_request` event. Pass criteria: a sticky comment from the local Action appears on this PR within ~3 minutes.

## Known limitations (tracked separately)

- One bulk markdown comment, not inline annotations on the diff (#65).
- Single provider; no failover (#66).
- Fork PRs see no review until the comment trigger lands (#64).
