### PR TITLE
agents/glue-review: provider failover and soft-fail (closes #66)

### DIFF
--- a/.github/workflows/glue-review-comment.yml
+++ b/.github/workflows/glue-review-comment.yml
@@ -78,12 +78,13 @@ jobs:
         uses: ./agents/glue-review
         continue-on-error: true
         with:
-          provider: nvidia
-          model: moonshotai/kimi-k2.6
+          provider: nvidia,openrouter,gemini
           base-ref: ${{ steps.pr.outputs.base_ref }}
           max-turns: '12'
           pr-number: ${{ github.event.issue.number }}
           nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 
       - name: "React :rocket: on success"
         if: steps.review.outputs.exit-code == '0'

--- a/.github/workflows/glue-review.yml
+++ b/.github/workflows/glue-review.yml
@@ -39,16 +39,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Gate on provider key
+      - name: Gate on any provider key
         id: gate
         env:
-          KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NVIDIA_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GEMINI_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          if [ -z "$KEY" ]; then
-            echo "NVIDIA_API_KEY not set (fork PR or missing secret); skipping review."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ -n "$NVIDIA_KEY" ] || [ -n "$OPENROUTER_KEY" ] || [ -n "$GEMINI_KEY" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No provider key set (fork PR or no secrets configured); skipping review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Skip docs-only PRs
@@ -73,8 +75,13 @@ jobs:
         if: steps.gate.outputs.skip == 'false' && steps.scope.outputs.skip == 'false'
         uses: ./agents/glue-review
         with:
-          provider: nvidia
-          model: moonshotai/kimi-k2.6
+          # Failover order: NVIDIA Kimi K2.6 first (strongest free model);
+          # OpenRouter Ling next (deterministic free); Gemini last as a
+          # paid-tier fallback. Each provider is tried only when its key
+          # is set in the env, so missing keys are silent skips.
+          provider: nvidia,openrouter,gemini
           base-ref: ${{ github.event.pull_request.base.ref }}
           max-turns: '12'
           nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

--- a/agents/glue-review/action.yml
+++ b/agents/glue-review/action.yml
@@ -13,8 +13,10 @@ branding:
 inputs:
   provider:
     description: |
-      Provider name: `nvidia`, `openrouter`, or `gemini`. Defaults to
-      `nvidia` for the strongest free model (Kimi K2.6).
+      Provider list. Single name (e.g. `nvidia`) or comma-separated for
+      failover (e.g. `nvidia,openrouter,gemini`). Each provider is tried
+      in order; the first whose API key is set in env AND whose call
+      succeeds wins. Default `nvidia` keeps single-provider behavior.
     required: false
     default: nvidia
   model:

--- a/agents/glue-review/failover_test.go
+++ b/agents/glue-review/failover_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveProvidersSingle(t *testing.T) {
+	t.Parallel()
+	got, err := resolveProviders("nvidia")
+	if err != nil {
+		t.Fatalf("resolveProviders: %v", err)
+	}
+	if len(got) != 1 || got[0].name != "nvidia" || got[0].envName != "NVIDIA_API_KEY" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestResolveProvidersList(t *testing.T) {
+	t.Parallel()
+	got, err := resolveProviders("nvidia, openrouter ,gemini")
+	if err != nil {
+		t.Fatalf("resolveProviders: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(got), got)
+	}
+	names := []string{got[0].name, got[1].name, got[2].name}
+	want := []string{"nvidia", "openrouter", "gemini"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, names[i], want[i])
+		}
+	}
+}
+
+func TestResolveProvidersDefault(t *testing.T) {
+	t.Parallel()
+	got, _ := resolveProviders("")
+	if len(got) != 1 || got[0].name != "nvidia" {
+		t.Fatalf("default should be 'nvidia', got %+v", got)
+	}
+}
+
+func TestResolveProvidersRejectsUnknown(t *testing.T) {
+	t.Parallel()
+	_, err := resolveProviders("nvidia,bogus")
+	if err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("expected unknown-provider error, got %v", err)
+	}
+}
+
+func TestResolveProvidersTolerantOfBlanks(t *testing.T) {
+	t.Parallel()
+	got, err := resolveProviders("nvidia,,openrouter,")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %+v", got)
+	}
+}
+
+func TestProviderKeyAvailableReadsEnv(t *testing.T) {
+	t.Setenv("NVIDIA_API_KEY", "k")
+	t.Setenv("GEMINI_API_KEY", "")
+	if !providerKeyAvailable("nvidia") {
+		t.Fatal("nvidia should be available with key set")
+	}
+	if providerKeyAvailable("gemini") {
+		t.Fatal("gemini should not be available with empty key")
+	}
+	if providerKeyAvailable("bogus") {
+		t.Fatal("unknown provider must report unavailable")
+	}
+}

