### PR TITLE
prompts: PromptCatalog versioned-prompt loader (closes #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,42 @@ _, err := session.PromptJSON(ctx, "Return a project name and count.", &out)
 `response_json_schema`). V1 validation is JSON decoding into the caller's Go
 type.
 
+### Tools
+
+`glue.NewTool[Args]` decodes `ToolCall.Arguments` into a typed Go value
+before invoking the executor, so most tools no longer need a manual
+`json.Unmarshal`. Pair it with `glue.TextResult` / `glue.ErrorResult` for
+the result side:
+
+```go
+type weatherArgs struct {
+	City string `json:"city"`
+}
+
+weather := glue.NewTool[weatherArgs](
+	glue.ToolSpec{
+		Name:        "weather",
+		Description: "Lookup current weather for a city.",
+		Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": { "city": { "type": "string" } },
+  "required": ["city"]
+}`),
+	},
+	func(ctx context.Context, a weatherArgs) (glue.ToolResult, error) {
+		report, err := lookup(ctx, a.City)
+		if err != nil {
+			return glue.ErrorResult(err), nil
+		}
+		return glue.TextResult(report), nil
+	},
+)
+```
+
+Malformed arguments surface to the model as an error `ToolResult` rather
+than crashing the loop. Schema generation from `Args` is intentionally
+out of scope; supply `Parameters` explicitly.
+
 ## Testing without Gemini
 
 The `glue.Provider` interface is small, so tests can drive sessions with a

--- a/README.md
+++ b/README.md
@@ -273,6 +273,34 @@ formatted JSON, and runs the result through `Session.Prompt`. Unknown skill
 names return a typed error. Skills supplied via `AgentOptions.Skills` win on
 name collision over disk-discovered skills.
 
+### Versioned prompts
+
+`prompts.NewCatalog(fsys, dir, defaultVersion)` wraps an `embed.FS` of
+`<version>.md` files so agents can A/B-test prompts and roll back without
+rebuilding history. Unknown versions return an error that lists every
+available version verbatim — silent fallback would hide A/B test
+misconfiguration.
+
+```go
+import (
+	"embed"
+
+	"github.com/erain/glue/prompts"
+)
+
+//go:embed prompts/*.md
+var promptFS embed.FS
+
+cat, err := prompts.NewCatalog(promptFS, "prompts", "v2")
+if err != nil { /* default version must exist at construction time */ }
+
+systemPrompt, err := cat.Get("v1") // or cat.Get("") for the default
+```
+
+The catalog is read-only and concurrency-safe. Templating and variable
+substitution are intentionally out of scope; rendering is the caller's
+job.
+
 ### Structured JSON results
 
 ```go

--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@ even when the underlying model is fast.
 loop event for every prompt run on that session. `glue.WithEvents` registers
 a per-prompt handler that fires alongside it.
 
+For the two most common cases — mirror text deltas and log tool starts
+to a writer — use the convenience options:
+
+```go
+_, err := session.Prompt(ctx, "Stream a haiku about glue.",
+	glue.WithStreamWriter(os.Stdout),
+	glue.WithToolLogger(os.Stderr),
+)
+```
+
+`WithStreamWriter` writes `EventTextDelta.Delta` straight to the writer;
+`WithToolLogger` emits `[tool] <name>\n` on `EventToolStart`. Both nil-safe
+and silently drop writer errors. They compose additively with `WithEvents`
+and each other — adding one does not displace any other handler.
+
+For richer formatting, use `WithEvents` directly:
+
 ```go
 unsubscribe := session.Subscribe(func(e glue.Event) {
 	if e.Type == glue.EventTextDelta {

--- a/README.md
+++ b/README.md
@@ -166,6 +166,45 @@ result, err := session.Prompt(ctx, "Be concise.",
 )
 ```
 
+### Provider failover
+
+`glue.WithFailover(provs...)` returns a Provider that tries each
+underlying provider in order until one accepts a Stream — useful when
+your CLI agent supports multiple LLM backends and you want it to skip
+providers whose API keys aren't set rather than fail. Pre-filter via
+the small registry under `providers`:
+
+```go
+import (
+	"github.com/erain/glue"
+	"github.com/erain/glue/providers"
+	_ "github.com/erain/glue/providers/gemini"      // registers "gemini"
+	_ "github.com/erain/glue/providers/nvidia"      // registers "nvidia"
+	_ "github.com/erain/glue/providers/openrouter"  // registers "openrouter"
+)
+
+var provs []glue.Provider
+for _, name := range []string{"nvidia", "openrouter", "gemini"} {
+	if !providers.KeyAvailable(name) {
+		continue
+	}
+	p, _, _, err := providers.New(name)
+	if err == nil {
+		provs = append(provs, p)
+	}
+}
+agent := glue.NewAgent(glue.AgentOptions{
+	Provider: glue.WithFailover(provs...),
+	Model:    "", // let each provider use its DefaultModel
+})
+```
+
+`WithFailover` only falls through *before* the first event commits to
+the consumer (Stream error, immediate `ProviderEventError`, or empty
+stream). Once any non-error event is observed, it commits to that
+provider for the rest of the turn. All-providers-failed surfaces as a
+typed `*glue.FailoverError` with per-provider attempts.
+
 ### Roles
 
 A role is a named instruction profile with an optional model override.

--- a/agents/glue-review/tools.go
+++ b/agents/glue-review/tools.go
@@ -73,9 +73,14 @@ const (
 	defaultReadMaxBytes = 80 * 1024
 )
 
+type gitDiffArgs struct {
+	Base     string `json:"base"`
+	MaxBytes int    `json:"max_bytes"`
+}
+
 func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
