### PR TITLE
agents/glue-review: inline review comments via PR Reviews API (closes #65)

### DIFF
--- a/.github/workflows/glue-review-comment.yml
+++ b/.github/workflows/glue-review-comment.yml
@@ -84,7 +84,6 @@ jobs:
           max-turns: '12'
           pr-number: ${{ github.event.issue.number }}
           nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
-          glue-ref: main
 
       - name: "React :rocket: on success"
         if: steps.review.outputs.exit-code == '0'

--- a/.github/workflows/glue-review.yml
+++ b/.github/workflows/glue-review.yml
@@ -78,7 +78,3 @@ jobs:
           base-ref: ${{ github.event.pull_request.base.ref }}
           max-turns: '12'
           nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
-          # `glue-ref` defaults to the action's ref. For local-path uses
-          # there is no action ref, so pin to main; consumers of the
-          # remote Action get the action's own ref automatically.
-          glue-ref: main

--- a/agents/glue-review/action.yml
+++ b/agents/glue-review/action.yml
@@ -57,13 +57,6 @@ inputs:
     description: Go toolchain version for `setup-go`.
     required: false
     default: stable
-  glue-ref:
-    description: |
-      Tag, branch, or SHA in github.com/erain/glue to install
-      glue-review from. Defaults to the action's own ref so consumers
-      pin once and the binary follows.
-    required: false
-    default: ${{ github.action_ref || 'main' }}
   pr-number:
     description: |
       PR number to comment on. Defaults to
@@ -101,11 +94,17 @@ runs:
 
     - name: Install glue-review
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
       run: |
-        # Pin the binary to the action's ref so the consumer's `uses:`
-        # version controls the binary version too.
-        go install "github.com/erain/glue/agents/glue-review@${{ inputs.glue-ref }}"
-        echo "GOBIN=$(go env GOPATH)/bin" >> "$GITHUB_ENV"
+        # Build from the Action's own source tree. For `uses:` references
+        # GitHub fetches the requested ref into ${{ github.action_path }},
+        # so the binary matches the consumer's pinned action ref exactly.
+        # No separate go install — that would fetch a possibly-different
+        # version of the same source from the module cache.
+        cd "$ACTION_PATH"
+        go build -o "${RUNNER_TEMP}/glue-review" .
+        echo "GLUE_REVIEW_BIN=${RUNNER_TEMP}/glue-review" >> "$GITHUB_ENV"
 
     - name: Run glue-review
       id: run
@@ -118,7 +117,8 @@ runs:
         set +e
         review_path="${RUNNER_TEMP}/glue-review.md"
         err_path="${RUNNER_TEMP}/glue-review.err"
-        bin="$(go env GOPATH)/bin/glue-review"
+        inline_path="${RUNNER_TEMP}/glue-review-inline.json"
+        bin="$GLUE_REVIEW_BIN"
 
         args=(
           --provider "${{ inputs.provider }}"
@@ -126,6 +126,7 @@ runs:
           --max-turns "${{ inputs.max-turns }}"
           --id "pr-${{ inputs.pr-number }}"
           --store ".glue/action-sessions"
+          --inline-json "$inline_path"
         )
         if [ -n "${{ inputs.model }}" ]; then
           args+=(--model "${{ inputs.model }}")
@@ -136,13 +137,103 @@ runs:
 
         echo "review-path=$review_path" >> "$GITHUB_OUTPUT"
         echo "err-path=$err_path"       >> "$GITHUB_OUTPUT"
+        echo "inline-path=$inline_path" >> "$GITHUB_OUTPUT"
         echo "exit-code=$rc"            >> "$GITHUB_OUTPUT"
         echo "review bytes: $(wc -c < "$review_path")"
+        echo "inline-json bytes: $(wc -c < "$inline_path" 2>/dev/null || echo 0)"
         echo "----stderr (last 4k)----"
         tail -c 4096 "$err_path" || true
 
+    - name: Post inline review (when parseable)
+      id: review_post
+      if: steps.run.outputs.exit-code == '0'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REVIEW_PATH: ${{ steps.run.outputs.review-path }}
+        INLINE_PATH: ${{ steps.run.outputs.inline-path }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        REPO: ${{ github.repository }}
+      run: |
+        # Phase 3b (#65): when the agent emitted at least one parseable
+        # `[severity] path:line` entry inside Issues/Suggestions, post
+        # them as inline comments on the diff via the PR Reviews API.
+        # If nothing parseable came out (or the inline file is missing),
+        # we fall through to the bulk sticky-comment path below.
+        if [ ! -s "$INLINE_PATH" ]; then
+          echo "no inline file; falling back to sticky comment"
+          echo "posted=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        count=$(jq 'length' "$INLINE_PATH" 2>/dev/null || echo 0)
+        if [ "$count" = "0" ]; then
+          echo "inline file empty; falling back to sticky comment"
+          echo "posted=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Resolve PR head SHA — required by the Reviews API.
+        head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+
+        # Dismiss any prior inline reviews from this bot before posting a
+        # new one. Match by the v1 marker we inject into every review body
+        # so re-runs replace, not stack. Dismissing keeps the audit trail
+        # but greys out old reviews in the UI.
+        prior_ids=$(
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq "[.[] | select(.body and (.body | contains(\"<!-- glue-review:v1:do-not-edit -->\"))) | select(.state != \"DISMISSED\") | .id] | .[]" \
+        )
+        for id in $prior_ids; do
+          gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/reviews/$id/dismissals" \
+            -f message="Superseded by a newer glue-review run." >/dev/null || true
+        done
+
+        # Build the review payload. The body is the full markdown minus
+        # nothing — leaving Issues/Suggestions in place keeps the
+        # narrative readable when the inline comments are scrolled past.
+        # The marker still goes into the body so the dismissal lookup
+        # above finds future iterations.
+        marker='<!-- glue-review:v1:do-not-edit -->'
+        body_path="${RUNNER_TEMP}/review-body.md"
+        {
+          printf '%s\n' "$marker"
+          cat "$REVIEW_PATH"
+          printf '\n\n---\n*🤖 Posted by [glue-review](https://github.com/erain/glue/tree/main/agents/glue-review).*'
+        } > "$body_path"
+
+        # PR Reviews API expects comments as `{path, line, side, body}`.
+        # Severity is folded into the body so reviewers see it inline.
+        comments_path="${RUNNER_TEMP}/review-comments.json"
+        jq '[.[] | {
+          path:    .path,
+          line:    .line,
+          side:    "RIGHT",
+          body:    "**[\(.severity)]** \(.body)"
+        }]' "$INLINE_PATH" > "$comments_path"
+
+        # Build the full review payload as JSON so newlines / quotes survive.
+        payload_path="${RUNNER_TEMP}/review-payload.json"
+        jq -n --arg commit_id "$head_sha" \
+              --rawfile body "$body_path" \
+              --slurpfile comments "$comments_path" \
+              '{commit_id: $commit_id, body: $body, event: "COMMENT", comments: $comments[0]}' \
+          > "$payload_path"
+
+        # Post. If the API rejects (e.g., a path:line not in the diff),
+        # capture the error and fall back to the sticky path.
+        if url=$(gh api -X POST "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --input "$payload_path" --jq '.html_url'); then
+          echo "Posted inline review: $url"
+          echo "posted=true"  >> "$GITHUB_OUTPUT"
+          echo "review-url=$url" >> "$GITHUB_OUTPUT"
+        else
+          echo "Inline review POST failed; will fall back to sticky comment."
+          echo "posted=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Post or update sticky comment
       id: post
+      if: steps.review_post.outputs.posted != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}

