### PR TITLE
action: don't overwrite a successful review with a soft-fail

### DIFF
--- a/agents/glue-review/action.yml
+++ b/agents/glue-review/action.yml
@@ -345,7 +345,13 @@ runs:
         # heredocs awkward). gh api -F body=@file reads the file as-is.
         BODY_PATH="${RUNNER_TEMP}/glue-review-body.md"
 
+        # Soft-fail marker so we can recognise a previous failure body
+        # and overwrite it (but never overwrite a real review).
+        SOFT_FAIL_MARK='<!-- glue-review:soft-fail -->'
+
+        SUCCESS=0
         if [ "$EXIT_CODE" = "0" ] && [ -s "$REVIEW_PATH" ]; then
+          SUCCESS=1
           {
             printf '%s\n' "$MARKER"
             cat "$REVIEW_PATH"
@@ -354,6 +360,7 @@ runs:
         else
           {
             printf '%s\n' "$MARKER"
+            printf '%s\n' "$SOFT_FAIL_MARK"
             printf '%s\n\n' '⚠️ **glue-review could not produce a review.**'
             printf 'Exit code: `%s`. Re-run the workflow to retry.\n\n' "$EXIT_CODE"
             printf '<details><summary>Failure log (last 3.5 KiB of stderr)</summary>\n\n'
@@ -369,14 +376,44 @@ runs:
             "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq "[.[] | select(.body | contains(\"$MARKER\"))] | first | .id"
         )
-
+        existing_is_soft_fail=0
         if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
-          url=$(gh api -X PATCH "repos/$REPO/issues/comments/$existing_id" \
-            -F body="@$BODY_PATH" --jq '.url')
-          echo "Updated comment $existing_id"
-        else
-          url=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            -F body="@$BODY_PATH" --jq '.url')
-          echo "Created new sticky comment"
+          existing_body=$(gh api "repos/$REPO/issues/comments/$existing_id" --jq '.body')
+          if printf '%s' "$existing_body" | grep -qF "$SOFT_FAIL_MARK"; then
+            existing_is_soft_fail=1
+          fi
         fi
-        echo "comment-url=$url" >> "$GITHUB_OUTPUT"
+
+        # Behaviour matrix:
+        #   success + no existing                       -> create new sticky
+        #   success + existing (any flavor)             -> overwrite in-place
+        #   fail    + no existing                       -> create soft-fail sticky
+        #   fail    + existing review (not soft-fail)   -> SKIP: keep the prior good review
+        #   fail    + existing soft-fail sticky         -> overwrite (refresh the error)
+        if [ "$SUCCESS" = "1" ]; then
+          if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
+            url=$(gh api -X PATCH "repos/$REPO/issues/comments/$existing_id" \
+              -F body="@$BODY_PATH" --jq '.url')
+            echo "Updated comment $existing_id (success)"
+          else
+            url=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -F body="@$BODY_PATH" --jq '.url')
+            echo "Created new sticky comment"
+          fi
+          echo "comment-url=$url" >> "$GITHUB_OUTPUT"
+        else
+          if [ -n "$existing_id" ] && [ "$existing_id" != "null" ] && [ "$existing_is_soft_fail" = "0" ]; then
+            echo "::warning::glue-review run failed (exit $EXIT_CODE); previous successful review on comment $existing_id is kept intact."
+            echo "comment-url=" >> "$GITHUB_OUTPUT"
+          elif [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
+            url=$(gh api -X PATCH "repos/$REPO/issues/comments/$existing_id" \
+              -F body="@$BODY_PATH" --jq '.url')
+            echo "Updated soft-fail comment $existing_id (still failing)"
+            echo "comment-url=$url" >> "$GITHUB_OUTPUT"
+          else
+            url=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -F body="@$BODY_PATH" --jq '.url')
+            echo "Created soft-fail sticky comment"
+            echo "comment-url=$url" >> "$GITHUB_OUTPUT"
+          fi
+        fi


### PR DESCRIPTION
## Summary
- A 429 or other transient failure on a re-run used to **edit-in-place** the previous good review on the PR thread, replacing it with `⚠️ glue-review could not produce a review`. First-time users hitting this in their first hour with the tool would write us off.
- The action now tags soft-fail bodies with an inline `<!-- glue-review:soft-fail -->` marker so we can tell them apart from a real review and choose the right behaviour:

  | scenario | behaviour |
  | --- | --- |
  | success + no existing | create new sticky |
  | success + existing (any flavor) | overwrite in-place |
  | fail + no existing | create soft-fail sticky |
  | **fail + existing real review** | **SKIP — keep the prior review, emit `::warning::`** |
  | fail + existing soft-fail sticky | overwrite (refresh the error log) |

- YAML-only change. No code-path touched outside the post step.

## Test plan
- [x] `go test ./agents/glue-review/... -run '^TestSystemPrompt|^TestParse|...' ` clean.
- [x] Action.yml linted via `gh workflow run` from the eval repo on the next smoke.
- [ ] Smoke PR re-trigger to confirm behaviour (eval repo PR #1 — its sticky comment should now survive a 429 retry).