### PR TITLE
agents/glue-review: prepare v1.0.0 release (closes #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+The library at `github.com/erain/glue` remains **pre-1.0**; the `0.x`
+series may break API on minor bumps. The PR-review agent at
+`agents/glue-review` ships with its own version line and is **1.0**;
+see [`agents/glue-review/CHANGELOG.md`](agents/glue-review/CHANGELOG.md)
+for its release notes.
+
+This file tracks library-level changes only.
+
+## Unreleased
+
+- (no library changes since the agent's `v1.0.0` release)
+
+## Initial bootstrap (pre-1.0)
+
+The library has been under active development as a Go agent harness
+inspired by [pi-mono](https://github.com/badlogic/pi-mono) and
+[Flue](https://github.com/withastro/flue). Notable shipped surface:
+
+- `Agent` / `Session` public API; file-backed session store at
+  `stores/file`.
+- Reusable provider-agnostic loop in `loop/`.
+- Providers: `gemini`, `nvidia`, `openrouter`, with shared
+  OpenAI-compatible plumbing in `providers/openaicompat`.
+- Skills, roles, structured JSON output, parallel tool execution.
+
+The library will cut `v1.0.0` once the public API is settled. For now
+the agent's stability does not require library stability — the agent
+absorbs library bumps internally.

--- a/README.md
+++ b/README.md
@@ -285,17 +285,30 @@ Real agents built on the harness live under `agents/` (peer of the harness
 itself), not `examples/` (which holds tutorial-grade demos only).
 
 - [`agents/glue-review`](agents/glue-review) — a free, local pre-push branch
-  reviewer. Reads the diff against `main`, deep-reads files when context
-  demands it, and emits structured review notes. Defaults to NVIDIA's free
-  Kimi K2.6; flags swap to OpenRouter or Gemini. This is the recommended
-  starting point for seeing what a real Glue agent looks like, and the bot
-  that reviews PRs in this repo.
+  reviewer **(stable: `v1`)**. Reads the diff against `main`, deep-reads
+  files when context demands it, posts inline review comments on the diff
+  via the GitHub PR Reviews API, and falls back to a sticky markdown
+  comment when entries don't parse cleanly. Defaults to NVIDIA's free
+  Kimi K2.6; flags swap to OpenRouter or Gemini.
+
+  As a CLI:
 
   ```sh
   export NVIDIA_API_KEY=nvapi-...
   go run ./agents/glue-review              # review current branch vs main
   go run ./agents/glue-review --provider openrouter
   ```
+
+  As a GitHub Action — drop into any repo:
+
+  ```yaml
+  - uses: erain/glue/agents/glue-review@v1
+    with:
+      nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+  ```
+
+  See [`agents/glue-review/CHANGELOG.md`](agents/glue-review/CHANGELOG.md)
+  for surface guarantees and release history.
 
 ## Examples
 

--- a/agents/glue-review/CHANGELOG.md
+++ b/agents/glue-review/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+This file tracks releases of the `glue-review` agent and its GitHub
+Action. It is independent from the parent `github.com/erain/glue`
+library, which versions separately.
+
+## v1.0.0 — 2026-05-05
+
+First stable release. The Action's input/output surface is now
+guaranteed to be backwards-compatible across the `v1.x` series.
+
+### Added
+
+- **Composite GitHub Action** at `agents/glue-review/action.yml`. Drop
+  it in any repo with one workflow line:
+
+  ```yaml
+  - uses: erain/glue/agents/glue-review@v1
+    with:
+      nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+  ```
+
+- **Provider failover**. Pass `provider: nvidia,openrouter,gemini` to
+  try each in order; the first whose API key is set in env and whose
+  call succeeds wins. Soft-fails to a sticky comment when all fail.
+
+- **Inline review comments** posted via the GitHub Pull Request
+  Reviews API. Lines that don't parse cleanly fall through to a
+  bulk-markdown sticky comment. Re-runs dismiss prior bot reviews so
+  the diff stays uncluttered.
+
+- **`/glue-review` comment trigger** for fork PRs, gated on
+  `OWNER`/`MEMBER`/`COLLABORATOR` association so random commenters
+  cannot trigger free LLM spend.
+
+- **Path filters**. `paths` / `paths-ignore` Action inputs (and
+  `--paths` / `--paths-ignore` CLI flags) restrict the diff via Git
+  pathspecs at the source — out-of-scope files never reach the model.
+
+- **Custom prompts**. `prompt` and `prompt-version` inputs let
+  deployments retarget the agent ("only review SQL migrations") or
+  pin a specific system-prompt revision.
+
+- **Sensitive-file blocklist**. The `read_file` tool refuses to open
+  paths matching a built-in pattern list (`.env`, `id_rsa`, `*.pem`,
+  `credentials.json`, etc.). Extended via `extra-blocked-paths`.
+
+- **Citation validation**. Inline-comment entries whose `path:line`
+  is not reachable on the new side of the diff are dropped before
+  the review is posted. Defends against fabricated citations — a
+  real LLM failure mode we observed in pre-1.0 dev.
+
+- **Prompt versioning**. System prompts live as `prompts/<version>.md`
+  files embedded via `//go:embed`. The sticky-comment marker carries
+  the version so a future prompt-shape change starts fresh comments
+  instead of editing existing ones into a different format.
+
+- **Fixture replay tests**. Three synthetic-repo scenarios
+  (`panic-stub`, `subtle-bug`, `cosmetic-only`) replay through a real
+  free model on every CI push to catch prompt regressions.
+
+### Surface guarantees
+
+What `v1.0.0` promises:
+
+- Action inputs and outputs documented in `action.yml` will not
+  break in the `v1.x` series.
+- The CLI flag set on `glue-review` will not lose flags in `v1.x`.
+- The sticky-comment marker shape stays stable so re-runs continue to
+  edit the right comment.
+- The inline-comment JSON schema stays stable.
+
+What `v1.0.0` does NOT promise:
+
+- Byte-stable model output. LLMs drift; we depend on them.
+- Library API stability. `github.com/erain/glue` remains `0.x`.
+- Free-tier provider availability. NVIDIA, OpenRouter, and their
+  upstream model hosts can rate-limit or break independently;
+  failover is best-effort.
+
+### Pinning
+
+For maximum stability:
+
+```yaml
+- uses: erain/glue/agents/glue-review@v1.0.0
+```
+
+For minor-bump auto-updates (recommended):
+
+```yaml
+- uses: erain/glue/agents/glue-review@v1
+```
+
+The `v1` floating tag advances on every backwards-compatible release.

--- a/agents/glue-review/README.md
+++ b/agents/glue-review/README.md
@@ -22,10 +22,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - uses: erain/glue/agents/glue-review@main  # pin to a tag in production
+      - uses: erain/glue/agents/glue-review@v1   # or @v1.0.0 for strict pinning
         with:
           nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
 ```
+
+Releases follow semver in the `v1.x` series; see
+[CHANGELOG.md](CHANGELOG.md) for what shipped when. The `v1` floating
+tag advances on every backwards-compatible release.
 
 That posts a sticky review comment on every PR. Use `provider: openrouter` or
 `provider: gemini` (with the matching `*-api-key` input) to swap backends.
@@ -169,6 +173,17 @@ fabricated paths. Add a new fixture when locking in a prompt behavior:
     expect: func(t *testing.T, review string) { /* invariants */ },
 }
 ```
+
+## What it looks like on a PR
+
+The bot posts inline review comments on the diff plus a top-level
+review body. Severity tags (`[critical]` / `[major]` / `[minor]`) are
+preserved on each line so reviewers can scan triage at a glance.
+
+> *(A screenshot of a real review will land here once the next
+> non-trivial PR runs through the v1 Action — see the live samples
+> on merged PRs in this repo's history under the `glue-review`
+> author for the current shape.)*
 
 ## What it does
 


### PR DESCRIPTION
## Summary

Final 1.0 blocker. After this PR merges, I'll cut the `v1.0.0` and floating `v1` tags so external consumers can pin their `uses:` line to a stable surface.

## What ships at v1.0

The four blockers we just landed:

- #78 — sensitive-file blocklist on `read_file`
- #79 — `paths` / `paths-ignore` / `prompt` / `prompt-version` Action inputs
- #80 — citation validation (drops fabricated `path:line` entries)
- This PR — CHANGELOG + README updates + tags

The Action's input/output surface is locked under `v1.x` semver. Library at `github.com/erain/glue` stays pre-1.0; the agent absorbs library bumps internally.

## Files in this PR

- `CHANGELOG.md` — top-level; explains the split versioning (library pre-1.0, agent 1.0).
- `agents/glue-review/CHANGELOG.md` — full v1.0.0 release notes with explicit surface guarantees.
- `agents/glue-review/README.md` — `uses: ... @v1`, links to CHANGELOG, screenshot placeholder.
- `README.md` (top-level) — agent entry now advertises `v1` stability.

## Tag plan (after merge)

```
git tag -a v1.0.0 -m "agents/glue-review v1.0.0"
git tag -a v1     -m "agents/glue-review v1 floating tag" v1.0.0
git push origin v1.0.0 v1
```

Subsequent backwards-compatible releases bump v1.x.0 and advance the floating `v1` tag.

🤖 Generated with Claude Code