--- a/agents/glue-review/main.go
+++ b/agents/glue-review/main.go
@@ -17,7 +17,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -51,32 +53,39 @@ Output format (Markdown, in this order, omit empty sections):
 One sentence on what this branch does.
 
 ## Issues
-Bugs, regressions, or correctness problems. Include file:line references when possible. Prefix each with severity: [critical] [major] [minor].
+Bugs, regressions, or correctness problems. Each entry MUST start with a severity tag and a file:line citation in this exact shape so a tool can route them as inline review comments:
+
+- [critical|major|minor] path/to/file.ext:LINE — description
+
+Use the line number from the new (post-change) side of the diff. If you genuinely cannot pin a line, use :0 (the entry will land in the bulk review body instead of inline).
 
 ## Suggestions
-Style, design, or maintainability improvements. Be specific; cite file paths.
+Style, design, or maintainability improvements. Same prefix format as Issues:
+
+- [minor|major] path/to/file.ext:LINE — description
 
 ## Looks good
-Things the change got right that are worth calling out (only when meaningful — do not pad).
+Free-form bullets. Only when meaningful — do not pad.
 
 ## Open questions
-Things you cannot decide from the diff alone and want the author to clarify.
+Things you cannot decide from the diff alone and want the author to clarify. Free-form bullets.
 