--- a/agents/glue-review/main.go
+++ b/agents/glue-review/main.go
@@ -98,66 +98,67 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	provider, defaultModel, err := newProvider(cfg.provider)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	model := cfg.model
-	if model == "" {
-		model = defaultModel
-	}
-
-	agent := glue.NewAgent(glue.AgentOptions{
-		Provider:     provider,
-		Model:        model,
-		Tools:        reviewTools(cfg.work),
-		SystemPrompt: systemPrompt,
-		Store:        filestore.New(cfg.store),
-		WorkDir:      cfg.work,
-		MaxTurns:     cfg.maxTurns,
-	})
-	session, err := agent.Session(ctx, cfg.id)
+	providers, err := resolveProviders(cfg.provider)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
 
-	// When --inline-json is set we tee stdout into a buffer so we can
-	// parse the final review without re-running anything. The existing
-	// streaming-to-stdout behavior is preserved verbatim.
-	var captured bytes.Buffer
-	textSink := io.Writer(stdout)
-	if cfg.inlineJSON != "" {
-		textSink = io.MultiWriter(stdout, &captured)
-	}
-
-	wrote := false
-	_, err = session.Prompt(ctx, cfg.prompt,
-		glue.WithEvents(func(e glue.Event) {
-			switch e.Type {
-			case glue.EventTextDelta:
-				if e.Delta != "" {
-					fmt.Fprint(textSink, e.Delta)
-					wrote = true
-				}
-			case glue.EventToolStart:
-				if e.ToolName != "" {
-					fmt.Fprintf(stderr, "[tool] %s\n", e.ToolName)
-				}
-			}
-		}),
+	// Try each configured provider in order. The first one whose key is
+	// available AND whose Prompt() succeeds wins. We hold all streamed
+	// text in a per-attempt buffer so a half-streamed failed attempt
+	// doesn't pollute stdout.
+	var (
+		successCaptured bytes.Buffer
+		attemptErrors   []string
+		succeeded       bool
+		usedProvider    string
 	)
-	if wrote {
-		fmt.Fprintln(textSink)
+	for i, p := range providers {
+		// Probe the env var the provider package reads. Without this, an
+		// upstream missing-key error would only surface mid-stream and
+		// we'd burn time on a doomed attempt.
+		if !providerKeyAvailable(p.name) {
+			fmt.Fprintf(stderr, "[failover] skip %s: %s not set in env\n", p.name, p.envName)
+			continue
+		}
+		fmt.Fprintf(stderr, "[failover] attempt %d/%d: provider=%s\n", i+1, len(providers), p.name)
+
+		var buf bytes.Buffer
+		err := runOnce(ctx, cfg, p, &buf, stderr)
+		if err == nil {
+			succeeded = true
+			successCaptured = buf
+			usedProvider = p.name
+			break
+		}
+		attemptErrors = append(attemptErrors, fmt.Sprintf("%s: %v", p.name, err))
+		fmt.Fprintf(stderr, "[failover] %s failed: %v\n", p.name, err)
 	}
-	if err != nil {
-		fmt.Fprintln(stderr, err)
+
+	if !succeeded {
+		if len(attemptErrors) == 0 {
+			fmt.Fprintln(stderr, "no provider had its API key set; aborting")
+		} else {
+			fmt.Fprintln(stderr, "all providers failed:")
+			for _, e := range attemptErrors {
+				fmt.Fprintf(stderr, "  - %s\n", e)
+			}
+		}
 		return 1
+	}
+	fmt.Fprintf(stderr, "[failover] succeeded with %s\n", usedProvider)
+
+	// Stream the captured text through to stdout once.
+	if successCaptured.Len() > 0 {
+		fmt.Fprint(stdout, successCaptured.String())
+		if !strings.HasSuffix(successCaptured.String(), "\n") {
+			fmt.Fprintln(stdout)
+		}
 	}
 
 	if cfg.inlineJSON != "" {
-		entries := parseInlineComments(captured.String())
+		entries := parseInlineComments(successCaptured.String())
 		raw, mErr := json.MarshalIndent(entries, "", "  ")
 		if mErr != nil {
 			fmt.Fprintf(stderr, "marshal inline JSON: %v\n", mErr)
@@ -171,12 +172,59 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+// runOnce executes one Prompt against a specific provider, buffering
+// streamed text into `into`. Returning a non-nil error tells the caller
+// to drop the buffer and move on to the next provider.
+func runOnce(ctx context.Context, cfg config, p providerEntry, into io.Writer, stderr io.Writer) error {
+	prov, defaultModel, err := newProvider(p.name)
+	if err != nil {
+		return err
+	}
+	model := cfg.model
+	if model == "" {
+		model = defaultModel
+	}
+
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider:     prov,
+		Model:        model,
+		Tools:        reviewTools(cfg.work),
+		SystemPrompt: systemPrompt,
+		Store:        filestore.New(cfg.store),
+		WorkDir:      cfg.work,
+		MaxTurns:     cfg.maxTurns,
+	})
+	// Per-attempt session id so a failed attempt's transcript does not
+	// poison the next attempt's session.
+	sessionID := fmt.Sprintf("%s-%s", cfg.id, p.name)
+	session, err := agent.Session(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+
+	_, err = session.Prompt(ctx, cfg.prompt,
+		glue.WithEvents(func(e glue.Event) {
+			switch e.Type {
+			case glue.EventTextDelta:
+				if e.Delta != "" {
+					fmt.Fprint(into, e.Delta)
+				}
+			case glue.EventToolStart:
+				if e.ToolName != "" {
+					fmt.Fprintf(stderr, "[tool] %s\n", e.ToolName)
+				}
+			}
+		}),
+	)
+	return err
+}
+
 func parseFlags(args []string, stderr io.Writer) (config, error) {
 	flags := flag.NewFlagSet("glue-review", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 
 	base := flags.String("base", "main", "base branch / ref to diff against")
-	provider := flags.String("provider", "nvidia", "provider: nvidia, openrouter, or gemini")
+	provider := flags.String("provider", "nvidia", "provider list (single name or comma-separated for failover, e.g. 'nvidia,openrouter,gemini'); first provider with its API key in env wins")
 	model := flags.String("model", "", "model id (defaults vary by provider)")
 	id := flags.String("id", "glue-review", "session id (file-backed sessions key off this)")
 	store := flags.String("store", ".glue/review-sessions", "session store directory")
@@ -199,7 +247,7 @@ func parseFlags(args []string, stderr io.Writer) (config, error) {
 
 	cfg := config{
 		base:       *base,
-		provider:   strings.ToLower(strings.TrimSpace(*provider)),
+		provider:   strings.TrimSpace(*provider),
 		model:      *model,
 		id:         *id,
 		store:      *store,
@@ -225,4 +273,61 @@ func newProvider(name string) (glue.Provider, string, error) {
 	default:
 		return nil, "", fmt.Errorf("unknown provider %q (want nvidia, openrouter, or gemini)", name)
 	}
+}
+
+// providerEntry pairs a provider name with the env var the provider
+// package reads when no explicit APIKey is supplied. We probe the env
+// var before constructing the provider so missing-key skips are
+// instantaneous instead of mid-stream errors.
+type providerEntry struct {
+	name    string
+	envName string
+}
+
+// resolveProviders parses the comma-separated --provider list into the
+// ordered try list. Single-provider users (`--provider nvidia`) and
+// failover users (`--provider nvidia,openrouter,gemini`) share the
+// same flag — back-compat preserved.
+func resolveProviders(raw string) ([]providerEntry, error) {
+	if strings.TrimSpace(raw) == "" {
+		raw = "nvidia"
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]providerEntry, 0, len(parts))
+	for _, name := range parts {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name == "" {
+			continue
+		}
+		env, ok := envForProvider(name)
+		if !ok {
+			return nil, fmt.Errorf("unknown provider %q in --provider list", name)
+		}
+		out = append(out, providerEntry{name: name, envName: env})
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no providers configured")
+	}
+	return out, nil
+}
+
+func envForProvider(name string) (string, bool) {
+	switch name {
+	case "nvidia":
+		return "NVIDIA_API_KEY", true
+	case "openrouter":
+		return "OPENROUTER_API_KEY", true
+	case "gemini":
+		return "GEMINI_API_KEY", true
+	default:
+		return "", false
+	}
+}
+
+func providerKeyAvailable(name string) bool {
+	env, ok := envForProvider(name)
+	if !ok {
+		return false
+	}
+	return strings.TrimSpace(os.Getenv(env)) != ""
 }


### PR DESCRIPTION
## Summary

Phase 3c of the productionization roadmap (#70). When NVIDIA 502s or rate-limits, the workflow now falls through to OpenRouter, then Gemini, before the soft-fail comment kicks in.

## Changes

**Agent (`agents/glue-review`)**:
- `--provider` now accepts a comma-separated list. Single names still work (back-compat); the default is unchanged.
- `resolveProviders` parses the list and rejects unknown names before any agent is constructed.
- Each attempt uses a per-attempt session id (`<id>-<provider>`) so a failed transcript doesn't poison the next attempt.
- Streamed text is buffered per attempt; only the successful attempt's buffer reaches stdout. Failed attempts never surface as half-baked review output.
- Stderr emits structured `[failover]` lines for log readability.
- When all configured providers fail, stderr lists per-provider errors and the binary exits 1 — the Action's existing soft-fail comment path takes over.

**Workflows**:
- Both glue-review.yml workflows pass `provider: nvidia,openrouter,gemini` and forward all three secret inputs. Missing secrets are silent skips at the agent level.

**Tests**: 5 new unit tests for list parsing and env-var key probing; existing tests continue to pass.

## Self-test

This PR exercises the new code on its own `pull_request` event. We expect NVIDIA to win (its key is set in repo secrets); the failover path is exercised whenever NVIDIA upstream errors, which we've already seen happen organically.

## Acceptance (from #66)

- `--provider <list>` flag in `agents/glue-review` tries each in order.
- Workflow / Action passes failover list explicitly: `nvidia,openrouter,gemini`.
- Soft-fail comment renders with collapsed per-provider error trail (existing path; not changed by this PR).
