### PR TITLE
agents/glue-review: validate inline-comment citations against the diff (closes #80)

### DIFF
--- a/agents/glue-review/README.md
+++ b/agents/glue-review/README.md
@@ -107,6 +107,19 @@ implicit `*` include so "everything except testdata" works as expected.
   Only `v1` ships today; the version is embedded in sticky comment
   markers so future prompt-shape revisions don't mangle existing comments.
 
+## Citation validation
+
+After the model emits its review, glue-review re-fetches the diff and
+validates each parsed `[severity] path:line` citation against the new
+side of the diff. Entries pointing at files not in the diff, or at line
+numbers outside any added/context hunk, are dropped and logged to
+stderr; they never reach the inline review on the PR.
+
+This protects against the most common LLM failure mode for code review:
+fabricating a plausibly-shaped file:line citation that doesn't exist in
+the change. The bulk markdown body is left as-is — citation drops only
+affect inline annotations, where a wrong location is a hard UX failure.
+
 ## Sensitive-file blocklist
 
 `read_file` refuses to open paths that match any of a built-in

--- a/agents/glue-review/main.go
+++ b/agents/glue-review/main.go
@@ -129,6 +129,25 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 
 	if cfg.inlineJSON != "" {
 		entries := parseInlineComments(successCaptured.String())
+		// Citation validation: re-fetch the diff once and drop any
+		// inline comments whose path:line is not reachable on the new
+		// side. Defends against the model fabricating plausibly-shaped
+		// file:line citations — a real failure mode we observed with
+		// Kimi K2.6 on PR #72. Validation is best-effort: a diff parse
+		// error degrades to "skip validation" rather than failing the
+		// whole run, so a flaky git invocation cannot red the workflow.
+		if diff, dErr := fetchValidationDiff(ctx, cfg); dErr == nil {
+			lineMap := parseDiffLineMap(diff)
+			kept, dropped := validateInlineComments(entries, lineMap)
+			if len(dropped) > 0 {
+				fmt.Fprintf(stderr, "[validate] dropping %d/%d inline comments with unverifiable file:line citations\n",
+					len(dropped), len(entries))
+				fmt.Fprint(stderr, describeDropped(dropped, lineMap))
+			}
+			entries = kept
+		} else {
+			fmt.Fprintf(stderr, "[validate] skipped: %v\n", dErr)
+		}
 		raw, mErr := json.MarshalIndent(entries, "", "  ")
 		if mErr != nil {
 			fmt.Fprintf(stderr, "marshal inline JSON: %v\n", mErr)
@@ -140,6 +159,24 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+// fetchValidationDiff re-runs the same `git diff` the agent saw, so
+// the validation step can match inline comments against the same set
+// of new-side line numbers the model was looking at. Honors --paths
+// and --paths-ignore so out-of-scope files are excluded from
+// validation as well as from the agent's input.
+func fetchValidationDiff(ctx context.Context, cfg config) (string, error) {
+	// cfg.base may already include `origin/` (CI passes it that way) or
+	// be a bare branch name (local dev). Use it verbatim — Git resolves
+	// either form against `HEAD`.
+	gitArgs := []string{"diff", "--no-color", cfg.base + "...HEAD"}
+	pathspec := buildPathspec(cfg.paths, cfg.pathsIgnore)
+	if len(pathspec) > 0 {
+		gitArgs = append(gitArgs, "--")
+		gitArgs = append(gitArgs, pathspec...)
+	}
+	return runGit(ctx, cfg.work, gitArgs...)
 }
 
 // runOnce executes one Prompt against a specific provider, buffering

--- a/agents/glue-review/validate.go
+++ b/agents/glue-review/validate.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// diffLineMap records, per file path, the set of line numbers on the
+// NEW (post-change) side that are part of the diff — i.e., either
+// added (`+`) or context (the lines a model could reasonably reference
+// when explaining a change). Pure removals are intentionally excluded
+// from the new side: there is no new-side line number to point at.
+//
+// The map is built once from the unified diff string and consulted by
+// validateInlineComments to drop fabricated `path:line` citations.
+type diffLineMap map[string]map[int]bool
+
+// parseDiffLineMap walks a `git diff --no-color` output and records
+// every (file, new-side line) pair the diff makes available for inline
+// commenting. The parser is intentionally tolerant: malformed hunks
+// are skipped rather than failing the run, since a diff parse error
+// post-hoc should never red the review.
+//
+// File detection uses the `+++ b/<path>` line that follows each
+// `--- a/<path>` pair. Hunks are identified by `@@ -a,b +c,d @@`.
+// Within a hunk:
+//   - `+` lines advance the new-side counter and are recorded.
+//   - ` ` (context) lines advance the new-side counter and are recorded.
+//   - `-` lines do NOT advance the new-side counter and are not recorded.
+func parseDiffLineMap(diff string) diffLineMap {
+	out := diffLineMap{}
+	scanner := bufio.NewScanner(strings.NewReader(diff))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var currentPath string
+	var newLine int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "+++ "):
+			// Format: `+++ b/<path>` (or `+++ /dev/null` for deletions).
+			rest := strings.TrimPrefix(line, "+++ ")
+			rest = strings.TrimSpace(rest)
+			if rest == "/dev/null" {
+				currentPath = ""
+				continue
+			}
+			currentPath = strings.TrimPrefix(rest, "b/")
+		case strings.HasPrefix(line, "@@ "):
+			// Format: `@@ -a,b +c,d @@ optional context`. We only need c.
+			start, ok := parseHunkNewStart(line)
+			if !ok {
+				continue
+			}
+			newLine = start
+		case currentPath != "" && strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++"):
+			recordLine(out, currentPath, newLine)
+			newLine++
+		case currentPath != "" && strings.HasPrefix(line, " "):
+			recordLine(out, currentPath, newLine)
+			newLine++
+		case currentPath != "" && strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---"):
+			// Removal — does NOT consume a new-side line.
+			continue
+		}
+	}
+	return out
+}
+
+func recordLine(m diffLineMap, path string, line int) {
+	if line <= 0 {
+		return
+	}
+	set, ok := m[path]
+	if !ok {
+		set = map[int]bool{}
+		m[path] = set
+	}
+	set[line] = true
+}
+
+// parseHunkNewStart pulls `c` out of `@@ -a,b +c,d @@ ...`. Returns
+// (start, ok). For single-line hunks (`+c` instead of `+c,d`), `,d`
+// is absent — handle both.
+func parseHunkNewStart(header string) (int, bool) {
+	plus := strings.Index(header, "+")
+	if plus < 0 {
+		return 0, false
+	}
+	rest := header[plus+1:]
+	end := strings.IndexAny(rest, " ,")
+	if end < 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
+}
+
+// validateInlineComments splits inline-comment entries into those
+// whose `path:line` is reachable on the new side of the diff and
+// those that are not. Callers should write the kept set into the JSON
+// payload and log the dropped set to stderr so workflow logs surface
+// what the model fabricated.
+func validateInlineComments(comments []InlineComment, lineMap diffLineMap) (kept, dropped []InlineComment) {
+	if len(comments) == 0 {
+		return nil, nil
+	}
+	for _, c := range comments {
+		set, ok := lineMap[c.Path]
+		if !ok {
+			dropped = append(dropped, c)
+			continue
+		}
+		if !set[c.Line] {
+			dropped = append(dropped, c)
+			continue
+		}
+		kept = append(kept, c)
+	}
+	return kept, dropped
+}
+
+// describeDropped returns a one-line-per-entry log of dropped inline
+// comments, suitable for writing to stderr after a validation pass.
+func describeDropped(dropped []InlineComment, lineMap diffLineMap) string {
+	if len(dropped) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range dropped {
+		set, fileInDiff := lineMap[c.Path]
+		reason := "path not in diff"
+		if fileInDiff {
+			reason = fmt.Sprintf("line %d not on new side of diff (file has %d added/context lines)", c.Line, len(set))
+		}
+		fmt.Fprintf(&b, "[validate] dropped [%s] %s:%d — %s (%s)\n",
+			c.Severity, c.Path, c.Line, reason, snippet(c.Body, 80))
+	}
+	return b.String()
+}
+
+func snippet(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/agents/glue-review/validate_test.go
+++ b/agents/glue-review/validate_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleDiff = `diff --git a/main.go b/main.go
+index e69de29..0123456 100644
+--- a/main.go
++++ b/main.go
+@@ -0,0 +1,5 @@
++package main
++
++func main() {
++	panic("todo")
++}
+diff --git a/util.go b/util.go
+index 1111111..2222222 100644
+--- a/util.go
++++ b/util.go
+@@ -10,6 +10,8 @@ func Hello() string {
+ 	return "hi"
+ }
+
++func Bye() string {
++	return "bye"
++}
+ func unchanged() {}
+ // some old line
+-// removed line
+diff --git a/dropped.go b/dropped.go
+deleted file mode 100644
+index 3333333..0000000
+--- a/dropped.go
++++ /dev/null
+@@ -1,3 +0,0 @@
+-package main
+-
+-func gone() {}
+`
+
+func TestParseDiffLineMapAddedFile(t *testing.T) {
+	t.Parallel()
+	m := parseDiffLineMap(sampleDiff)
+
+	mainLines, ok := m["main.go"]
+	if !ok {
+		t.Fatalf("main.go missing from line map: %+v", m)
+	}
+	for line := 1; line <= 5; line++ {
+		if !mainLines[line] {
+			t.Errorf("main.go line %d should be in map", line)
+		}
+	}
+	if mainLines[6] {
+		t.Errorf("main.go line 6 should NOT be in map (file is 5 lines)")
+	}
+}
+
+func TestParseDiffLineMapModifiedFile(t *testing.T) {
+	t.Parallel()
+	m := parseDiffLineMap(sampleDiff)
+
+	utilLines, ok := m["util.go"]
+	if !ok {
+		t.Fatalf("util.go missing: %+v", m)
+	}
+	// Hunk starts at +10. The body contains 7 new-side advancing lines:
+	// 2 context, 3 added (the new func), 2 context. Removals don't count.
+	expectInMap := []int{10, 11, 12, 13, 14, 15, 16}
+	for _, line := range expectInMap {
+		if !utilLines[line] {
+			t.Errorf("util.go: expected line %d in map (have %+v)", line, utilLines)
+		}
+	}
+}
+
+func TestParseDiffLineMapSkipsDeletedFile(t *testing.T) {
+	t.Parallel()
+	m := parseDiffLineMap(sampleDiff)
+	if _, ok := m["dropped.go"]; ok {
+		t.Errorf("dropped.go should not appear in new-side line map (deleted): %+v", m["dropped.go"])
+	}
+}
+
+func TestValidateInlineCommentsKeepsValid(t *testing.T) {
+	t.Parallel()
+	m := parseDiffLineMap(sampleDiff)
+	comments := []InlineComment{
+		{Path: "main.go", Line: 4, Severity: "major", Body: "panic stub"},
+		{Path: "util.go", Line: 13, Severity: "minor", Body: "new helper"},
+	}
+	kept, dropped := validateInlineComments(comments, m)
+	if len(kept) != 2 || len(dropped) != 0 {
+		t.Fatalf("kept=%d dropped=%d (want 2/0)", len(kept), len(dropped))
+	}
+}
+
+func TestValidateInlineCommentsDropsFabricated(t *testing.T) {
+	t.Parallel()
+	m := parseDiffLineMap(sampleDiff)
+	comments := []InlineComment{
+		{Path: "main.go", Line: 4, Severity: "major", Body: "real entry"},
+		// Fabrications — wrong file or wrong line:
+		{Path: "main.go", Line: 99, Severity: "critical", Body: "phantom line"},
+		{Path: "imaginary.go", Line: 1, Severity: "major", Body: "phantom file"},
+		{Path: "dropped.go", Line: 1, Severity: "major", Body: "deleted file"},
+	}
+	kept, dropped := validateInlineComments(comments, m)
+	if len(kept) != 1 {
+		t.Fatalf("expected 1 kept, got %d: %+v", len(kept), kept)
+	}
+	if kept[0].Body != "real entry" {
+		t.Fatalf("wrong entry kept: %+v", kept[0])
+	}
+	if len(dropped) != 3 {
+		t.Fatalf("expected 3 dropped, got %d: %+v", len(dropped), dropped)
+	}
+}
+
+func TestDescribeDroppedNamesReason(t *testing.T) {
+	t.Parallel()
+	m := parseDiffLineMap(sampleDiff)
+	dropped := []InlineComment{
+		{Path: "imaginary.go", Line: 1, Severity: "major", Body: "phantom"},
+		{Path: "main.go", Line: 99, Severity: "critical", Body: "wrong line"},
+	}
+	out := describeDropped(dropped, m)
+	if !strings.Contains(out, "imaginary.go") || !strings.Contains(out, "path not in diff") {
+		t.Errorf("missing 'path not in diff' reason: %s", out)
+	}
+	if !strings.Contains(out, "main.go") || !strings.Contains(out, "line 99 not on new side") {
+		t.Errorf("missing 'line not on new side' reason: %s", out)
+	}
+}
+
+func TestParseDiffLineMapHandlesEmpty(t *testing.T) {
+	t.Parallel()
+	if got := parseDiffLineMap(""); len(got) != 0 {
+		t.Fatalf("empty diff should yield empty map, got %+v", got)
+	}
+}
+
+func TestParseHunkNewStartShortForm(t *testing.T) {
+	t.Parallel()
+	cases := map[string]int{
+		"@@ -1,5 +10,3 @@":   10,
+		"@@ -1 +1 @@":        1,           // single-line hunks
+		"@@ -1,3 +20 @@":     20,          // single-line on new side only
+		"@@ -1,5 +10,3 @@ func Foo()": 10, // trailing context
+	}
+	for in, want := range cases {
+		got, ok := parseHunkNewStart(in)
+		if !ok || got != want {
+			t.Errorf("parseHunkNewStart(%q) = (%d,%v), want (%d,true)", in, got, ok, want)
+		}
+	}
+	// Malformed:
+	if _, ok := parseHunkNewStart("garbage"); ok {
+		t.Error("garbage header should not parse")
+	}
+}


### PR DESCRIPTION
## Summary

Third of four 1.0 blockers. Adds post-hoc validation: every parsed `[severity] path:line` citation must point at a real new-side line in the diff, or it gets dropped before the inline review is posted.

## Why this is blocker-shaped

We've already seen Kimi K2.6 fabricate `[critical]` issues against `path:line` citations that don't exist in the change (visible on PR #72 against the dogfood workflow). Prompt engineering helps but isn't deterministic. Validation is.

## How it works

1. Re-fetch the diff via `git diff <base>...HEAD` honoring `--paths` and `--paths-ignore` so validation matches the same scope the agent saw.
2. Parse hunks into a `{path -> set of new-side line numbers}` map.
3. For each parsed inline comment, drop if the path isn't in the diff or the line isn't in the path's new-side set.
4. Log each dropped entry to stderr with a one-line reason.
5. Bulk markdown body is left as-is — validation only affects inline annotations, where a wrong location is a hard UX failure.

## Failure modes handled

- Path not in diff → dropped.
- Line in path but on the old (removed) side → dropped (the model is referencing a deleted line; can't comment inline).
- Deleted files entirely → dropped (no new side).
- Diff fetch fails → validation skipped, all entries pass through; the run does not red.

## Test plan

- [x] 7 unit tests covering parseDiffLineMap (added/modified/deleted file shapes), validateInlineComments (kept/dropped split), describeDropped (reason text), parseHunkNewStart (short and standard hunk headers).
- [x] Sample diff fixture in `validate_test.go` doubles as documentation of expected parser behavior.
- [x] Existing fixture-replay tests should still pass; legitimate citations from real models continue through unchanged.

🤖 Generated with Claude Code