-Be direct. Cite file paths. Never invent code that is not in the diff.`
+Be direct. Never invent code that is not in the diff. Never reference files that are not changed by the diff in Issues or Suggestions.`
 
 func main() {
 	os.Exit(run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
 }
 
 type config struct {
-	base     string
-	provider string
-	model    string
-	id       string
-	store    string
-	work     string
-	maxTurns int
-	prompt   string
+	base       string
+	provider   string
+	model      string
+	id         string
+	store      string
+	work       string
+	maxTurns   int
+	prompt     string
+	inlineJSON string
 }
 
 func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -114,13 +123,22 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// When --inline-json is set we tee stdout into a buffer so we can
+	// parse the final review without re-running anything. The existing
+	// streaming-to-stdout behavior is preserved verbatim.
+	var captured bytes.Buffer
+	textSink := io.Writer(stdout)
+	if cfg.inlineJSON != "" {
+		textSink = io.MultiWriter(stdout, &captured)
+	}
+
 	wrote := false
 	_, err = session.Prompt(ctx, cfg.prompt,
 		glue.WithEvents(func(e glue.Event) {
 			switch e.Type {
 			case glue.EventTextDelta:
 				if e.Delta != "" {
-					fmt.Fprint(stdout, e.Delta)
+					fmt.Fprint(textSink, e.Delta)
 					wrote = true
 				}
 			case glue.EventToolStart:
@@ -131,11 +149,24 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		}),
 	)
 	if wrote {
-		fmt.Fprintln(stdout)
+		fmt.Fprintln(textSink)
 	}
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
+	}
+
+	if cfg.inlineJSON != "" {
+		entries := parseInlineComments(captured.String())
+		raw, mErr := json.MarshalIndent(entries, "", "  ")
+		if mErr != nil {
+			fmt.Fprintf(stderr, "marshal inline JSON: %v\n", mErr)
+			return 1
+		}
+		if wErr := os.WriteFile(cfg.inlineJSON, raw, 0o644); wErr != nil {
+			fmt.Fprintf(stderr, "write inline JSON: %v\n", wErr)
+			return 1
+		}
 	}
 	return 0
 }
