### PR TITLE
glue: typed NewTool[T] + TextResult/ErrorResult helpers (closes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,42 @@ _, err := session.PromptJSON(ctx, "Return a project name and count.", &out)
 `response_json_schema`). V1 validation is JSON decoding into the caller's Go
 type.
 
+### Tools
+
+`glue.NewTool[Args]` decodes `ToolCall.Arguments` into a typed Go value
+before invoking the executor, so most tools no longer need a manual
+`json.Unmarshal`. Pair it with `glue.TextResult` / `glue.ErrorResult` for
+the result side:
+
+```go
+type weatherArgs struct {
+	City string `json:"city"`
+}
+
+weather := glue.NewTool[weatherArgs](
+	glue.ToolSpec{
+		Name:        "weather",
+		Description: "Lookup current weather for a city.",
+		Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": { "city": { "type": "string" } },
+  "required": ["city"]
+}`),
+	},
+	func(ctx context.Context, a weatherArgs) (glue.ToolResult, error) {
+		report, err := lookup(ctx, a.City)
+		if err != nil {
+			return glue.ErrorResult(err), nil
+		}
+		return glue.TextResult(report), nil
+	},
+)
+```
+
+Malformed arguments surface to the model as an error `ToolResult` rather
+than crashing the loop. Schema generation from `Args` is intentionally
+out of scope; supply `Parameters` explicitly.
+
 ## Testing without Gemini
 
 The `glue.Provider` interface is small, so tests can drive sessions with a

--- a/agents/glue-review/tools.go
+++ b/agents/glue-review/tools.go
@@ -73,9 +73,14 @@ const (
 	defaultReadMaxBytes = 80 * 1024
 )
 
+type gitDiffArgs struct {
+	Base     string `json:"base"`
+	MaxBytes int    `json:"max_bytes"`
+}
+
 func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
-	return glue.Tool{
-		ToolSpec: glue.ToolSpec{
+	return glue.NewTool[gitDiffArgs](
+		glue.ToolSpec{
 			Name:        "git_diff_branch",
 			Description: "Show the diff of the current branch versus a base ref (default 'main'). Includes file additions, deletions, and modifications. The diff may be pre-filtered by deployment-supplied path globs — only files in scope appear. Use this first to scope the review.",
 			Parameters: json.RawMessage(`{
@@ -86,19 +91,12 @@ func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
   }
 }`),
 		},
-		Execute: func(ctx context.Context, call glue.ToolCall) (glue.ToolResult, error) {
-			var args struct {
-				Base     string `json:"base"`
-				MaxBytes int    `json:"max_bytes"`
-			}
-			if err := json.Unmarshal(call.Arguments, &args); err != nil {
-				return glue.ToolResult{}, err
-			}
-			base := strings.TrimSpace(args.Base)
+		func(ctx context.Context, a gitDiffArgs) (glue.ToolResult, error) {
+			base := strings.TrimSpace(a.Base)
 			if base == "" {
 				base = "main"
 			}
-			max := args.MaxBytes
+			max := a.MaxBytes
 			if max <= 0 {
 				max = defaultDiffMaxBytes
 			}
@@ -109,16 +107,21 @@ func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
 			}
 			out, err := runGit(ctx, workDir, gitArgs...)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			return textResult(truncate(out, max)), nil
+			return glue.TextResult(truncate(out, max)), nil
 		},
-	}
+	)
+}
+
+type gitLogArgs struct {
+	Base  string `json:"base"`
+	Limit int    `json:"limit"`
 }
 
 func gitLogBranchTool(workDir string) glue.Tool {
-	return glue.Tool{
-		ToolSpec: glue.ToolSpec{
+	return glue.NewTool[gitLogArgs](
+		glue.ToolSpec{
 			Name:        "git_log_branch",
 			Description: "Show the commit history of the current branch since a base ref (default 'main'). Useful for reading commit messages to understand author intent.",
 			Parameters: json.RawMessage(`{
@@ -129,19 +132,12 @@ func gitLogBranchTool(workDir string) glue.Tool {
   }
 }`),
 		},
-		Execute: func(ctx context.Context, call glue.ToolCall) (glue.ToolResult, error) {
-			var args struct {
-				Base  string `json:"base"`
-				Limit int    `json:"limit"`
-			}
-			if err := json.Unmarshal(call.Arguments, &args); err != nil {
-				return glue.ToolResult{}, err
-			}
-			base := strings.TrimSpace(args.Base)
+		func(ctx context.Context, a gitLogArgs) (glue.ToolResult, error) {
+			base := strings.TrimSpace(a.Base)
 			if base == "" {
 				base = "main"
 			}
-			limit := args.Limit
+			limit := a.Limit
 			if limit <= 0 {
 				limit = defaultLogLimit
 			}
@@ -153,16 +149,21 @@ func gitLogBranchTool(workDir string) glue.Tool {
 				base+"..HEAD",
 			)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			return textResult(out), nil
+			return glue.TextResult(out), nil
 		},
-	}
+	)
+}
+
+type readFileArgs struct {
+	Path     string `json:"path"`
+	MaxBytes int    `json:"max_bytes"`
 }
 
 func readFileTool(workDir string, blockedPatterns []string) glue.Tool {
-	return glue.Tool{
-		ToolSpec: glue.ToolSpec{
+	return glue.NewTool[readFileArgs](
+		glue.ToolSpec{
 			Name:        "read_file",
 			Description: "Read a UTF-8 text file from the working directory. Returns the file content, truncated if larger than max_bytes. Use this to inspect files mentioned in the diff when surrounding context is needed. Refuses to open secret-shaped files (.env, id_rsa, *.pem, credentials.json, etc.).",
 			Parameters: json.RawMessage(`{
@@ -174,41 +175,34 @@ func readFileTool(workDir string, blockedPatterns []string) glue.Tool {
   "required": ["path"]
 }`),
 		},
-		Execute: func(_ context.Context, call glue.ToolCall) (glue.ToolResult, error) {
-			var args struct {
-				Path     string `json:"path"`
-				MaxBytes int    `json:"max_bytes"`
-			}
-			if err := json.Unmarshal(call.Arguments, &args); err != nil {
-				return glue.ToolResult{}, err
-			}
+		func(_ context.Context, a readFileArgs) (glue.ToolResult, error) {
 			// Blocklist check happens BEFORE traversal resolution so the
 			// model sees a stable error message regardless of whether
 			// the file even exists. We also re-check the resolved path
 			// below to defend against e.g. symlink-to-secret tricks.
-			if blocked, pat := pathBlocked(args.Path, blockedPatterns); blocked {
-				return errorResult(fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", args.Path, pat)), nil
+			if blocked, pat := pathBlocked(a.Path, blockedPatterns); blocked {
+				return glue.ErrorResult(fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", a.Path, pat)), nil
 			}
-			resolved, err := safeJoin(workDir, args.Path)
+			resolved, err := safeJoin(workDir, a.Path)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			max := args.MaxBytes
+			max := a.MaxBytes
 			if max <= 0 {
 				max = defaultReadMaxBytes
 			}
 			f, err := os.Open(resolved)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
 			defer f.Close()
 			data, err := io.ReadAll(io.LimitReader(f, int64(max)+1))
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			return textResult(truncate(string(data), max)), nil
+			return glue.TextResult(truncate(string(data), max)), nil
 		},
-	}
+	)
 }
 
 // runGit shells out to the local git binary in workDir. Output is
@@ -269,15 +263,3 @@ func truncate(s string, max int) string {
 	return s[:max-len(note)] + note
 }
 
-func textResult(text string) glue.ToolResult {
-	return glue.ToolResult{
-		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
-	}
-}
-
-func errorResult(err error) glue.ToolResult {
-	return glue.ToolResult{
-		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: err.Error()}},
-		IsError: true,
-	}
-}

--- a/tool_helpers.go
+++ b/tool_helpers.go
@@ -1,0 +1,48 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// TextResult wraps a string in a ToolResult with a single text content part.
+// Use it from tool executors when the tool succeeds with textual output.
+func TextResult(s string) ToolResult {
+	return ToolResult{
+		Content: []ContentPart{{Type: ContentTypeText, Text: s}},
+	}
+}
+
+// ErrorResult wraps an error in a ToolResult tagged with IsError=true so the
+// model sees it as a tool failure rather than the loop crashing. The error's
+// Error() string becomes the visible text.
+func ErrorResult(err error) ToolResult {
+	return ToolResult{
+		Content: []ContentPart{{Type: ContentTypeText, Text: err.Error()}},
+		IsError: true,
+	}
+}
+
+// NewTool builds a Tool whose executor decodes ToolCall.Arguments into a
+// typed Go value before invoking fn. Empty arguments decode as the zero
+// value of T. JSON decode failures surface to the model as an error
+// ToolResult — matching the existing manual pattern — so a malformed call
+// does not crash the loop.
+//
+// Callers still supply spec.Parameters (a JSON Schema). Schema generation
+// from T is intentionally out of scope.
+func NewTool[T any](spec ToolSpec, fn func(ctx context.Context, args T) (ToolResult, error)) Tool {
+	return Tool{
+		ToolSpec: spec,
+		Execute: func(ctx context.Context, call ToolCall) (ToolResult, error) {
+			var args T
+			if len(call.Arguments) > 0 {
+				if err := json.Unmarshal(call.Arguments, &args); err != nil {
+					return ErrorResult(fmt.Errorf("decode arguments for tool %q: %w", spec.Name, err)), nil
+				}
+			}
+			return fn(ctx, args)
+		},
+	}
+}

--- a/tool_helpers_test.go
+++ b/tool_helpers_test.go
@@ -1,0 +1,110 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTextResult(t *testing.T) {
+	r := TextResult("hello")
+	if r.IsError {
+		t.Fatalf("TextResult must not be tagged IsError")
+	}
+	if len(r.Content) != 1 || r.Content[0].Type != ContentTypeText || r.Content[0].Text != "hello" {
+		t.Fatalf("unexpected content: %+v", r.Content)
+	}
+}
+
+func TestErrorResult(t *testing.T) {
+	r := ErrorResult(errors.New("boom"))
+	if !r.IsError {
+		t.Fatalf("ErrorResult must be tagged IsError")
+	}
+	if len(r.Content) != 1 || r.Content[0].Text != "boom" {
+		t.Fatalf("unexpected content: %+v", r.Content)
+	}
+}
+
+type echoArgs struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestNewTool_DecodesTypedArgs(t *testing.T) {
+	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
+		return TextResult(a.Name + "/" + intStr(a.Count)), nil
+	})
+
+	res, err := tool.Execute(context.Background(), ToolCall{
+		Name:      "echo",
+		Arguments: json.RawMessage(`{"name":"glue","count":3}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %+v", res)
+	}
+	if got := res.Content[0].Text; got != "glue/3" {
+		t.Fatalf("unexpected text: %q", got)
+	}
+}
+
+func TestNewTool_EmptyArgsZeroValue(t *testing.T) {
+	called := false
+	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
+		called = true
+		if a.Name != "" || a.Count != 0 {
+			t.Fatalf("expected zero value, got %+v", a)
+		}
+		return TextResult("ok"), nil
+	})
+	if _, err := tool.Execute(context.Background(), ToolCall{Name: "echo"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !called {
+		t.Fatalf("fn not invoked on empty args")
+	}
+}
+
+func TestNewTool_MalformedArgsReturnsErrorResult(t *testing.T) {
+	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
+		t.Fatalf("fn should not be invoked on malformed args")
+		return ToolResult{}, nil
+	})
+	res, err := tool.Execute(context.Background(), ToolCall{
+		Name:      "echo",
+		Arguments: json.RawMessage(`{not-json`),
+	})
+	if err != nil {
+		t.Fatalf("Execute returned err=%v; expected error ToolResult, not loop crash", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true on malformed args; got %+v", res)
+	}
+	if !strings.Contains(res.Content[0].Text, `tool "echo"`) {
+		t.Fatalf("expected error text to name the tool; got %q", res.Content[0].Text)
+	}
+}
+
+func intStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}

