### PR TITLE
ci: /glue-review comment trigger for fork PRs (closes #64)

### DIFF
--- a/.github/workflows/glue-review-comment.yml
+++ b/.github/workflows/glue-review-comment.yml
@@ -1,0 +1,107 @@
+name: glue-review (comment trigger)
+
+# Lets a maintainer trigger glue-review on any PR — including PRs from
+# forks, where the regular `pull_request` workflow has no access to
+# secrets — by commenting `/glue-review` on the PR.
+#
+# Why a separate workflow: `issue_comment` runs in the base-repo
+# context with full secret access, but only fires on comments. This is
+# the GitHub-canonical pattern for "let a trusted human ask the bot to
+# look at this fork PR." It does NOT run automatically on every fork
+# PR — that would let randos burn API credits.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: glue-review-comment-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: review (comment-triggered)
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/glue-review') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+
+    steps:
+      - name: "React :eyes: on trigger comment"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api -X POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes >/dev/null || true
+
+      - name: Resolve PR head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Fetch the PR explicitly — the issue_comment payload knows it's
+          # a PR but doesn't carry the PR head ref / SHA. Resolving here
+          # also pins the SHA at trigger time so a fork pushing right
+          # after the comment can't swap code from under us.
+          json=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          head_sha=$(echo "$json" | jq -r '.head.sha')
+          base_ref=$(echo "$json" | jq -r '.base.ref')
+          if [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
+            echo "could not resolve PR head SHA" >&2
+            exit 1
+          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR_NUMBER: head=$head_sha base=$base_ref"
+
+      - name: Checkout pinned head SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Run glue-review
+        id: review
+        uses: ./agents/glue-review
+        continue-on-error: true
+        with:
+          provider: nvidia
+          model: moonshotai/kimi-k2.6
+          base-ref: ${{ steps.pr.outputs.base_ref }}
+          max-turns: '12'
+          pr-number: ${{ github.event.issue.number }}
+          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+          glue-ref: main
+
+      - name: "React :rocket: on success"
+        if: steps.review.outputs.exit-code == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api -X POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=rocket >/dev/null || true
+
+      - name: "React :x: on failure"
+        if: steps.review.outputs.exit-code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api -X POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=-1 >/dev/null || true

--- a/agents/glue-review/README.md
+++ b/agents/glue-review/README.md
@@ -33,6 +33,60 @@ That posts a sticky review comment on every PR. Use `provider: openrouter` or
 Inputs and outputs are documented in [`action.yml`](action.yml). Re-runs
 update the existing sticky comment instead of stacking duplicates.
 
+### Fork PRs (production setup)
+
+GitHub does not pass repository secrets to `pull_request` workflows from
+forks, for security reasons. The `pull_request`-triggered workflow above
+will skip any fork PR — by design, since otherwise a fork could exfiltrate
+the LLM API key just by opening a PR.
+
+The standard fix is a **second workflow** triggered by an `issue_comment`
+that a maintainer types on the PR:
+
+```yaml
+# .github/workflows/glue-review-comment.yml
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/glue-review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - id: pr
+        env: { GH_TOKEN: ${{ github.token }} }
+        run: |
+          json=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}")
+          echo "head_sha=$(echo "$json" | jq -r .head.sha)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(echo "$json" | jq -r .base.ref)" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}  # pin SHA at trigger time
+          fetch-depth: 0
+      - uses: erain/glue/agents/glue-review@main
+        with:
+          base-ref: ${{ steps.pr.outputs.base_ref }}
+          pr-number: ${{ github.event.issue.number }}
+          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+```
+
+`issue_comment` runs in the **base-repo context** with full secret access,
+but only fires when a maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) comments
+`/glue-review` on the PR. Untrusted commenters are filtered out by
+`author_association`. The head SHA is resolved at trigger time and pinned
+on checkout so a fork pushing immediately after the trigger comment cannot
+swap code into the run.
+
+This repo runs both workflows. See [.github/workflows/glue-review.yml](../../.github/workflows/glue-review.yml)
+and [.github/workflows/glue-review-comment.yml](../../.github/workflows/glue-review-comment.yml).
+
 ## What it does
 
 Given a Git working directory, the agent:


### PR DESCRIPTION
## Summary

Phase 3a of the productionization roadmap (#70). Adds a second workflow file at `.github/workflows/glue-review-comment.yml` that runs glue-review when a maintainer comments `/glue-review` on a PR, including PRs from forks.

## Why

GitHub does not pass repository secrets to `pull_request` workflows from forks (anti-exfiltration). The `pull_request` workflow added in #62 therefore skips fork PRs by design. `issue_comment` runs in the base-repo context with full secret access — the standard fix.

## Security gates

- `author_association` must be `OWNER`, `MEMBER`, or `COLLABORATOR`. Random commenters cannot trigger free LLM spend.
- PR head SHA is resolved via `gh api` at trigger time and pinned on checkout, so a fork pushing immediately after the comment cannot swap code into the run.
- :eyes: reaction on trigger; :rocket: or :-1: on completion so the human typing `/glue-review` knows the bot is working.

## Self-test

Cannot test from this PR alone (it's a same-repo PR; the fork-PR path is exercised when an external contributor opens one and a maintainer types `/glue-review`). The new workflow's syntax is validated locally via `yaml.safe_load`. Once merged, `/glue-review` on this very PR will exercise it as a smoke test.

## What's not in this PR

- `safe-to-review` label / `pull_request_target` mode — would let trusted automation fire without a human comment. Fine to add later if needed; today the comment trigger is enough.
- Provider failover (#66) and inline review comments (#65) are still tracked separately.
