### PR TITLE
ci: fix openrouter live tests (skip 429 + swap to ring-2.6-1t)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,9 @@ jobs:
           # Pin a deterministic free model with a consistently-available
           # upstream (Novita). Popular routes (google/gemma-4-*:free,
           # minimax-m2.5:free) are over-subscribed and 429 frequently.
-          OPENROUTER_LIVE_MODEL: inclusionai/ling-2.6-1t:free
+          # Previous pin (ling-2.6-1t:free) graduated to paid 2026-05;
+          # ring is its successor in the same InclusionAI family.
+          OPENROUTER_LIVE_MODEL: inclusionai/ring-2.6-1t:free
         run: |
           if [ -z "$OPENROUTER_API_KEY" ]; then
             echo "OPENROUTER_API_KEY not configured; skipping live tests."

--- a/agents/glue-review/README.md
+++ b/agents/glue-review/README.md
@@ -258,7 +258,7 @@ glue-review --provider gemini --model gemini-2.5-flash
 |---|---|---|
 | `--base` | `main` | Base ref to diff against. |
 | `--provider` | `nvidia` | One of `nvidia`, `openrouter`, `gemini`. |
-| `--model` | provider-specific | NVIDIA: `moonshotai/kimi-k2.6`; OpenRouter: `inclusionai/ling-2.6-1t:free`; Gemini: `gemini-2.5-flash`. |
+| `--model` | provider-specific | NVIDIA: `moonshotai/kimi-k2.6`; OpenRouter: `inclusionai/ring-2.6-1t:free`; Gemini: `gemini-2.5-flash`. |
 | `--id` | `glue-review` | Session id. Sessions are file-backed under `--store`. |
 | `--store` | `.glue/review-sessions` | Where the file-backed session store lives. |
 | `--work` | `.` | Working directory; must be inside the Git repo. |

--- a/agents/glue-review/action.yml
+++ b/agents/glue-review/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: |
       Model id. When empty, uses the provider-specific default
       (NVIDIA: moonshotai/kimi-k2.6, OpenRouter:
-      inclusionai/ling-2.6-1t:free, Gemini: gemini-2.5-flash).
+      inclusionai/ring-2.6-1t:free, Gemini: gemini-2.5-flash).
     required: false
     default: ''
   base-ref:

--- a/agents/glue-review/fixture_test.go
+++ b/agents/glue-review/fixture_test.go
@@ -214,7 +214,7 @@ func runAgentInRepo(t *testing.T, repo, provider, sessionID string) (string, err
 	// uses its default. The fixtures are tiny so any model works.
 	switch provider {
 	case "openrouter":
-		args = append(args, "--model", "inclusionai/ling-2.6-1t:free")
+		args = append(args, "--model", "inclusionai/ring-2.6-1t:free")
 	case "nvidia":
 		args = append(args, "--model", "meta/llama-3.3-70b-instruct")
 	}

--- a/agents/glue-review/fixture_test.go
+++ b/agents/glue-review/fixture_test.go
@@ -121,6 +121,13 @@ func TestFixtureReplay(t *testing.T) {
 			f.seed(t, repo)
 			review, err := runAgentInRepo(t, repo, provider, fmt.Sprintf("fixture-%s-%d", f.name, time.Now().UnixNano()))
 			if err != nil {
+				// Free upstreams (e.g. inclusionai/ling-2.6-1t:free)
+				// share a 20 req/min quota and 429 frequently. Treat
+				// upstream rate limits as a skip so transient quota
+				// trips don't fail CI; other failures still fail loudly.
+				if msg := err.Error(); strings.Contains(msg, "http 429") || strings.Contains(msg, "Rate limit exceeded") {
+					t.Skipf("upstream rate-limited (free tier): %v", err)
+				}
 				t.Fatalf("run failed: %v", err)
 			}
 			t.Logf("%s review (%d bytes):\n%s", f.name, len(review), review)

--- a/agents/glue-review/main.go
+++ b/agents/glue-review/main.go
@@ -287,7 +287,7 @@ func newProvider(name string) (glue.Provider, string, error) {
 	case "", "nvidia":
 		return nvidia.New(nvidia.Options{}), "moonshotai/kimi-k2.6", nil
 	case "openrouter":
-		return openrouter.New(openrouter.Options{}), "inclusionai/ling-2.6-1t:free", nil
+		return openrouter.New(openrouter.Options{}), "inclusionai/ring-2.6-1t:free", nil
 	case "gemini":
 		return gemini.New(gemini.Options{}), "gemini-2.5-flash", nil
 	default:

--- a/agents/glue-review/main_test.go
+++ b/agents/glue-review/main_test.go
@@ -45,7 +45,7 @@ func TestNewProviderSelectionAndDefaults(t *testing.T) {
 	cases := map[string]string{
 		"":           "moonshotai/kimi-k2.6",
 		"nvidia":     "moonshotai/kimi-k2.6",
-		"openrouter": "inclusionai/ling-2.6-1t:free",
+		"openrouter": "inclusionai/ring-2.6-1t:free",
 		"gemini":     "gemini-2.5-flash",
 	}
 	for input, wantModel := range cases {
@@ -244,7 +244,7 @@ func TestLiveReviewSmoke(t *testing.T) {
 	var args []string
 	switch {
 	case os.Getenv("OPENROUTER_API_KEY") != "":
-		args = []string{"--provider", "openrouter", "--model", "inclusionai/ling-2.6-1t:free"}
+		args = []string{"--provider", "openrouter", "--model", "inclusionai/ring-2.6-1t:free"}
 	case os.Getenv("NVIDIA_API_KEY") != "":
 		args = []string{"--provider", "nvidia", "--model", "meta/llama-3.3-70b-instruct"}
 	default:

--- a/providers/openrouter/openrouter.go
+++ b/providers/openrouter/openrouter.go
@@ -13,10 +13,10 @@ import (
 // probe key availability without hard-coding the name.
 const EnvKey = "OPENROUTER_API_KEY"
 
-// DefaultModel is the registry-level default model. The free Ling
+// DefaultModel is the registry-level default model. The free Ring
 // route is fast and unmetered; OpenRouter callers with a paid key
 // typically override via glue.WithModel.
-const DefaultModel = "inclusionai/ling-2.6-1t:free"
+const DefaultModel = "inclusionai/ring-2.6-1t:free"
 
 const (
 	providerName   = "openrouter"

--- a/providers/openrouter/openrouter_test.go
+++ b/providers/openrouter/openrouter_test.go
@@ -76,9 +76,11 @@ func TestStreamUsesAPIKeyEnv(t *testing.T) {
 }
 
 // TestLiveSmoke runs against the real OpenRouter endpoint when
-// OPENROUTER_API_KEY is set. Defaults to inclusionai/ling-2.6-1t:free —
+// OPENROUTER_API_KEY is set. Defaults to inclusionai/ring-2.6-1t:free —
 // a deterministic free model whose upstream (Novita) is consistently
-// available. Better-known free routes (google/gemma-4-*:free,
+// available. (The previous ling-2.6-1t:free pin graduated to paid in
+// May 2026; ring is its successor in the same InclusionAI family.)
+// Better-known free routes (google/gemma-4-*:free,
 // minimax/minimax-m2.5:free) are over-subscribed and frequently 429 at
 // the upstream. Local devs can swap to the openrouter/free meta-route
 // (which auto-routes around 429s but is non-deterministic) via
@@ -90,7 +92,7 @@ func TestLiveSmoke(t *testing.T) {
 	}
 	model := os.Getenv("OPENROUTER_LIVE_MODEL")
 	if model == "" {
-		model = "inclusionai/ling-2.6-1t:free"
+		model = "inclusionai/ring-2.6-1t:free"
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
@@ -123,7 +125,7 @@ func TestLiveSmoke(t *testing.T) {
 				if done == nil {
 					t.Fatalf("channel closed without Done event; text=%q", text.String())
 				}
-				// Default model (inclusionai/ling-2.6-1t:free) emits visible
+				// Default model (inclusionai/ring-2.6-1t:free) emits visible
 				// text. When OPENROUTER_LIVE_MODEL points at the
 				// non-deterministic openrouter/free meta-route, some upstreams
 				// emit only reasoning — accept thinking as a fallback.

--- a/providers/openrouter/openrouter_test.go
+++ b/providers/openrouter/openrouter_test.go
@@ -105,6 +105,9 @@ func TestLiveSmoke(t *testing.T) {
 		Options: map[string]any{"max_tokens": 16, "temperature": 0.0},
 	})
 	if err != nil {
+		if isUpstream429(err.Error()) {
+			t.Skipf("upstream rate-limited (free tier): %v", err)
+		}
 		t.Fatalf("Stream: %v", err)
 	}
 
@@ -140,6 +143,9 @@ func TestLiveSmoke(t *testing.T) {
 			case loop.ProviderEventDone:
 				done = event.Message
 			case loop.ProviderEventError:
+				if isUpstream429(event.Error) {
+					t.Skipf("upstream rate-limited (free tier): %s", event.Error)
+				}
 				t.Fatalf("provider error: %s", event.Error)
 			}
 		}
@@ -164,4 +170,13 @@ func newCapturingServer(t *testing.T) (*httptest.Server, func() http.Header) {
 func drain(ch <-chan loop.ProviderEvent) {
 	for range ch {
 	}
+}
+
+// isUpstream429 reports whether an error message looks like an OpenRouter
+// upstream rate-limit response. Free routes (e.g. inclusionai/ling-2.6-1t:free)
+// share a 20 req/min quota and 429 frequently; we treat those as a skip so
+// transient upstream limits don't fail CI, while real wire-protocol
+// regressions (other HTTP codes, malformed SSE) still fail loudly.
+func isUpstream429(msg string) bool {
+	return strings.Contains(msg, "http 429") || strings.Contains(msg, "Rate limit exceeded")
 }


### PR DESCRIPTION
## Summary

CI's `live (openrouter)` job has been red since #99. Diagnosis revealed two overlapping failures, not one:

1. **Upstream rate-limit (transient)**: free routes share a 20 req/min quota and `429 Rate limit exceeded` shows up on busy hours. The first commit teaches `TestLiveSmoke` and `TestFixtureReplay` to treat `http 429` (only) as a skip — same pattern the workflow already uses for a missing API key. Narrow match; other HTTP codes / malformed SSE still fail loudly.

2. **Pinned model graduated to paid**: a CI rerun on the 429-skip branch surfaced `http 404: Ling-2.6-1T is no longer available as a free model`. The pinned `inclusionai/ling-2.6-1t:free` flipped to paid in May 2026. Second commit swaps to its successor `inclusionai/ring-2.6-1t:free` — same author, same 262k ctx, same presumed Novita upstream — across the registry default, workflow env, agent fallback, both tests, README, and action.yml.

The 429 skip is kept as defense in depth for future quota trips.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] Non-live tests pass for `providers/openrouter` and `agents/glue-review`
- [x] `TestFixtureReplay` still runs the live path locally (~117s)
- [x] CI's `live (openrouter)` job goes green on this PR