@@ -152,6 +183,7 @@ func parseFlags(args []string, stderr io.Writer) (config, error) {
 	work := flags.String("work", ".", "working directory (must be inside the Git repo)")
 	maxTurns := flags.Int("max-turns", 16, "loop budget — caps total assistant turns")
 	prompt := flags.String("prompt", "", "override the default review prompt")
+	inlineJSON := flags.String("inline-json", "", "if set, write parsed inline-comment entries to this path as JSON (one array of {path,line,severity,body}); the final markdown still goes to stdout")
 
 	flags.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: glue-review [flags]")
@@ -166,14 +198,15 @@ func parseFlags(args []string, stderr io.Writer) (config, error) {
 	}
 
 	cfg := config{
-		base:     *base,
-		provider: strings.ToLower(strings.TrimSpace(*provider)),
-		model:    *model,
-		id:       *id,
-		store:    *store,
-		work:     *work,
-		maxTurns: *maxTurns,
-		prompt:   *prompt,
+		base:       *base,
+		provider:   strings.ToLower(strings.TrimSpace(*provider)),
+		model:      *model,
+		id:         *id,
+		store:      *store,
+		work:       *work,
+		maxTurns:   *maxTurns,
+		prompt:     *prompt,
+		inlineJSON: *inlineJSON,
 	}
 	if cfg.prompt == "" {
 		cfg.prompt = fmt.Sprintf("Review the current Git branch against base ref %q. Use the tools to gather context, then output the final review only.", cfg.base)

--- a/agents/glue-review/parse.go
+++ b/agents/glue-review/parse.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// InlineComment is one line-level review entry that the calling Action
+// can submit via the GitHub Pull Request Reviews API.
+type InlineComment struct {
+	Path     string `json:"path"`
+	Line     int    `json:"line"`
+	Severity string `json:"severity"`
+	Body     string `json:"body"`
+}
+
+// inlineEntryRE matches a single Issues / Suggestions list entry the
+// system prompt asks for:
+//
+//	- [critical|major|minor] path/to/file.ext:LINE — description
+//
+// We accept a few variants because models are inconsistent:
+//
+//   - Leading `-`, `*`, or `[N]` bullet markers (or none).
+//   - Bold severity (`**[major]**`).
+//   - Separator may be em-dash `—`, hyphen `-`, en-dash `–`, or colon `:`.
+//   - Trailing description may be multi-line; we only capture up to the
+//     next entry start or section header.
+var inlineEntryRE = regexp.MustCompile(
+	`(?m)^[ \t]*(?:[-*]|\d+\.)?[ \t]*` + // optional list marker
+		`(?:\*\*)?\[(critical|major|minor)\](?:\*\*)?[ \t]+` + // severity (optionally bold)
+		"(?:`|\\*\\*)?" + // optional opening backtick OR bold
+		`([^\s:` + "`" + `*]+):(\d+)` + // path:line
+		"(?:`|\\*\\*)?" + // optional closing backtick OR bold
+		`[ \t]*[—–\-:][ \t]*` + // separator
+		`(.+)$`, // description
+)
+
+// parseInlineComments scans a review's Markdown output for entries
+// inside the Issues and Suggestions sections that match the strict
+// `[severity] path:line — body` shape. Entries with `:0` (model
+// signaling "no precise line") and entries in any other section are
+// skipped — they belong in the bulk review body.
+func parseInlineComments(markdown string) []InlineComment {
+	if markdown == "" {
+		return nil
+	}
+	sections := splitSections(markdown)
+	out := []InlineComment{}
+	for _, name := range []string{"Issues", "Suggestions"} {
+		body, ok := sections[name]
+		if !ok {
+			continue
+		}
+		for _, m := range inlineEntryRE.FindAllStringSubmatch(body, -1) {
+			line, err := strconv.Atoi(m[3])
+			if err != nil || line <= 0 {
+				continue
+			}
+			out = append(out, InlineComment{
+				Severity: m[1],
+				Path:     m[2],
+				Line:     line,
+				Body:     strings.TrimSpace(m[4]),
+			})
+		}
+	}
+	return out
+}
+
+// splitSections walks the markdown looking for `## Header` lines and
+// returns each section's body keyed by header text. Headers outside the
+// canonical set (Summary, Issues, Suggestions, Looks good, Open
+// questions) are still captured verbatim — we don't gate on them in
+// case the model deviates.
+func splitSections(markdown string) map[string]string {
+	out := map[string]string{}
+	lines := strings.Split(markdown, "\n")
+	current := ""
+	var buf strings.Builder
+	flush := func() {
+		if current != "" {
+			out[current] = buf.String()
+		}
+		buf.Reset()
+	}
+	for _, line := range lines {
+		if h, ok := matchHeading(line); ok {
+			flush()
+			current = h
+			continue
+		}
+		if current != "" {
+			buf.WriteString(line)
+			buf.WriteByte('\n')
+		}
+	}
+	flush()
+	return out
+}
+
+// matchHeading returns the canonical title (case-preserved, trimmed) if
+// the line is an H2 markdown header, else "", false.
+func matchHeading(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "## ") {
+		return "", false
+	}
+	return strings.TrimSpace(trimmed[3:]), true
+}

--- a/agents/glue-review/parse_test.go
+++ b/agents/glue-review/parse_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseInlineCommentsHappyPath(t *testing.T) {
+	t.Parallel()
+	md := "## Summary\n" +
+		"This branch adds X.\n\n" +
+		"## Issues\n" +
+		"- [critical] main.go:12 — segfault on nil pointer\n" +
+		"- [major] **server/handler.go:42** — leaks file descriptor\n" + // bold path is tolerated
+		"- [minor] `pkg/utils.go:7` — unused import\n\n" + // backticked path
+		"## Suggestions\n" +
+		"- [minor] README.md:5 - explain new flag\n\n" + // hyphen separator
+		"## Looks good\n" +
+		"- [bonus] file.go:1 — should NOT parse, not a real severity\n"
+
+	got := parseInlineComments(md)
+	want := []struct {
+		path string
+		line int
+		sev  string
+	}{
+		{"main.go", 12, "critical"},
+		{"server/handler.go", 42, "major"},
+		{"pkg/utils.go", 7, "minor"},
+		{"README.md", 5, "minor"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d; got=%+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].Path != w.path || got[i].Line != w.line || got[i].Severity != w.sev {
+			t.Errorf("entry %d = %+v, want path=%s line=%d sev=%s", i, got[i], w.path, w.line, w.sev)
+		}
+	}
+}
+
+func TestParseInlineCommentsSkipsZeroLine(t *testing.T) {
+	t.Parallel()
+	md := "## Issues\n- [major] some-file.go:0 — cannot pin line\n"
+	if got := parseInlineComments(md); len(got) != 0 {
+		t.Fatalf("expected zero entries (line=0 is sentinel); got %+v", got)
+	}
+}
+
+func TestParseInlineCommentsIgnoresOtherSections(t *testing.T) {
+	t.Parallel()
+	// Identical-shape entries outside Issues/Suggestions must NOT be parsed.
+	md := "## Open questions\n- [major] foo.go:1 — should not parse\n"
+	if got := parseInlineComments(md); len(got) != 0 {
+		t.Fatalf("expected empty (entry outside Issues/Suggestions); got %+v", got)
+	}
+}
+
+func TestParseInlineCommentsEmptyMarkdown(t *testing.T) {
+	t.Parallel()
+	if got := parseInlineComments(""); len(got) != 0 {
+		t.Fatalf("expected nil/empty for empty input; got %+v", got)
+	}
+}
+
+func TestParseInlineCommentsFreeFormPasses(t *testing.T) {
+	t.Parallel()
+	// Free-form bullets (no `[severity] path:line`) inside Issues should
+	// be silently dropped — they belong in the bulk body.
+	md := "## Issues\n- This is a generic concern with no file reference.\n- [major] real.go:9 — actual entry\n"
+	got := parseInlineComments(md)
+	if len(got) != 1 || got[0].Path != "real.go" || got[0].Line != 9 {
+		t.Fatalf("expected one parsed entry; got %+v", got)
+	}
+}
+
+func TestSplitSections(t *testing.T) {
+	t.Parallel()
+	md := "## Summary\nintro\n\n## Issues\nfirst\n\n## Suggestions\nsecond\n"
+	got := splitSections(md)
+	if got["Summary"] == "" || got["Issues"] == "" || got["Suggestions"] == "" {
+		t.Fatalf("missing sections: %+v", got)
+	}
+	if got["Nonexistent"] != "" {
+		t.Fatalf("unknown section returned non-empty: %q", got["Nonexistent"])
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3b of the productionization roadmap (#70). Inline review comments instead of one bulk sticky.

## Changes

**Agent**:
- Tightened system prompt to require `[severity] path:line — description` shape; `:0` is a sentinel for "no precise line."
- Added `--inline-json <path>` flag. The agent tees its stdout into a buffer, parses Issues/Suggestions, and writes a JSON array of `{path, line, severity, body}` entries. CLI behavior without the flag is unchanged.
- New `parse.go` with a tolerant regex (handles bullet markers, bold/backtick wrappers, em-dash/en-dash/hyphen/colon separators) + 6 unit tests.

**Action**:
- Runs the agent with `--inline-json` to get the structured side channel.
- New step posts a single PR Review via the Reviews API with `{path, line, side: RIGHT, body}` per parsed entry. Severity is folded into each inline body so reviewers see it on the line.
- Re-run dedup: prior bot reviews carrying the v1 marker are dismissed before the new review posts (submitted reviews can't be deleted, only dismissed).
- Falls back to the existing sticky-comment path when the agent produced no parseable entries or when the Reviews API rejects the payload (path:line outside the diff).

## Self-test

This PR will exercise the new path on its own `pull_request` event. If the model produces parseable Issues/Suggestions, you'll see inline annotations on the diff plus a top-level review body. If not, the existing sticky comment shows up instead.

## Acceptance (from #65)

- Agent parses `[severity] path:line` prefixes from its own output.
- Reviews API call lands inline comments on the diff for parseable entries.
- Summary, Open questions, and unparseable entries appear as the bulk-review body.
- Re-running dismisses prior submissions cleanly.
- System prompt tightened to require the structured prefix.
