### PR TITLE
agents/glue-review: paths/paths-ignore + custom-prompt inputs (closes #79)

### DIFF
--- a/agents/glue-review/README.md
+++ b/agents/glue-review/README.md
@@ -87,6 +87,26 @@ swap code into the run.
 This repo runs both workflows. See [.github/workflows/glue-review.yml](../../.github/workflows/glue-review.yml)
 and [.github/workflows/glue-review-comment.yml](../../.github/workflows/glue-review-comment.yml).
 
+## Path filters
+
+Restrict the diff the agent sees with Git pathspec globs:
+
+- CLI: `--paths "src/**,*.go" --paths-ignore "vendor/**,*.gen.go"`
+- Action inputs: `paths` / `paths-ignore` (comma-separated).
+
+When `paths` is empty, every changed file is in scope. `paths-ignore`
+applies after `paths`. Excludes-only is fine — the agent injects an
+implicit `*` include so "everything except testdata" works as expected.
+
+## Custom prompts
+
+- `--prompt "..."` (CLI) / `prompt:` (Action input) replaces the user
+  message sent to the agent. Use for one-off focused runs ("only check
+  for SQL injection", "only review the migration files").
+- `--prompt-version v1` selects which built-in system prompt to load.
+  Only `v1` ships today; the version is embedded in sticky comment
+  markers so future prompt-shape revisions don't mangle existing comments.
+
 ## Sensitive-file blocklist
 
 `read_file` refuses to open paths that match any of a built-in

--- a/agents/glue-review/action.yml
+++ b/agents/glue-review/action.yml
@@ -59,6 +59,33 @@ inputs:
     description: Go toolchain version for `setup-go`.
     required: false
     default: stable
+  paths:
+    description: |
+      Comma-separated Git pathspec globs. Only files matching at least
+      one pattern are reviewed. When empty, all changed files are in
+      scope. Example: `src/**,*.go`.
+    required: false
+    default: ''
+  paths-ignore:
+    description: |
+      Comma-separated Git pathspec globs to exclude from review;
+      applied after `paths`. Example: `vendor/**,*.gen.go,testdata/**`.
+    required: false
+    default: ''
+  prompt:
+    description: |
+      User prompt to send to the agent. Overrides the built-in
+      "review the current branch" prompt — useful for one-off focused
+      reviews ("only check for SQL injection", etc.).
+    required: false
+    default: ''
+  prompt-version:
+    description: |
+      System-prompt version to load (the canonical reviewer
+      instructions). Only `v1` ships today; future revisions will be
+      additive.
+    required: false
+    default: ''
   extra-blocked-paths:
     description: |
       Comma-separated path patterns the read_file tool will refuse to
@@ -143,6 +170,18 @@ runs:
         fi
         if [ -n "${{ inputs.extra-blocked-paths }}" ]; then
           args+=(--blocked-paths "${{ inputs.extra-blocked-paths }}")
+        fi
+        if [ -n "${{ inputs.paths }}" ]; then
+          args+=(--paths "${{ inputs.paths }}")
+        fi
+        if [ -n "${{ inputs.paths-ignore }}" ]; then
+          args+=(--paths-ignore "${{ inputs.paths-ignore }}")
+        fi
+        if [ -n "${{ inputs.prompt }}" ]; then
+          args+=(--prompt "${{ inputs.prompt }}")
+        fi
+        if [ -n "${{ inputs.prompt-version }}" ]; then
+          args+=(--prompt-version "${{ inputs.prompt-version }}")
         fi
 
         "$bin" "${args[@]}" > "$review_path" 2> "$err_path"

--- a/agents/glue-review/main.go
+++ b/agents/glue-review/main.go
@@ -54,6 +54,8 @@ type config struct {
 	inlineJSON    string
 	promptVersion string
 	blockedPaths  []string
+	paths         []string
+	pathsIgnore   []string
 }
 
 func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -161,7 +163,7 @@ func runOnce(ctx context.Context, cfg config, p providerEntry, into io.Writer, s
 	agent := glue.NewAgent(glue.AgentOptions{
 		Provider:     prov,
 		Model:        model,
-		Tools:        reviewTools(cfg.work, cfg.blockedPaths),
+		Tools:        reviewTools(cfg.work, cfg.blockedPaths, cfg.paths, cfg.pathsIgnore),
 		SystemPrompt: systemPrompt,
 		Store:        filestore.New(cfg.store),
 		WorkDir:      cfg.work,
@@ -207,6 +209,8 @@ func parseFlags(args []string, stderr io.Writer) (config, error) {
 	inlineJSON := flags.String("inline-json", "", "if set, write parsed inline-comment entries to this path as JSON (one array of {path,line,severity,body}); the final markdown still goes to stdout")
 	promptVersion := flags.String("prompt-version", defaultPromptVersion, fmt.Sprintf("system-prompt version to load (available: %s)", strings.Join(availablePromptVersions(), ", ")))
 	blockedPaths := flags.String("blocked-paths", "", "comma-separated extra path patterns the read_file tool will refuse to open (extends the built-in blocklist of secret-shaped files; cannot subtract defaults)")
+	paths := flags.String("paths", "", "comma-separated Git pathspec globs; only files matching at least one pattern are reviewed. When empty, all changed files are in scope.")
+	pathsIgnore := flags.String("paths-ignore", "", "comma-separated Git pathspec globs to exclude from review; applied after --paths")
 
 	flags.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: glue-review [flags]")
@@ -232,6 +236,8 @@ func parseFlags(args []string, stderr io.Writer) (config, error) {
 		inlineJSON:    *inlineJSON,
 		promptVersion: strings.TrimSpace(*promptVersion),
 		blockedPaths:  splitCommaList(*blockedPaths),
+		paths:         splitCommaList(*paths),
+		pathsIgnore:   splitCommaList(*pathsIgnore),
 	}
 	if cfg.prompt == "" {
 		cfg.prompt = fmt.Sprintf("Review the current Git branch against base ref %q. Use the tools to gather context, then output the final review only.", cfg.base)

--- a/agents/glue-review/main_test.go
+++ b/agents/glue-review/main_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestReviewToolsRegistered(t *testing.T) {
 	t.Parallel()
-	tools := reviewTools(".", nil)
+	tools := reviewTools(".", nil, nil, nil)
 	wantNames := []string{"git_diff_branch", "git_log_branch", "read_file"}
 	if len(tools) != len(wantNames) {
 		t.Fatalf("got %d tools, want %d", len(tools), len(wantNames))
@@ -138,7 +138,7 @@ func TestGitToolsAgainstFakeRepo(t *testing.T) {
 
 	ctx := context.Background()
 
-	diff := gitDiffBranchTool(repo)
+	diff := gitDiffBranchTool(repo, nil)
 	res, err := diff.Execute(ctx, glue.ToolCall{Name: diff.Name, Arguments: json.RawMessage(`{}`)})
 	if err != nil {
 		t.Fatalf("diff Execute: %v", err)

--- a/agents/glue-review/pathspec_test.go
+++ b/agents/glue-review/pathspec_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestBuildPathspecEmpty(t *testing.T) {
+	t.Parallel()
+	if got := buildPathspec(nil, nil); got != nil {
+		t.Fatalf("expected nil for no filters, got %+v", got)
+	}
+	if got := buildPathspec([]string{}, []string{}); got != nil {
+		t.Fatalf("expected nil for empty slices, got %+v", got)
+	}
+}
+
+func TestBuildPathspecIncludesOnly(t *testing.T) {
+	t.Parallel()
+	got := buildPathspec([]string{"*.go", "cmd/**"}, nil)
+	want := []string{"*.go", "cmd/**"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestBuildPathspecExcludesOnly(t *testing.T) {
+	t.Parallel()
+	// Excludes-only must inject a `*` catch-all include so Git's
+	// pathspec semantics produce the intuitive "everything except X".
+	got := buildPathspec(nil, []string{"vendor/**", "*.gen.go"})
+	want := []string{"*", ":(exclude)vendor/**", ":(exclude)*.gen.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestBuildPathspecBothLists(t *testing.T) {
+	t.Parallel()
+	got := buildPathspec([]string{"src/**"}, []string{"src/testdata/**"})
+	want := []string{"src/**", ":(exclude)src/testdata/**"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestGitDiffBranchToolHonorsPathspec drives the diff tool against a
+// real git repo with two changed files and asserts the pathspec
+// actually narrows the output. This catches regressions where the
+// pathspec arg list gets fed in wrong order.
+func TestGitDiffBranchToolHonorsPathspec(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	gitInit(t, repo)
+	writeFile(t, repo, "main.go", "package main\nfunc main(){}\n")
+	writeFile(t, repo, "secret/notes.md", "TODO: ship faster\n")
+	gitCommit(t, repo, "two files", "main.go", "secret/notes.md")
+
+	ctx := context.Background()
+
+	// 1) No pathspec: both files appear in diff.
+	tool := gitDiffBranchTool(repo, nil)
+	res, err := tool.Execute(ctx, glue.ToolCall{Name: tool.Name, Arguments: json.RawMessage(`{}`)})
+	if err != nil {
+		t.Fatalf("baseline diff: %v", err)
+	}
+	body := res.Content[0].Text
+	if !strings.Contains(body, "main.go") || !strings.Contains(body, "secret/notes.md") {
+		t.Fatalf("baseline diff missing files: %s", body)
+	}
+
+	// 2) Include-only: just .go files.
+	toolGo := gitDiffBranchTool(repo, buildPathspec([]string{"*.go"}, nil))
+	res, _ = toolGo.Execute(ctx, glue.ToolCall{Name: toolGo.Name, Arguments: json.RawMessage(`{}`)})
+	body = res.Content[0].Text
+	if !strings.Contains(body, "main.go") {
+		t.Errorf("include-only: main.go should appear: %s", body)
+	}
+	if strings.Contains(body, "secret/notes.md") {
+		t.Errorf("include-only: secret/notes.md should NOT appear: %s", body)
+	}
+
+	// 3) Exclude-only: skip everything under secret/.
+	toolEx := gitDiffBranchTool(repo, buildPathspec(nil, []string{"secret/*"}))
+	res, _ = toolEx.Execute(ctx, glue.ToolCall{Name: toolEx.Name, Arguments: json.RawMessage(`{}`)})
+	body = res.Content[0].Text
+	if !strings.Contains(body, "main.go") {
+		t.Errorf("exclude-only: main.go should appear: %s", body)
+	}
+	if strings.Contains(body, "secret/notes.md") {
+		t.Errorf("exclude-only: secret/notes.md should NOT appear: %s", body)
+	}
+}

--- a/agents/glue-review/tools.go
+++ b/agents/glue-review/tools.go
@@ -30,13 +30,41 @@ import (
 //
 // The git tools shell out to the system `git` binary so we don't pull
 // in a Git library just for `diff` / `log`.
-func reviewTools(workDir string, extraBlocked []string) []glue.Tool {
+func reviewTools(workDir string, extraBlocked, paths, pathsIgnore []string) []glue.Tool {
 	blocked := mergeBlocklist(extraBlocked)
+	pathspec := buildPathspec(paths, pathsIgnore)
 	return []glue.Tool{
-		gitDiffBranchTool(workDir),
+		gitDiffBranchTool(workDir, pathspec),
 		gitLogBranchTool(workDir),
 		readFileTool(workDir, blocked),
 	}
+}
+
+// buildPathspec converts include / exclude glob lists into Git pathspec
+// arguments. The Git CLI accepts:
+//
+//   - bare patterns as include filters (e.g. `*.go`, `cmd/...`)
+//   - `:(exclude)pattern` or `:!pattern` as exclude filters
+//
+// Excludes only take effect after at least one include pattern is
+// present, so when callers pass only excludes we add `*` as an explicit
+// catch-all include — matching the intuitive "review everything except X"
+// semantics.
+func buildPathspec(paths, pathsIgnore []string) []string {
+	if len(paths) == 0 && len(pathsIgnore) == 0 {
+		return nil
+	}
+	out := []string{}
+	for _, p := range paths {
+		out = append(out, p)
+	}
+	if len(out) == 0 && len(pathsIgnore) > 0 {
+		out = append(out, "*")
+	}
+	for _, p := range pathsIgnore {
+		out = append(out, ":(exclude)"+p)
+	}
+	return out
 }
 
 const (
@@ -45,11 +73,11 @@ const (
 	defaultReadMaxBytes = 80 * 1024
 )
 
-func gitDiffBranchTool(workDir string) glue.Tool {
+func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
 	return glue.Tool{
 		ToolSpec: glue.ToolSpec{
 			Name:        "git_diff_branch",
-			Description: "Show the diff of the current branch versus a base ref (default 'main'). Includes file additions, deletions, and modifications. Use this first to scope the review.",
+			Description: "Show the diff of the current branch versus a base ref (default 'main'). Includes file additions, deletions, and modifications. The diff may be pre-filtered by deployment-supplied path globs — only files in scope appear. Use this first to scope the review.",
 			Parameters: json.RawMessage(`{
   "type": "object",
   "properties": {
@@ -74,7 +102,12 @@ func gitDiffBranchTool(workDir string) glue.Tool {
 			if max <= 0 {
 				max = defaultDiffMaxBytes
 			}
-			out, err := runGit(ctx, workDir, "diff", "--no-color", base+"...HEAD")
+			gitArgs := []string{"diff", "--no-color", base + "...HEAD"}
+			if len(pathspec) > 0 {
+				gitArgs = append(gitArgs, "--")
+				gitArgs = append(gitArgs, pathspec...)
+			}
+			out, err := runGit(ctx, workDir, gitArgs...)
 			if err != nil {
 				return errorResult(err), nil
 			}


### PR DESCRIPTION
## Summary

Second of four 1.0 blockers. Adds Action inputs `paths`, `paths-ignore`, `prompt`, `prompt-version`, all mirrored as CLI flags. Path filters apply at the `git diff` source, so the model never sees out-of-scope files.

## Inputs

| Input | What it does |
|---|---|
| `paths` | Comma-separated Git pathspec globs; only matches are reviewed. |
| `paths-ignore` | Comma-separated globs excluded from review; applied after `paths`. |
| `prompt` | Caller's user message; replaces the default "review the branch" prompt. |
| `prompt-version` | System-prompt version selector; previously only a CLI flag. |

## Pathspec construction

`buildPathspec(paths, pathsIgnore)` translates the two lists into Git pathspec arguments. Excludes-only injects an implicit `*` include so "everything except testdata" produces the intuitive result — Git only honors excludes after at least one include is present.

## Test plan

- [x] 4 unit tests for `buildPathspec` (empty / includes / excludes / both).
- [x] `TestGitDiffBranchToolHonorsPathspec` creates a real git repo with two changed files and asserts the diff narrows correctly under baseline, include-only, and exclude-only configurations.
- [x] Existing tests + fixture replays unchanged.

🤖 Generated with Claude Code