-	return glue.Tool{
-		ToolSpec: glue.ToolSpec{
+	return glue.NewTool[gitDiffArgs](
+		glue.ToolSpec{
 			Name:        "git_diff_branch",
 			Description: "Show the diff of the current branch versus a base ref (default 'main'). Includes file additions, deletions, and modifications. The diff may be pre-filtered by deployment-supplied path globs — only files in scope appear. Use this first to scope the review.",
 			Parameters: json.RawMessage(`{
@@ -86,19 +91,12 @@ func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
   }
 }`),
 		},
-		Execute: func(ctx context.Context, call glue.ToolCall) (glue.ToolResult, error) {
-			var args struct {
-				Base     string `json:"base"`
-				MaxBytes int    `json:"max_bytes"`
-			}
-			if err := json.Unmarshal(call.Arguments, &args); err != nil {
-				return glue.ToolResult{}, err
-			}
-			base := strings.TrimSpace(args.Base)
+		func(ctx context.Context, a gitDiffArgs) (glue.ToolResult, error) {
+			base := strings.TrimSpace(a.Base)
 			if base == "" {
 				base = "main"
 			}
-			max := args.MaxBytes
+			max := a.MaxBytes
 			if max <= 0 {
 				max = defaultDiffMaxBytes
 			}
@@ -109,16 +107,21 @@ func gitDiffBranchTool(workDir string, pathspec []string) glue.Tool {
 			}
 			out, err := runGit(ctx, workDir, gitArgs...)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			return textResult(truncate(out, max)), nil
+			return glue.TextResult(truncate(out, max)), nil
 		},
-	}
+	)
+}
+
+type gitLogArgs struct {
+	Base  string `json:"base"`
+	Limit int    `json:"limit"`
 }
 
 func gitLogBranchTool(workDir string) glue.Tool {
-	return glue.Tool{
-		ToolSpec: glue.ToolSpec{
+	return glue.NewTool[gitLogArgs](
+		glue.ToolSpec{
 			Name:        "git_log_branch",
 			Description: "Show the commit history of the current branch since a base ref (default 'main'). Useful for reading commit messages to understand author intent.",
 			Parameters: json.RawMessage(`{
@@ -129,19 +132,12 @@ func gitLogBranchTool(workDir string) glue.Tool {
   }
 }`),
 		},
-		Execute: func(ctx context.Context, call glue.ToolCall) (glue.ToolResult, error) {
-			var args struct {
-				Base  string `json:"base"`
-				Limit int    `json:"limit"`
-			}
-			if err := json.Unmarshal(call.Arguments, &args); err != nil {
-				return glue.ToolResult{}, err
-			}
-			base := strings.TrimSpace(args.Base)
+		func(ctx context.Context, a gitLogArgs) (glue.ToolResult, error) {
+			base := strings.TrimSpace(a.Base)
 			if base == "" {
 				base = "main"
 			}
-			limit := args.Limit
+			limit := a.Limit
 			if limit <= 0 {
 				limit = defaultLogLimit
 			}
@@ -153,16 +149,21 @@ func gitLogBranchTool(workDir string) glue.Tool {
 				base+"..HEAD",
 			)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			return textResult(out), nil
+			return glue.TextResult(out), nil
 		},
-	}
+	)
+}
+
+type readFileArgs struct {
+	Path     string `json:"path"`
+	MaxBytes int    `json:"max_bytes"`
 }
 
 func readFileTool(workDir string, blockedPatterns []string) glue.Tool {
-	return glue.Tool{
-		ToolSpec: glue.ToolSpec{
+	return glue.NewTool[readFileArgs](
+		glue.ToolSpec{
 			Name:        "read_file",
 			Description: "Read a UTF-8 text file from the working directory. Returns the file content, truncated if larger than max_bytes. Use this to inspect files mentioned in the diff when surrounding context is needed. Refuses to open secret-shaped files (.env, id_rsa, *.pem, credentials.json, etc.).",
 			Parameters: json.RawMessage(`{
@@ -174,41 +175,34 @@ func readFileTool(workDir string, blockedPatterns []string) glue.Tool {
   "required": ["path"]
 }`),
 		},
-		Execute: func(_ context.Context, call glue.ToolCall) (glue.ToolResult, error) {
-			var args struct {
-				Path     string `json:"path"`
-				MaxBytes int    `json:"max_bytes"`
-			}
-			if err := json.Unmarshal(call.Arguments, &args); err != nil {
-				return glue.ToolResult{}, err
-			}
+		func(_ context.Context, a readFileArgs) (glue.ToolResult, error) {
 			// Blocklist check happens BEFORE traversal resolution so the
 			// model sees a stable error message regardless of whether
 			// the file even exists. We also re-check the resolved path
 			// below to defend against e.g. symlink-to-secret tricks.
-			if blocked, pat := pathBlocked(args.Path, blockedPatterns); blocked {
-				return errorResult(fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", args.Path, pat)), nil
+			if blocked, pat := pathBlocked(a.Path, blockedPatterns); blocked {
+				return glue.ErrorResult(fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", a.Path, pat)), nil
 			}
-			resolved, err := safeJoin(workDir, args.Path)
+			resolved, err := safeJoin(workDir, a.Path)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			max := args.MaxBytes
+			max := a.MaxBytes
 			if max <= 0 {
 				max = defaultReadMaxBytes
 			}
 			f, err := os.Open(resolved)
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
 			defer f.Close()
 			data, err := io.ReadAll(io.LimitReader(f, int64(max)+1))
 			if err != nil {
-				return errorResult(err), nil
+				return glue.ErrorResult(err), nil
 			}
-			return textResult(truncate(string(data), max)), nil
+			return glue.TextResult(truncate(string(data), max)), nil
 		},
-	}
+	)
 }
 
 // runGit shells out to the local git binary in workDir. Output is
@@ -269,15 +263,3 @@ func truncate(s string, max int) string {
 	return s[:max-len(note)] + note
 }
 
-func textResult(text string) glue.ToolResult {
-	return glue.ToolResult{
-		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
-	}
-}
-
-func errorResult(err error) glue.ToolResult {
-	return glue.ToolResult{
-		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: err.Error()}},
-		IsError: true,
-	}
-}

--- a/docs/adr/0003-shell-filesystem-tools.md
+++ b/docs/adr/0003-shell-filesystem-tools.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Accepted (design-only; no implementation in this ADR).
+Accepted. Implemented in #89 — read-side filesystem and git helpers
+ship as `tools/fs` (`SafeJoin`, `Truncate`, `Blocklist`, `ReadFileTool`)
+and `tools/git` (`RunGit`, `BuildPathspec`, `DiffBranchTool`,
+`LogBranchTool`). Write-side filesystem and arbitrary shell execution
+remain out of scope until a follow-up ADR designs the safety boundary.
 
 ## Context
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,6 +52,11 @@ The module path is `github.com/erain/glue`.
   (`openrouter.ai/api/v1`), aggregator of many upstream models. Sends
   attribution headers (`HTTP-Referer`, `X-Title`) and tolerates
   comment-line SSE keep-alives during cold routing.
+- `providers`: driver-style registry (`Register`, `New`, `Lookup`,
+  `Known`, `KeyAvailable`). Each provider sub-package self-registers
+  via `init()` so importing `_ "github.com/erain/glue/providers/<name>"`
+  makes that name resolvable. Holds factory functions, not constructed
+  providers, so registration is cheap and credential-free.
 - `stores/file`: file-backed JSON session store with atomic writes.
 - `tools/fs`: filesystem tool factories — `SafeJoin`, `Truncate`,
   `Blocklist`, and a ready-to-register `ReadFileTool`. Outside the core

--- a/docs/design.md
+++ b/docs/design.md
@@ -53,6 +53,12 @@ The module path is `github.com/erain/glue`.
   attribution headers (`HTTP-Referer`, `X-Title`) and tolerates
   comment-line SSE keep-alives during cold routing.
 - `stores/file`: file-backed JSON session store with atomic writes.
+- `tools/fs`: filesystem tool factories — `SafeJoin`, `Truncate`,
+  `Blocklist`, and a ready-to-register `ReadFileTool`. Outside the core
+  package per ADR 0003 so the harness stays free of POSIX coupling.
+- `tools/git`: git tool factories — `RunGit`, `BuildPathspec`,
+  `DiffBranchTool`, `LogBranchTool`. Shells out to the system `git`
+  binary; no Git library dependency.
 - `cmd/glue`: local CLI runner built on top of the public library.
 
 The dependency direction is intentionally narrow:

--- a/event_helpers.go
+++ b/event_helpers.go
@@ -1,0 +1,47 @@
+package glue
+
+import (
+	"fmt"
+	"io"
+)
+
+// WithStreamWriter mirrors EventTextDelta.Delta to w on every prompt
+// event. Composes additively with WithEvents and other event-related
+// options — installing one does not displace any other.
+//
+// Errors from the writer are silently dropped: this is a convenience
+// option, not a delivery-guaranteed pipe. Callers that need backpressure
+// or error visibility should register a custom WithEvents handler
+// instead.
+//
+// A nil writer is a no-op so callers can pass conditional writers
+// without branching.
+func WithStreamWriter(w io.Writer) PromptOption {
+	return func(c *promptConfig) {
+		if w == nil {
+			return
+		}
+		c.auxEmits = append(c.auxEmits, func(e Event) {
+			if e.Type == EventTextDelta && e.Delta != "" {
+				_, _ = io.WriteString(w, e.Delta)
+			}
+		})
+	}
+}
+
+// WithToolLogger mirrors EventToolStart events to w as
+// "[tool] <name>\n". Composes additively with other event-related
+// options. Errors from the writer are silently dropped; nil w is a
+// no-op.
+func WithToolLogger(w io.Writer) PromptOption {
+	return func(c *promptConfig) {
+		if w == nil {
+			return
+		}
+		c.auxEmits = append(c.auxEmits, func(e Event) {
+			if e.Type == EventToolStart && e.ToolName != "" {
+				_, _ = fmt.Fprintf(w, "[tool] %s\n", e.ToolName)
+			}
+		})
+	}
+}

--- a/event_helpers_test.go
+++ b/event_helpers_test.go
@@ -1,0 +1,108 @@
+package glue
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+type streamFakeProvider struct {
+	deltas   []string
+	toolName string
+	emitTool bool
+	turn     int
+}
+
+func (p *streamFakeProvider) Stream(_ context.Context, _ ProviderRequest) (<-chan ProviderEvent, error) {
+	ch := make(chan ProviderEvent, len(p.deltas)+4)
+	ch <- ProviderEvent{Type: ProviderEventStart}
+	if p.turn == 0 {
+		for _, d := range p.deltas {
+			ch <- ProviderEvent{Type: ProviderEventTextDelta, Delta: d}
+		}
+		if p.emitTool {
+			ch <- ProviderEvent{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "1", Name: p.toolName, Arguments: []byte(`{}`)}}
+		}
+	}
+	ch <- ProviderEvent{Type: ProviderEventDone}
+	close(ch)
+	p.turn++
+	return ch, nil
+}
+
+func TestWithStreamWriter_MirrorsDeltas(t *testing.T) {
+	var buf bytes.Buffer
+	agent := NewAgent(AgentOptions{Provider: &streamFakeProvider{deltas: []string{"hel", "lo"}}})
+	session, _ := agent.Session(context.Background(), "test")
+	if _, err := session.Prompt(context.Background(), "go", WithStreamWriter(&buf)); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "hello" {
+		t.Fatalf("expected mirrored text 'hello', got %q", got)
+	}
+}
+
+func TestWithStreamWriter_NilWriterIsNoOp(t *testing.T) {
+	agent := NewAgent(AgentOptions{Provider: &streamFakeProvider{deltas: []string{"x"}}})
+	session, _ := agent.Session(context.Background(), "test")
+	// Should not panic.
+	if _, err := session.Prompt(context.Background(), "go", WithStreamWriter(nil)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWithToolLogger_MirrorsToolStart(t *testing.T) {
+	var buf bytes.Buffer
+	agent := NewAgent(AgentOptions{
+		Provider: &streamFakeProvider{deltas: []string{"a"}, emitTool: true, toolName: "echo"},
+		Tools: []Tool{
+			NewTool[struct{}](ToolSpec{Name: "echo"}, func(_ context.Context, _ struct{}) (ToolResult, error) {
+				return TextResult("ok"), nil
+			}),
+		},
+		MaxTurns: 2,
+	})
+	session, _ := agent.Session(context.Background(), "test")
+	if _, err := session.Prompt(context.Background(), "go", WithToolLogger(&buf)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "[tool] echo\n") {
+		t.Fatalf("expected '[tool] echo' in log, got %q", buf.String())
+	}
+}
+
+func TestStreamHelpers_ComposeWithWithEvents(t *testing.T) {
+	var (
+		streamBuf bytes.Buffer
+		toolBuf   bytes.Buffer
+		evCount   int
+	)
+	agent := NewAgent(AgentOptions{
+		Provider: &streamFakeProvider{deltas: []string{"hi"}, emitTool: true, toolName: "echo"},
+		Tools: []Tool{
+			NewTool[struct{}](ToolSpec{Name: "echo"}, func(_ context.Context, _ struct{}) (ToolResult, error) {
+				return TextResult("ok"), nil
+			}),
+		},
+		MaxTurns: 2,
+	})
+	session, _ := agent.Session(context.Background(), "test")
+	_, err := session.Prompt(context.Background(), "go",
+		WithStreamWriter(&streamBuf),
+		WithToolLogger(&toolBuf),
+		WithEvents(func(Event) { evCount++ }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if streamBuf.String() != "hi" {
+		t.Fatalf("stream writer dropped events: %q", streamBuf.String())
+	}
+	if !strings.Contains(toolBuf.String(), "[tool] echo") {
+		t.Fatalf("tool logger dropped events: %q", toolBuf.String())
+	}
+	if evCount == 0 {
+		t.Fatal("WithEvents should still fire alongside the helpers")
+	}
+}

--- a/failover.go
+++ b/failover.go
@@ -1,0 +1,100 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/erain/glue/loop"
+)
+
+// WithFailover returns a Provider that tries each underlying provider in
+// order until one accepts a Stream. Failure modes that trigger fallover:
+//
+//   - the underlying Stream call returns a non-nil error before any
+//     event is emitted;
+//   - the underlying stream's first event is a [ProviderEventError];
+//   - the underlying stream closes immediately with no events.
+//
+// Once any non-error event is observed the wrapper commits to that
+// provider for the rest of the turn — it does not recover mid-stream.
+// This preserves the loop's "no half-streamed transcripts on retry"
+// invariant.
+//
+// Callers that want env-key probing (skip provider X when its API key
+// is unset) should pre-filter via [providers.KeyAvailable] from
+// github.com/erain/glue/providers and pass only the candidates whose
+// keys are present.
+//
+// Returns a typed error implementing [FailoverError] when all providers
+// fail; use errors.As to inspect per-provider attempts.
+func WithFailover(provs ...Provider) Provider {
+	return failoverProvider{provs: provs}
+}
+
+type failoverProvider struct {
+	provs []Provider
+}
+
+// FailoverError aggregates per-provider failures from a [WithFailover]
+// stream attempt. It implements error and exposes Attempts so callers
+// can inspect each provider's outcome.
+type FailoverError struct {
+	Attempts []FailoverAttempt
+}
+
+// FailoverAttempt is one provider's result inside a [FailoverError].
+type FailoverAttempt struct {
+	Index int
+	Err   error
+}
+
+func (e *FailoverError) Error() string {
+	parts := make([]string, 0, len(e.Attempts))
+	for _, a := range e.Attempts {
+		parts = append(parts, fmt.Sprintf("provider[%d]: %v", a.Index, a.Err))
+	}
+	return "all providers failed: " + strings.Join(parts, "; ")
+}
+
+func (f failoverProvider) Stream(ctx context.Context, req loop.ProviderRequest) (<-chan loop.ProviderEvent, error) {
+	if len(f.provs) == 0 {
+		return nil, errors.New("WithFailover: no providers")
+	}
+
+	attempts := make([]FailoverAttempt, 0, len(f.provs))
+	for i, p := range f.provs {
+		ch, err := p.Stream(ctx, req)
+		if err != nil {
+			attempts = append(attempts, FailoverAttempt{Index: i, Err: err})
+			continue
+		}
+
+		first, ok := <-ch
+		if !ok {
+			attempts = append(attempts, FailoverAttempt{Index: i, Err: errors.New("empty stream")})
+			continue
+		}
+		if first.Type == loop.ProviderEventError {
+			// drain the rest so the underlying provider can clean up
+			for range ch {
+			}
+			attempts = append(attempts, FailoverAttempt{Index: i, Err: errors.New(first.Error)})
+			continue
+		}
+
+		// commit: re-emit the first event then forward the rest.
+		out := make(chan loop.ProviderEvent, 16)
+		go func() {
+			defer close(out)
+			out <- first
+			for ev := range ch {
+				out <- ev
+			}
+		}()
+		return out, nil
+	}
+
+	return nil, &FailoverError{Attempts: attempts}
+}

--- a/failover_test.go
+++ b/failover_test.go
@@ -1,0 +1,152 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type stubProvider struct {
+	streamErr error
+	events    []ProviderEvent
+}
+
+func (s stubProvider) Stream(_ context.Context, _ ProviderRequest) (<-chan ProviderEvent, error) {
+	if s.streamErr != nil {
+		return nil, s.streamErr
+	}
+	ch := make(chan ProviderEvent, len(s.events))
+	for _, e := range s.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func okStream(text string) []ProviderEvent {
+	return []ProviderEvent{
+		{Type: ProviderEventStart},
+		{Type: ProviderEventTextDelta, Delta: text},
+		{Type: ProviderEventDone},
+	}
+}
+
+func collect(t *testing.T, ch <-chan ProviderEvent) []ProviderEvent {
+	t.Helper()
+	var out []ProviderEvent
+	for ev := range ch {
+		out = append(out, ev)
+	}
+	return out
+}
+
+func TestFailover_FirstSucceeds(t *testing.T) {
+	p := WithFailover(
+		stubProvider{events: okStream("first")},
+		stubProvider{events: okStream("second")},
+	)
+	ch, err := p.Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(t, ch)
+	if len(got) != 3 || got[1].Delta != "first" {
+		t.Fatalf("expected first provider's stream, got %+v", got)
+	}
+}
+
+func TestFailover_StreamErrorFallsThrough(t *testing.T) {
+	p := WithFailover(
+		stubProvider{streamErr: errors.New("boom")},
+		stubProvider{events: okStream("fallback")},
+	)
+	ch, err := p.Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(t, ch)
+	if len(got) != 3 || got[1].Delta != "fallback" {
+		t.Fatalf("expected fallback stream, got %+v", got)
+	}
+}
+
+func TestFailover_FirstEventErrorFallsThrough(t *testing.T) {
+	p := WithFailover(
+		stubProvider{events: []ProviderEvent{{Type: ProviderEventError, Error: "model errored"}}},
+		stubProvider{events: okStream("fallback")},
+	)
+	ch, err := p.Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(t, ch)
+	if len(got) != 3 || got[1].Delta != "fallback" {
+		t.Fatalf("expected fallback stream, got %+v", got)
+	}
+}
+
+func TestFailover_EmptyStreamFallsThrough(t *testing.T) {
+	p := WithFailover(
+		stubProvider{events: nil},
+		stubProvider{events: okStream("fallback")},
+	)
+	ch, err := p.Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(t, ch)
+	if len(got) != 3 || got[1].Delta != "fallback" {
+		t.Fatalf("expected fallback stream, got %+v", got)
+	}
+}
+
+func TestFailover_AllFailReturnsAggregateError(t *testing.T) {
+	p := WithFailover(
+		stubProvider{streamErr: errors.New("boom1")},
+		stubProvider{events: []ProviderEvent{{Type: ProviderEventError, Error: "boom2"}}},
+	)
+	_, err := p.Stream(context.Background(), ProviderRequest{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var fe *FailoverError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *FailoverError, got %T: %v", err, err)
+	}
+	if len(fe.Attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", len(fe.Attempts))
+	}
+	if !strings.Contains(err.Error(), "boom1") || !strings.Contains(err.Error(), "boom2") {
+		t.Fatalf("aggregate should include each failure: %v", err)
+	}
+}
+
+func TestFailover_NoProviders(t *testing.T) {
+	_, err := WithFailover().Stream(context.Background(), ProviderRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty failover")
+	}
+}
+
+func TestFailover_CommitsAfterFirstSuccessfulEvent(t *testing.T) {
+	// Once the first non-error event is observed, the wrapper must NOT
+	// fall through even if a later event is an error.
+	p := WithFailover(
+		stubProvider{events: []ProviderEvent{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventError, Error: "mid-stream error"},
+		}},
+		stubProvider{events: okStream("fallback")},
+	)
+	ch, err := p.Stream(context.Background(), ProviderRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(t, ch)
+	// Should be the first provider's events (commit), not the fallback.
+	if len(got) != 2 || got[1].Type != ProviderEventError {
+		t.Fatalf("expected committed-but-errored first provider, got %+v", got)
+	}
+}
+

--- a/prompts/catalog.go
+++ b/prompts/catalog.go
@@ -1,0 +1,124 @@
+// Package prompts provides a small versioned-prompt loader that wraps
+// an embed.FS rooted at a directory of `<name>.md` files. It exists so
+// agents that A/B-test prompts (or want to roll back without rebuilding)
+// don't have to re-implement the same loader each time.
+//
+// Typical usage:
+//
+//	//go:embed prompts/*.md
+//	var promptFS embed.FS
+//
+//	cat, err := prompts.NewCatalog(promptFS, "prompts", "v2")
+//	if err != nil { ... }
+//	body, err := cat.Get("v1")  // or cat.Get("") for the default
+package prompts
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+// Catalog is a frozen view over an embed.FS of `<version>.md` prompts.
+// Construct with NewCatalog. Lookups are read-only and concurrency-safe.
+type Catalog struct {
+	fsys           fs.FS
+	dir            string
+	defaultVersion string
+	versions       []string
+}
+
+// NewCatalog wraps fsys rooted at dir. Files matching `*.md` directly
+// under dir become available versions (the file stem is the version
+// name). defaultVersion must exist in the catalog or NewCatalog returns
+// an error — fail-fast on misconfiguration is preferred to silent
+// fallback at lookup time.
+func NewCatalog(fsys fs.FS, dir, defaultVersion string) (*Catalog, error) {
+	versions, err := listVersions(fsys, dir)
+	if err != nil {
+		return nil, fmt.Errorf("prompts: read %s: %w", dir, err)
+	}
+	if defaultVersion == "" {
+		return nil, fmt.Errorf("prompts: default version is required (available: %s)", strings.Join(versions, ", "))
+	}
+	if !contains(versions, defaultVersion) {
+		return nil, fmt.Errorf("prompts: default version %q not found in %s (available: %s)", defaultVersion, dir, strings.Join(versions, ", "))
+	}
+	return &Catalog{
+		fsys:           fsys,
+		dir:            dir,
+		defaultVersion: defaultVersion,
+		versions:       versions,
+	}, nil
+}
+
+// Get returns the prompt body for the requested version. Empty version
+// falls back to the default. Unknown versions return an error that
+// lists every available version verbatim — silent fallback would hide
+// A/B test misconfiguration.
+//
+// The returned body is the file content trimmed of trailing newlines
+// and re-suffixed with a single newline, so callers can append further
+// instructions without double-blank-line drift.
+func (c *Catalog) Get(version string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("prompts: nil catalog")
+	}
+	if strings.TrimSpace(version) == "" {
+		version = c.defaultVersion
+	}
+	data, err := fs.ReadFile(c.fsys, path.Join(c.dir, version+".md"))
+	if err != nil {
+		return "", fmt.Errorf("prompts: unknown version %q (available: %s)", version, strings.Join(c.versions, ", "))
+	}
+	return strings.TrimRight(string(data), "\n") + "\n", nil
+}
+
+// Versions returns every version available in the catalog, sorted.
+func (c *Catalog) Versions() []string {
+	if c == nil {
+		return nil
+	}
+	out := make([]string, len(c.versions))
+	copy(out, c.versions)
+	return out
+}
+
+// Default returns the default version supplied to NewCatalog.
+func (c *Catalog) Default() string {
+	if c == nil {
+		return ""
+	}
+	return c.defaultVersion
+}
+
+func listVersions(fsys fs.FS, dir string) ([]string, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		out = append(out, strings.TrimSuffix(name, ".md"))
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/prompts/catalog_test.go
+++ b/prompts/catalog_test.go
@@ -1,0 +1,113 @@
+package prompts
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func newTestFS() fstest.MapFS {
+	return fstest.MapFS{
+		"prompts/v1.md":   {Data: []byte("v1 body\n")},
+		"prompts/v2.md":   {Data: []byte("v2 body\n\n")},
+		"prompts/notes/x": {Data: []byte("nested non-md")},
+		"prompts/skip.txt": {Data: []byte("not markdown")},
+	}
+}
+
+func TestCatalog_GetKnownVersion(t *testing.T) {
+	cat, err := NewCatalog(newTestFS(), "prompts", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := cat.Get("v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != "v2 body\n" {
+		t.Fatalf("expected single-trailing-newline body, got %q", body)
+	}
+}
+
+func TestCatalog_GetEmptyUsesDefault(t *testing.T) {
+	cat, err := NewCatalog(newTestFS(), "prompts", "v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := cat.Get("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != "v2 body\n" {
+		t.Fatalf("expected default body, got %q", body)
+	}
+}
+
+func TestCatalog_GetUnknownLists(t *testing.T) {
+	cat, err := NewCatalog(newTestFS(), "prompts", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cat.Get("v3")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `unknown version "v3"`) {
+		t.Fatalf("error should name version: %v", err)
+	}
+	if !strings.Contains(msg, "v1") || !strings.Contains(msg, "v2") {
+		t.Fatalf("error should list available versions: %v", err)
+	}
+}
+
+func TestCatalog_NewCatalog_DefaultMustExist(t *testing.T) {
+	_, err := NewCatalog(newTestFS(), "prompts", "v9")
+	if err == nil {
+		t.Fatal("expected error when default version missing")
+	}
+	if !strings.Contains(err.Error(), `default version "v9" not found`) {
+		t.Fatalf("unexpected message: %v", err)
+	}
+}
+
+func TestCatalog_NewCatalog_EmptyDefault(t *testing.T) {
+	_, err := NewCatalog(newTestFS(), "prompts", "")
+	if err == nil {
+		t.Fatal("expected error when default version empty")
+	}
+}
+
+func TestCatalog_NewCatalog_MissingDir(t *testing.T) {
+	_, err := NewCatalog(newTestFS(), "no-such-dir", "v1")
+	if err == nil {
+		t.Fatal("expected error when dir missing")
+	}
+}
+
+func TestCatalog_VersionsAndDefault(t *testing.T) {
+	cat, err := NewCatalog(newTestFS(), "prompts", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cat.Versions()
+	if len(got) != 2 || got[0] != "v1" || got[1] != "v2" {
+		t.Fatalf("Versions() = %v; want [v1 v2]", got)
+	}
+	if cat.Default() != "v1" {
+		t.Fatalf("Default() = %q; want v1", cat.Default())
+	}
+}
+
+func TestCatalog_Nil(t *testing.T) {
+	var c *Catalog
+	if _, err := c.Get("v1"); err == nil {
+		t.Fatal("nil catalog Get should error")
+	}
+	if c.Versions() != nil {
+		t.Fatal("nil catalog Versions should be nil")
+	}
+	if c.Default() != "" {
+		t.Fatal("nil catalog Default should be empty")
+	}
+}

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -9,11 +9,28 @@ import (
 	"time"
 
 	"github.com/erain/glue/loop"
+	"github.com/erain/glue/providers"
 
 	"google.golang.org/genai"
 )
 
+// EnvKey is the environment variable the provider reads when Options.APIKey
+// is empty. Exposed so the providers registry and downstream agents can
+// probe key availability without hard-coding the name.
+const EnvKey = "GEMINI_API_KEY"
+
+// DefaultModel is the registry-level default model for this provider.
+const DefaultModel = "gemini-2.5-flash"
+
 const providerName = "gemini"
+
+func init() {
+	providers.Register(providerName, providers.Factory{
+		New:          func() loop.Provider { return New(Options{}) },
+		DefaultModel: DefaultModel,
+		EnvKey:       EnvKey,
+	})
+}
 
 // Options configures the Gemini provider.
 //
@@ -86,7 +103,7 @@ func (p *Provider) clientFor(ctx context.Context) (*genai.Client, error) {
 	}
 	apiKey := p.apiKey
 	if apiKey == "" {
-		apiKey = os.Getenv("GEMINI_API_KEY")
+		apiKey = os.Getenv(EnvKey)
 	}
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		APIKey:  apiKey,

--- a/providers/nvidia/nvidia.go
+++ b/providers/nvidia/nvidia.go
@@ -3,14 +3,34 @@ package nvidia
 import (
 	"net/http"
 
+	"github.com/erain/glue/loop"
+	"github.com/erain/glue/providers"
 	"github.com/erain/glue/providers/openaicompat"
 )
+
+// EnvKey is the environment variable the provider reads when Options.APIKey
+// is empty. Exposed so the providers registry and downstream agents can
+// probe key availability without hard-coding the name.
+const EnvKey = "NVIDIA_API_KEY"
+
+// DefaultModel is the registry-level default model for this provider.
+// Kimi K2.6 on NVIDIA build is currently the strongest free model
+// exposed through build.nvidia.com.
+const DefaultModel = "moonshotai/kimi-k2.6"
 
 const (
 	providerName   = "nvidia"
 	defaultBaseURL = "https://integrate.api.nvidia.com/v1"
-	apiKeyEnv      = "NVIDIA_API_KEY"
+	apiKeyEnv      = EnvKey
 )
+
+func init() {
+	providers.Register(providerName, providers.Factory{
+		New:          func() loop.Provider { return New(Options{}) },
+		DefaultModel: DefaultModel,
+		EnvKey:       EnvKey,
+	})
+}
 
 // Options configures the NVIDIA provider.
 //

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -3,13 +3,25 @@ package openrouter
 import (
 	"net/http"
 
+	"github.com/erain/glue/loop"
+	"github.com/erain/glue/providers"
 	"github.com/erain/glue/providers/openaicompat"
 )
+
+// EnvKey is the environment variable the provider reads when Options.APIKey
+// is empty. Exposed so the providers registry and downstream agents can
+// probe key availability without hard-coding the name.
+const EnvKey = "OPENROUTER_API_KEY"
+
+// DefaultModel is the registry-level default model. The free Ling
+// route is fast and unmetered; OpenRouter callers with a paid key
+// typically override via glue.WithModel.
+const DefaultModel = "inclusionai/ling-2.6-1t:free"
 
 const (
 	providerName   = "openrouter"
 	defaultBaseURL = "https://openrouter.ai/api/v1"
-	apiKeyEnv      = "OPENROUTER_API_KEY"
+	apiKeyEnv      = EnvKey
 
 	// Attribution headers OpenRouter recommends for clients so requests
 	// surface the calling project in their analytics. Both are overridable
@@ -17,6 +29,14 @@ const (
 	defaultRefererURL = "https://github.com/erain/glue"
 	defaultTitle      = "glue"
 )
+
+func init() {
+	providers.Register(providerName, providers.Factory{
+		New:          func() loop.Provider { return New(Options{}) },
+		DefaultModel: DefaultModel,
+		EnvKey:       EnvKey,
+	})
+}
 
 // Options configures the OpenRouter provider.
 //

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -1,0 +1,94 @@
+// Package providers exposes a small driver-style registry of provider
+// constructors. It lets callers ask for a provider by name without
+// hand-coding a switch over every shipped provider package.
+//
+// Each provider sub-package registers itself in init() so importing
+// `_ "github.com/erain/glue/providers/nvidia"` makes that provider
+// resolvable via providers.New("nvidia"). The registry holds factory
+// functions, not constructed providers, so registration is cheap and
+// has no I/O or credential side effects.
+package providers
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/erain/glue/loop"
+)
+
+// Factory describes one registered provider.
+type Factory struct {
+	// New returns a fresh provider configured with package defaults
+	// (no explicit API key — falls back to the provider's env var).
+	New func() loop.Provider
+
+	// DefaultModel is the model id callers should use when they have
+	// no opinion. The registry exposes it so a CLI agent can present
+	// `--model` defaults that vary by provider.
+	DefaultModel string
+
+	// EnvKey is the environment variable the provider reads when
+	// APIKey is empty. Used by KeyAvailable.
+	EnvKey string
+}
+
+var (
+	mu        sync.RWMutex
+	factories = map[string]Factory{}
+)
+
+// Register adds a provider to the registry. Re-registering an existing
+// name overwrites — driver-style packages may register from init() and
+// the last importer wins.
+func Register(name string, f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	factories[strings.ToLower(name)] = f
+}
+
+// Lookup returns the factory for name, or false if no provider is
+// registered under that name.
+func Lookup(name string) (Factory, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	f, ok := factories[strings.ToLower(name)]
+	return f, ok
+}
+
+// New constructs a fresh provider for the registered name. Returns the
+// provider, its default model, the env var it consults, and an error
+// if the name is unknown.
+func New(name string) (loop.Provider, string, string, error) {
+	f, ok := Lookup(name)
+	if !ok {
+		return nil, "", "", fmt.Errorf("unknown provider %q (known: %s)", name, strings.Join(Known(), ", "))
+	}
+	return f.New(), f.DefaultModel, f.EnvKey, nil
+}
+
+// Known returns the registered provider names, sorted for stable
+// output in error messages and CLI help text.
+func Known() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]string, 0, len(factories))
+	for name := range factories {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// KeyAvailable reports whether the registered provider's env var is
+// non-empty in the process environment. Returns false for unknown
+// providers and for providers registered without an EnvKey.
+func KeyAvailable(name string) bool {
+	f, ok := Lookup(name)
+	if !ok || f.EnvKey == "" {
+		return false
+	}
+	return strings.TrimSpace(os.Getenv(f.EnvKey)) != ""
+}

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -1,0 +1,90 @@
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue/loop"
+)
+
+type fakeProv struct{ name string }
+
+func (fakeProv) Stream(_ context.Context, _ loop.ProviderRequest) (<-chan loop.ProviderEvent, error) {
+	ch := make(chan loop.ProviderEvent)
+	close(ch)
+	return ch, nil
+}
+
+func TestRegistry_RegisterAndNew(t *testing.T) {
+	Register("test-fake", Factory{
+		New:          func() loop.Provider { return fakeProv{name: "fake"} },
+		DefaultModel: "fake/model",
+		EnvKey:       "TEST_FAKE_KEY",
+	})
+
+	p, model, env, err := New("test-fake")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+	if model != "fake/model" {
+		t.Fatalf("model: got %q want %q", model, "fake/model")
+	}
+	if env != "TEST_FAKE_KEY" {
+		t.Fatalf("env: got %q want %q", env, "TEST_FAKE_KEY")
+	}
+}
+
+func TestRegistry_Unknown(t *testing.T) {
+	_, _, _, err := New("definitely-not-registered")
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "unknown provider") {
+		t.Fatalf("error should include 'unknown provider': %v", err)
+	}
+}
+
+func TestRegistry_KeyAvailable(t *testing.T) {
+	Register("test-key-probe", Factory{
+		New:    func() loop.Provider { return fakeProv{} },
+		EnvKey: "TEST_KEY_PROBE_VAR",
+	})
+
+	t.Setenv("TEST_KEY_PROBE_VAR", "")
+	if KeyAvailable("test-key-probe") {
+		t.Fatal("expected false when env var unset")
+	}
+	t.Setenv("TEST_KEY_PROBE_VAR", "value")
+	if !KeyAvailable("test-key-probe") {
+		t.Fatal("expected true when env var set")
+	}
+
+	if KeyAvailable("not-registered") {
+		t.Fatal("unknown provider must not report KeyAvailable=true")
+	}
+}
+
+func TestRegistry_KnownIsSorted(t *testing.T) {
+	got := Known()
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Fatalf("Known() not sorted: %v", got)
+		}
+	}
+}
+
+func TestRegistry_CaseInsensitive(t *testing.T) {
+	Register("MixedCase", Factory{
+		New: func() loop.Provider { return fakeProv{} },
+	})
+	if _, ok := Lookup("mixedcase"); !ok {
+		t.Fatal("Lookup must be case-insensitive")
+	}
+	if _, ok := Lookup("MIXEDCASE"); !ok {
+		t.Fatal("Lookup must be case-insensitive on uppercase too")
+	}
+}

--- a/session.go
+++ b/session.go
@@ -94,6 +94,7 @@ type promptConfig struct {
 	options      map[string]any
 	maxTurns     int
 	emit         func(Event)
+	auxEmits     []func(Event)
 	jsonSchema   any
 	role         string
 	modelSet     bool
@@ -203,6 +204,9 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 		Emit: func(event Event) {
 			if config.emit != nil {
 				config.emit(event)
+			}
+			for _, aux := range config.auxEmits {
+				aux(event)
 			}
 			s.dispatchEvent(event)
 		},

--- a/tool_helpers.go
+++ b/tool_helpers.go
@@ -1,0 +1,48 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// TextResult wraps a string in a ToolResult with a single text content part.
+// Use it from tool executors when the tool succeeds with textual output.
+func TextResult(s string) ToolResult {
+	return ToolResult{
+		Content: []ContentPart{{Type: ContentTypeText, Text: s}},
+	}
+}
+
+// ErrorResult wraps an error in a ToolResult tagged with IsError=true so the
+// model sees it as a tool failure rather than the loop crashing. The error's
+// Error() string becomes the visible text.
+func ErrorResult(err error) ToolResult {
+	return ToolResult{
+		Content: []ContentPart{{Type: ContentTypeText, Text: err.Error()}},
+		IsError: true,
+	}
+}
+
+// NewTool builds a Tool whose executor decodes ToolCall.Arguments into a
+// typed Go value before invoking fn. Empty arguments decode as the zero
+// value of T. JSON decode failures surface to the model as an error
+// ToolResult — matching the existing manual pattern — so a malformed call
+// does not crash the loop.
+//
+// Callers still supply spec.Parameters (a JSON Schema). Schema generation
+// from T is intentionally out of scope.
+func NewTool[T any](spec ToolSpec, fn func(ctx context.Context, args T) (ToolResult, error)) Tool {
+	return Tool{
+		ToolSpec: spec,
+		Execute: func(ctx context.Context, call ToolCall) (ToolResult, error) {
+			var args T
+			if len(call.Arguments) > 0 {
+				if err := json.Unmarshal(call.Arguments, &args); err != nil {
+					return ErrorResult(fmt.Errorf("decode arguments for tool %q: %w", spec.Name, err)), nil
+				}
+			}
+			return fn(ctx, args)
+		},
+	}
+}

--- a/tool_helpers_test.go
+++ b/tool_helpers_test.go
@@ -1,0 +1,110 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTextResult(t *testing.T) {
+	r := TextResult("hello")
+	if r.IsError {
+		t.Fatalf("TextResult must not be tagged IsError")
+	}
+	if len(r.Content) != 1 || r.Content[0].Type != ContentTypeText || r.Content[0].Text != "hello" {
+		t.Fatalf("unexpected content: %+v", r.Content)
+	}
+}
+
+func TestErrorResult(t *testing.T) {
+	r := ErrorResult(errors.New("boom"))
+	if !r.IsError {
+		t.Fatalf("ErrorResult must be tagged IsError")
+	}
+	if len(r.Content) != 1 || r.Content[0].Text != "boom" {
+		t.Fatalf("unexpected content: %+v", r.Content)
+	}
+}
+
+type echoArgs struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestNewTool_DecodesTypedArgs(t *testing.T) {
+	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
+		return TextResult(a.Name + "/" + intStr(a.Count)), nil
+	})
+
+	res, err := tool.Execute(context.Background(), ToolCall{
+		Name:      "echo",
+		Arguments: json.RawMessage(`{"name":"glue","count":3}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %+v", res)
+	}
+	if got := res.Content[0].Text; got != "glue/3" {
+		t.Fatalf("unexpected text: %q", got)
+	}
+}
+
+func TestNewTool_EmptyArgsZeroValue(t *testing.T) {
+	called := false
+	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
+		called = true
+		if a.Name != "" || a.Count != 0 {
+			t.Fatalf("expected zero value, got %+v", a)
+		}
+		return TextResult("ok"), nil
+	})
+	if _, err := tool.Execute(context.Background(), ToolCall{Name: "echo"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !called {
+		t.Fatalf("fn not invoked on empty args")
+	}
+}
+
+func TestNewTool_MalformedArgsReturnsErrorResult(t *testing.T) {
+	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
+		t.Fatalf("fn should not be invoked on malformed args")
+		return ToolResult{}, nil
+	})
+	res, err := tool.Execute(context.Background(), ToolCall{
+		Name:      "echo",
+		Arguments: json.RawMessage(`{not-json`),
+	})
+	if err != nil {
+		t.Fatalf("Execute returned err=%v; expected error ToolResult, not loop crash", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true on malformed args; got %+v", res)
+	}
+	if !strings.Contains(res.Content[0].Text, `tool "echo"`) {
+		t.Fatalf("expected error text to name the tool; got %q", res.Content[0].Text)
+	}
+}
+
+func intStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}

--- a/tool_helpers_test.go
+++ b/tool_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -35,7 +36,7 @@ type echoArgs struct {
 
 func TestNewTool_DecodesTypedArgs(t *testing.T) {
 	tool := NewTool[echoArgs](ToolSpec{Name: "echo"}, func(_ context.Context, a echoArgs) (ToolResult, error) {
-		return TextResult(a.Name + "/" + intStr(a.Count)), nil
+		return TextResult(a.Name + "/" + strconv.Itoa(a.Count)), nil
 	})
 
 	res, err := tool.Execute(context.Background(), ToolCall{
@@ -90,21 +91,3 @@ func TestNewTool_MalformedArgsReturnsErrorResult(t *testing.T) {
 	}
 }
 
-func intStr(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	digits := []byte{}
-	for n > 0 {
-		digits = append([]byte{byte('0' + n%10)}, digits...)
-		n /= 10
-	}
-	if neg {
-		digits = append([]byte{'-'}, digits...)
-	}
-	return string(digits)
-}

--- a/tools/fs/blocklist.go
+++ b/tools/fs/blocklist.go
@@ -1,0 +1,136 @@
+package fs
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Blocklist is an ordered list of glob patterns matched against paths
+// the model asks to read. The matcher is three-way: whole-path, basename,
+// and per-component, all case-insensitive — so a model that types
+// `secrets/foo.txt` is rejected by the `secrets` pattern even though
+// the basename is `foo.txt`.
+//
+// Patterns use Go's filepath.Match semantics (`*`, `?`, character
+// classes). Add deployment-specific extensions via Merge; you cannot
+// subtract a default.
+type Blocklist []string
+
+// Default returns the built-in patterns: secret-shaped dotfiles, SSH key
+// material, cloud credential bundles, and "*secret*" naming. The list
+// targets files that PRs accidentally add and that an agent could be
+// tricked into quoting into a public review comment.
+func Default() Blocklist {
+	return Blocklist{
+		// Environment / secret bag dotfiles
+		".env",
+		".env.*",
+		".envrc",
+		".npmrc",
+		".netrc",
+		".pgpass",
+
+		// SSH / key material
+		"id_rsa", "id_rsa.*",
+		"id_ed25519", "id_ed25519.*",
+		"id_dsa", "id_dsa.*",
+		"id_ecdsa", "id_ecdsa.*",
+		"*.pem",
+		"*.key",
+		"*.p12",
+		"*.pfx",
+		"*.jks",
+
+		// Cloud / service account credentials
+		"credentials",
+		"credentials.json",
+		"service-account*.json",
+		"client-secret*.json",
+		"*.kubeconfig",
+
+		// Generic "secret" naming
+		"*_secret*",
+		"*_secrets*",
+		"*.secret",
+		"*.secrets",
+		"secret.*",
+		"secrets.*",
+		"secrets",
+
+		// AWS CLI / GCloud / Azure credential dirs
+		".aws",
+		".gcloud",
+		".azure",
+	}
+}
+
+// Merge returns a new Blocklist that appends extras to the receiver,
+// trimming and deduping. The receiver is not mutated.
+//
+// Use this when a deployment wants to add patterns: pass the user
+// input through Merge to layer it on top of Default(). Passing no
+// extras yields the receiver unchanged (after dedup).
+func (b Blocklist) Merge(extras ...string) Blocklist {
+	out := make(Blocklist, 0, len(b)+len(extras))
+	seen := map[string]struct{}{}
+	for _, p := range b {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	for _, p := range extras {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+// Match reports whether rel is blocked by any pattern in the list. The
+// returned pattern names which entry matched, for use in error messages.
+//
+// rel is matched three ways: as a whole path, as a basename, and as
+// each path component. All matches are case-insensitive on the
+// basename/component paths so `.ENV` and `Credentials.json` match the
+// lowercase patterns.
+func (b Blocklist) Match(rel string) (bool, string) {
+	clean := strings.TrimSpace(rel)
+	if clean == "" {
+		return false, ""
+	}
+	clean = filepath.ToSlash(clean)
+	base := filepath.Base(clean)
+	parts := strings.Split(clean, "/")
+
+	for _, pat := range b {
+		pat = strings.TrimSpace(pat)
+		if pat == "" {
+			continue
+		}
+		if ok, _ := filepath.Match(pat, clean); ok {
+			return true, pat
+		}
+		lowPat := strings.ToLower(pat)
+		if ok, _ := filepath.Match(lowPat, strings.ToLower(base)); ok {
+			return true, pat
+		}
+		for _, p := range parts {
+			if ok, _ := filepath.Match(lowPat, strings.ToLower(p)); ok {
+				return true, pat
+			}
+		}
+	}
+	return false, ""
+}

--- a/tools/fs/blocklist_test.go
+++ b/tools/fs/blocklist_test.go
@@ -1,0 +1,74 @@
+package fs
+
+import "testing"
+
+func TestBlocklistDefault_RejectsCommonSecrets(t *testing.T) {
+	bl := Default()
+	hits := []string{
+		".env",
+		".env.production",
+		"id_rsa",
+		"id_ed25519.pub",
+		"server.pem",
+		"deploy.key",
+		"credentials.json",
+		"service-account-prod.json",
+		"deep/path/to/.env",
+		"app/secrets/db.yaml",
+		".aws/credentials",
+		".AWS/CREDENTIALS",
+	}
+	for _, p := range hits {
+		t.Run("hit:"+p, func(t *testing.T) {
+			ok, pat := bl.Match(p)
+			if !ok {
+				t.Fatalf("expected %q to match a default pattern; pattern=%q", p, pat)
+			}
+		})
+	}
+}
+
+func TestBlocklistDefault_AllowsOrdinaryPaths(t *testing.T) {
+	bl := Default()
+	ok := []string{
+		"main.go",
+		"docs/design.md",
+		"README.md",
+		"src/handler.go",
+		"package.json",
+	}
+	for _, p := range ok {
+		t.Run("allow:"+p, func(t *testing.T) {
+			if blocked, pat := bl.Match(p); blocked {
+				t.Fatalf("expected %q to be allowed; matched pattern %q", p, pat)
+			}
+		})
+	}
+}
+
+func TestBlocklistMerge_AddsExtras(t *testing.T) {
+	bl := Default().Merge("vault.json", "vault.json", "  ", "*.token")
+	ok, pat := bl.Match("vault.json")
+	if !ok || pat != "vault.json" {
+		t.Fatalf("merged extra not active: ok=%v pat=%q", ok, pat)
+	}
+	ok, pat = bl.Match("session.token")
+	if !ok || pat != "*.token" {
+		t.Fatalf("merged glob not active: ok=%v pat=%q", ok, pat)
+	}
+}
+
+func TestBlocklistMerge_DoesNotMutateReceiver(t *testing.T) {
+	bl := Default()
+	before := len(bl)
+	_ = bl.Merge("foo")
+	if len(bl) != before {
+		t.Fatalf("Merge mutated receiver: before=%d after=%d", before, len(bl))
+	}
+}
+
+func TestBlocklistMatch_EmptyPath(t *testing.T) {
+	if ok, _ := Default().Match(""); ok {
+		t.Fatal("empty path must not match")
+	}
+}

--- a/tools/fs/fs.go
+++ b/tools/fs/fs.go
@@ -1,0 +1,63 @@
+// Package fs provides filesystem helpers and tool factories that agents
+// can register without reinventing path safety, output truncation, or
+// the sensitive-file blocklist.
+//
+// The package is intentionally outside the core glue package so the
+// harness stays free of POSIX coupling per ADR 0003. Importing fs gives
+// you ready-to-register tools (e.g. ReadFileTool) plus the primitives
+// they are built on (SafeJoin, Truncate, Blocklist).
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// SafeJoin resolves rel against base and rejects any path that escapes
+// base via "..", absolute prefixes, or symlinks. Returns the cleaned
+// absolute path on success.
+//
+// Use this from any tool that accepts a model-supplied path: a model
+// will eventually try `../../../etc/passwd`, and SafeJoin's job is to
+// turn that into an error before os.Open ever runs.
+func SafeJoin(base, rel string) (string, error) {
+	rel = strings.TrimSpace(rel)
+	if rel == "" {
+		return "", errors.New("path is required")
+	}
+	if filepath.IsAbs(rel) {
+		return "", errors.New("absolute paths are not allowed")
+	}
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return "", err
+	}
+	candidate := filepath.Clean(filepath.Join(absBase, rel))
+	rel2, err := filepath.Rel(absBase, candidate)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(rel2, "..") || rel2 == ".." {
+		return "", fmt.Errorf("path %q escapes work directory", rel)
+	}
+	return candidate, nil
+}
+
+// Truncate caps s at max bytes, appending a visible truncation marker
+// when the cap is hit. Returns s unchanged when len(s) <= max.
+//
+// Designed for tool-output capping: a runaway diff or log read should
+// shrink to a bounded size with a marker the model can recognize,
+// rather than silently dropping the tail.
+func Truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	const note = "\n\n[... truncated]"
+	if max <= len(note) {
+		return s[:max]
+	}
+	return s[:max-len(note)] + note
+}

--- a/tools/fs/fs_test.go
+++ b/tools/fs/fs_test.go
@@ -1,0 +1,76 @@
+package fs
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSafeJoin(t *testing.T) {
+	base := t.TempDir()
+	cases := []struct {
+		name    string
+		rel     string
+		wantErr string
+	}{
+		{"empty", "", "path is required"},
+		{"absolute", "/etc/passwd", "absolute paths are not allowed"},
+		{"traversal", "../outside", "escapes work directory"},
+		{"deep traversal", "a/b/../../../outside", "escapes work directory"},
+		{"trailing dotdot", "a/..", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SafeJoin(base, tc.rel)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.HasPrefix(got, base) {
+					t.Fatalf("resolved %q not under base %q", got, base)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got success: %q", tc.wantErr, got)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSafeJoin_AcceptsValidNested(t *testing.T) {
+	base := t.TempDir()
+	got, err := SafeJoin(base, "subdir/file.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(base, "subdir", "file.go")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"under cap", "hello", 10, "hello"},
+		{"exact cap", "hello", 5, "hello"},
+		{"over cap with marker fits", strings.Repeat("a", 100), 50, strings.Repeat("a", 50-len("\n\n[... truncated]")) + "\n\n[... truncated]"},
+		{"over cap, marker too big", "abcdefghij", 5, "abcde"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Truncate(tc.in, tc.max)
+			if got != tc.want {
+				t.Fatalf("Truncate(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/fs/read.go
+++ b/tools/fs/read.go
@@ -1,0 +1,87 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/erain/glue"
+)
+
+// DefaultReadMaxBytes is the default cap on a single read_file call.
+const DefaultReadMaxBytes = 80 * 1024
+
+// ReadFileOptions configures ReadFileTool.
+type ReadFileOptions struct {
+	// WorkDir is the root the tool reads under. Paths supplied by the
+	// model are resolved relative to WorkDir and rejected if they
+	// escape it.
+	WorkDir string
+
+	// Blocklist refuses paths matching these glob patterns. Pass
+	// fs.Default().Merge(extras...) to layer extras on top of the
+	// shipped defaults.
+	Blocklist Blocklist
+
+	// MaxBytes caps the returned content. Zero falls back to
+	// DefaultReadMaxBytes.
+	MaxBytes int
+}
+
+type readFileArgs struct {
+	Path     string `json:"path"`
+	MaxBytes int    `json:"max_bytes"`
+}
+
+// ReadFileTool returns a glue.Tool named "read_file" that reads UTF-8
+// text from opts.WorkDir, refuses sensitive paths, and truncates output
+// to the requested size. Errors are returned as error ToolResults so
+// the model can recover, not as Go errors that crash the loop.
+func ReadFileTool(opts ReadFileOptions) glue.Tool {
+	max := opts.MaxBytes
+	if max <= 0 {
+		max = DefaultReadMaxBytes
+	}
+	workDir := opts.WorkDir
+	blocklist := opts.Blocklist
+
+	return glue.NewTool[readFileArgs](
+		glue.ToolSpec{
+			Name:        "read_file",
+			Description: "Read a UTF-8 text file from the working directory. Returns the file content, truncated if larger than max_bytes. Use this to inspect files mentioned in the diff when surrounding context is needed. Refuses to open secret-shaped files (.env, id_rsa, *.pem, credentials.json, etc.).",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "path":      { "type": "string", "description": "Path relative to the working directory. '..' traversal is rejected." },
+    "max_bytes": { "type": "integer", "description": "Cap on returned bytes. Default 81920." }
+  },
+  "required": ["path"]
+}`),
+		},
+		func(_ context.Context, a readFileArgs) (glue.ToolResult, error) {
+			if blocked, pat := blocklist.Match(a.Path); blocked {
+				return glue.ErrorResult(fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", a.Path, pat)), nil
+			}
+			resolved, err := SafeJoin(workDir, a.Path)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			cap := a.MaxBytes
+			if cap <= 0 {
+				cap = max
+			}
+			f, err := os.Open(resolved)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			defer f.Close()
+			data, err := io.ReadAll(io.LimitReader(f, int64(cap)+1))
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return glue.TextResult(Truncate(string(data), cap)), nil
+		},
+	)
+}

--- a/tools/fs/read.go
+++ b/tools/fs/read.go
@@ -68,20 +68,20 @@ func ReadFileTool(opts ReadFileOptions) glue.Tool {
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
-			cap := a.MaxBytes
-			if cap <= 0 {
-				cap = max
+			limit := a.MaxBytes
+			if limit <= 0 {
+				limit = max
 			}
 			f, err := os.Open(resolved)
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
 			defer f.Close()
-			data, err := io.ReadAll(io.LimitReader(f, int64(cap)+1))
+			data, err := io.ReadAll(io.LimitReader(f, int64(limit)+1))
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
-			return glue.TextResult(Truncate(string(data), cap)), nil
+			return glue.TextResult(Truncate(string(data), limit)), nil
 		},
 	)
 }

--- a/tools/fs/read_test.go
+++ b/tools/fs/read_test.go
@@ -1,0 +1,85 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestReadFileTool_ReadsAndTruncates(t *testing.T) {
+	dir := t.TempDir()
+	body := strings.Repeat("a", 200)
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := ReadFileTool(ReadFileOptions{WorkDir: dir, Blocklist: Default(), MaxBytes: 50})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{"path":"f.txt"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].Text)
+	}
+	got := res.Content[0].Text
+	if !strings.HasSuffix(got, "[... truncated]") {
+		t.Fatalf("expected truncation marker; got %q", got)
+	}
+	if len(got) != 50 {
+		t.Fatalf("expected len=50, got %d", len(got))
+	}
+}
+
+func TestReadFileTool_BlocksSensitivePath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("S=1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := ReadFileTool(ReadFileOptions{WorkDir: dir, Blocklist: Default()})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{"path":".env"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected blocklist rejection, got success: %s", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "blocked by sensitive-file pattern") {
+		t.Fatalf("unexpected error message: %q", res.Content[0].Text)
+	}
+}
+
+func TestReadFileTool_RejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	tool := ReadFileTool(ReadFileOptions{WorkDir: dir})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{"path":"../escape"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected traversal rejection")
+	}
+}
+
+func TestReadFileTool_MissingPathArg(t *testing.T) {
+	tool := ReadFileTool(ReadFileOptions{WorkDir: t.TempDir()})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected error result on missing path")
+	}
+}

--- a/tools/git/diff.go
+++ b/tools/git/diff.go
@@ -1,0 +1,92 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/erain/glue"
+	tfs "github.com/erain/glue/tools/fs"
+)
+
+// DefaultDiffMaxBytes caps the diff returned by DiffBranchTool when the
+// model does not request a smaller cap.
+const DefaultDiffMaxBytes = 200 * 1024
+
+// DiffBranchOptions configures DiffBranchTool.
+type DiffBranchOptions struct {
+	// WorkDir is the git repo to diff in. Required.
+	WorkDir string
+
+	// Pathspec is appended after `--`; build with BuildPathspec from
+	// deployment-supplied include/exclude globs. Empty means "all
+	// changed files".
+	Pathspec []string
+
+	// DefaultBase is used when the tool call does not specify `base`.
+	// Empty falls back to "main".
+	DefaultBase string
+
+	// MaxBytes caps the returned diff. Zero falls back to
+	// DefaultDiffMaxBytes.
+	MaxBytes int
+
+	// Timeout caps a single git invocation. Zero falls back to
+	// DefaultRunTimeout from RunGit.
+	Timeout time.Duration
+}
+
+type diffBranchArgs struct {
+	Base     string `json:"base"`
+	MaxBytes int    `json:"max_bytes"`
+}
+
+// DiffBranchTool returns a glue.Tool named "git_diff_branch" that runs
+// `git diff --no-color <base>...HEAD` in opts.WorkDir, optionally
+// pathspec-filtered. Errors surface as error ToolResults so the model
+// can recover.
+func DiffBranchTool(opts DiffBranchOptions) glue.Tool {
+	defaultBase := opts.DefaultBase
+	if defaultBase == "" {
+		defaultBase = "main"
+	}
+	maxBytes := opts.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultDiffMaxBytes
+	}
+
+	return glue.NewTool[diffBranchArgs](
+		glue.ToolSpec{
+			Name:        "git_diff_branch",
+			Description: "Show the diff of the current branch versus a base ref (default 'main'). Includes file additions, deletions, and modifications. The diff may be pre-filtered by deployment-supplied path globs — only files in scope appear. Use this first to scope the review.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "base": { "type": "string", "description": "Base ref to diff against. Default 'main'." },
+    "max_bytes": { "type": "integer", "description": "Cap on returned diff size in bytes. Default 204800." }
+  }
+}`),
+		},
+		func(ctx context.Context, a diffBranchArgs) (glue.ToolResult, error) {
+			base := strings.TrimSpace(a.Base)
+			if base == "" {
+				base = defaultBase
+			}
+			cap := a.MaxBytes
+			if cap <= 0 {
+				cap = maxBytes
+			}
+			gitArgs := []string{"diff", "--no-color", base + "...HEAD"}
+			if len(opts.Pathspec) > 0 {
+				gitArgs = append(gitArgs, "--")
+				gitArgs = append(gitArgs, opts.Pathspec...)
+			}
+			out, err := RunGit(ctx, RunOptions{WorkDir: opts.WorkDir, Timeout: opts.Timeout}, gitArgs...)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return glue.TextResult(tfs.Truncate(out, cap)), nil
+		},
+	)
+}

--- a/tools/git/diff.go
+++ b/tools/git/diff.go
@@ -73,9 +73,9 @@ func DiffBranchTool(opts DiffBranchOptions) glue.Tool {
 			if base == "" {
 				base = defaultBase
 			}
-			cap := a.MaxBytes
-			if cap <= 0 {
-				cap = maxBytes
+			limit := a.MaxBytes
+			if limit <= 0 {
+				limit = maxBytes
 			}
 			gitArgs := []string{"diff", "--no-color", base + "...HEAD"}
 			if len(opts.Pathspec) > 0 {
@@ -86,7 +86,7 @@ func DiffBranchTool(opts DiffBranchOptions) glue.Tool {
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
-			return glue.TextResult(tfs.Truncate(out, cap)), nil
+			return glue.TextResult(tfs.Truncate(out, limit)), nil
 		},
 	)
 }

--- a/tools/git/git.go
+++ b/tools/git/git.go
@@ -1,0 +1,89 @@
+// Package git provides git tool factories and shell-out helpers that
+// agents can register without re-implementing PATH lookup, timeout
+// management, or pathspec construction.
+//
+// The package is intentionally outside the core glue package so the
+// harness stays free of POSIX coupling per ADR 0003. RunGit shells out
+// to the system `git` binary; importing this package does not pull in
+// a Git library.
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// DefaultRunTimeout caps a single git invocation. Override per-call via
+// RunOptions.Timeout when a long-running operation is expected.
+const DefaultRunTimeout = 15 * time.Second
+
+// RunOptions configures RunGit.
+type RunOptions struct {
+	// WorkDir is the cwd for the git invocation. Required.
+	WorkDir string
+
+	// Timeout caps a single invocation. Zero falls back to
+	// DefaultRunTimeout.
+	Timeout time.Duration
+}
+
+// RunGit invokes the system `git` binary in opts.WorkDir with the given
+// arguments. Stdout is returned on success; on failure the returned
+// error includes the command line and trimmed stderr so callers can
+// surface a useful message to the model.
+func RunGit(ctx context.Context, opts RunOptions, args ...string) (string, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", errors.New("git binary not found in PATH")
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultRunTimeout
+	}
+	dctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.CommandContext(dctx, "git", args...)
+	cmd.Dir = opts.WorkDir
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(errBuf.String()))
+	}
+	return out.String(), nil
+}
+
+// BuildPathspec converts include / exclude glob lists into Git pathspec
+// arguments. The Git CLI accepts:
+//
+//   - bare patterns as include filters (e.g. `*.go`, `cmd/...`)
+//   - `:(exclude)pattern` as exclude filters
+//
+// Excludes only take effect after at least one include pattern is
+// present, so when callers pass only excludes we add `*` as an explicit
+// catch-all include — matching the intuitive "review everything except X"
+// semantics.
+//
+// Returns nil when both lists are empty so callers can branch on
+// len(out) > 0 to decide whether to emit a `--` separator.
+func BuildPathspec(includes, excludes []string) []string {
+	if len(includes) == 0 && len(excludes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(includes)+len(excludes))
+	for _, p := range includes {
+		out = append(out, p)
+	}
+	if len(out) == 0 && len(excludes) > 0 {
+		out = append(out, "*")
+	}
+	for _, p := range excludes {
+		out = append(out, ":(exclude)"+p)
+	}
+	return out
+}

--- a/tools/git/git_test.go
+++ b/tools/git/git_test.go
@@ -1,0 +1,143 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestBuildPathspec(t *testing.T) {
+	cases := []struct {
+		name     string
+		includes []string
+		excludes []string
+		want     []string
+	}{
+		{"both empty", nil, nil, nil},
+		{"includes only", []string{"*.go", "cmd/..."}, nil, []string{"*.go", "cmd/..."}},
+		{"excludes only adds catch-all", nil, []string{"vendor/*"}, []string{"*", ":(exclude)vendor/*"}},
+		{"include + exclude", []string{"*.go"}, []string{"*_test.go"}, []string{"*.go", ":(exclude)*_test.go"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildPathspec(tc.includes, tc.excludes)
+			if !equalSlice(got, tc.want) {
+				t.Fatalf("BuildPathspec(%v, %v) = %v, want %v", tc.includes, tc.excludes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunGit_VersionWorks(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	out, err := RunGit(context.Background(), RunOptions{WorkDir: t.TempDir()}, "--version")
+	if err != nil {
+		t.Fatalf("git --version: %v", err)
+	}
+	if !strings.HasPrefix(out, "git version") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestRunGit_ErrorIncludesStderr(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	_, err := RunGit(context.Background(), RunOptions{WorkDir: t.TempDir()}, "log")
+	if err == nil {
+		t.Fatal("expected error from git log in empty dir")
+	}
+	if !strings.Contains(err.Error(), "git log") {
+		t.Fatalf("error should reference command: %v", err)
+	}
+}
+
+func TestDiffBranchTool_AgainstScratchRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	repo := initScratchRepo(t)
+
+	tool := DiffBranchTool(DiffBranchOptions{WorkDir: repo})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "feature.go") {
+		t.Fatalf("expected diff to mention feature.go; got %q", res.Content[0].Text)
+	}
+}
+
+func TestLogBranchTool_AgainstScratchRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	repo := initScratchRepo(t)
+
+	tool := LogBranchTool(LogBranchOptions{WorkDir: repo})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "add feature") {
+		t.Fatalf("expected log to mention 'add feature'; got %q", res.Content[0].Text)
+	}
+}
+
+func initScratchRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	mustGit(t, repo, "init", "-q", "-b", "main")
+	mustGit(t, repo, "commit", "--allow-empty", "-q", "-m", "init")
+	mustGit(t, repo, "checkout", "-q", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "feature.go")
+	mustGit(t, repo, "commit", "-q", "-m", "add feature")
+	return repo
+}
+
+func mustGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v (%s)", args, err, out)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/git/log.go
+++ b/tools/git/log.go
@@ -1,0 +1,88 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+// DefaultLogLimit caps the commit count returned by LogBranchTool when
+// the model does not request a smaller limit.
+const DefaultLogLimit = 50
+
+// LogBranchOptions configures LogBranchTool.
+type LogBranchOptions struct {
+	// WorkDir is the git repo to read commits from. Required.
+	WorkDir string
+
+	// DefaultBase is used when the tool call does not specify `base`.
+	// Empty falls back to "main".
+	DefaultBase string
+
+	// DefaultLimit is used when the tool call does not specify `limit`.
+	// Zero falls back to DefaultLogLimit.
+	DefaultLimit int
+
+	// Timeout caps a single git invocation. Zero falls back to
+	// DefaultRunTimeout from RunGit.
+	Timeout time.Duration
+}
+
+type logBranchArgs struct {
+	Base  string `json:"base"`
+	Limit int    `json:"limit"`
+}
+
+// LogBranchTool returns a glue.Tool named "git_log_branch" that runs
+// `git log --no-color -n<limit> <base>..HEAD` with a stable
+// pretty-format. Useful for reading commit messages to understand
+// author intent.
+func LogBranchTool(opts LogBranchOptions) glue.Tool {
+	defaultBase := opts.DefaultBase
+	if defaultBase == "" {
+		defaultBase = "main"
+	}
+	defaultLimit := opts.DefaultLimit
+	if defaultLimit <= 0 {
+		defaultLimit = DefaultLogLimit
+	}
+
+	return glue.NewTool[logBranchArgs](
+		glue.ToolSpec{
+			Name:        "git_log_branch",
+			Description: "Show the commit history of the current branch since a base ref (default 'main'). Useful for reading commit messages to understand author intent.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "base":  { "type": "string", "description": "Base ref. Default 'main'." },
+    "limit": { "type": "integer", "description": "Max commits returned. Default 50." }
+  }
+}`),
+		},
+		func(ctx context.Context, a logBranchArgs) (glue.ToolResult, error) {
+			base := strings.TrimSpace(a.Base)
+			if base == "" {
+				base = defaultBase
+			}
+			limit := a.Limit
+			if limit <= 0 {
+				limit = defaultLimit
+			}
+			out, err := RunGit(ctx, RunOptions{WorkDir: opts.WorkDir, Timeout: opts.Timeout},
+				"log",
+				"--no-color",
+				fmt.Sprintf("-n%d", limit),
+				"--pretty=format:%h %an  %s%n%b%n---",
+				base+"..HEAD",
+			)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return glue.TextResult(out), nil
+		},
+	)
+}


### PR DESCRIPTION
## Summary

- New package `github.com/erain/glue/prompts` with `Catalog` (`NewCatalog`, `Get`, `Versions`, `Default`).
- Mirrors the `agents/glue-review/prompt.go` pattern: A/B-test prompts via `embed.FS`, roll back without rebuilding history, and reject unknown versions with an error that lists every available version (no silent fallback).
- `NewCatalog` validates `defaultVersion` exists at construction time so misconfiguration fails fast.
- Templating/variable substitution intentionally out of scope; rendering is the caller's job.
- README "Versioned prompts" subsection added. Migration of `agents/glue-review/prompt.go` onto this catalog filed as a follow-up.

Stacked on #95–#98. Closes #92.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./prompts -count=1` (8/8 passing — known/empty/unknown lookups, default-must-exist, missing-dir, Versions/Default getters, nil-catalog safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)