--- a/tool_helpers_test.go
+++ b/tool_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -35,7 +36,7 @@ type echoArgs struct {
 
 func TestNewTool_DecodesTypedArgs(t *testing.T) {
 	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
-		return TextResult(a.Name + "/" + intStr(a.Count)), nil
+		return TextResult(a.Name + "/" + strconv.Itoa(a.Count)), nil
 	})
 
 	res, err := tool.Execute(context.Background(), ToolCall{
@@ -90,21 +91,3 @@ func TestNewTool_MalformedArgsReturnsErrorResult(t *testing.T) {
 	}
 }
 
-func intStr(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	digits := []byte{}
-	for n > 0 {
-		digits = append([]byte{byte('0' + n%10)}, digits...)
-		n /= 10
-	}
-	if neg {
-		digits = append([]byte{'-'}, digits...)
-	}
-	return string(digits)
-}


### PR DESCRIPTION
## Summary

- Add `glue.TextResult(string)` and `glue.ErrorResult(error)` so agents stop redefining them locally.
- Add `glue.NewTool[T any](spec, fn)` that decodes `ToolCall.Arguments` into `T` before invoking the executor; malformed JSON surfaces to the model as an error `ToolResult` rather than crashing the loop.
- Migrate `agents/glue-review/tools.go` as the first internal consumer (three tools converted, local helpers deleted).
- README gains a typed-tool example.

Schema generation from `T` is intentionally out of scope; callers continue to pass `Parameters` explicitly.

Closes #88

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green, agent fixture replay still passes)
- [x] Unit tests in `tool_helpers_test.go` cover typed decode, empty-args zero value, malformed-args → error ToolResult.

🤖 Generated with [Claude Code](https://claude.com/claude-code)