### PR TITLE
providers/codex/auth: token reader + refresh (closes #117)

### DIFF
--- a/providers/codex/auth/auth.go
+++ b/providers/codex/auth/auth.go
@@ -1,0 +1,338 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Constants mirroring the upstream Codex CLI. See ADR-0006.
+const (
+	// ClientID is the OAuth client id baked into OpenAI's Hydra
+	// allowlist for the Codex CLI. Third-party tools that piggyback on
+	// the same subscription auth must send this exact value or refresh
+	// is rejected.
+	ClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+	// DefaultRefreshURL is the OAuth token endpoint used for refresh.
+	// Overridden by CODEX_REFRESH_TOKEN_URL_OVERRIDE for tests.
+	DefaultRefreshURL = "https://auth.openai.com/oauth/token"
+
+	// RefreshCadence is how long after a successful refresh we
+	// proactively refresh again, matching upstream Codex CLI's 8-day
+	// window.
+	RefreshCadence = 8 * 24 * time.Hour
+
+	// authFileBasename is the upstream-defined filename.
+	authFileBasename = "auth.json"
+
+	// Environment overrides honored when resolving the auth file path.
+	envGlueOverride = "GLUE_CODEX_AUTH"
+	envCodexHome    = "CODEX_HOME"
+	envRefreshURL   = "CODEX_REFRESH_TOKEN_URL_OVERRIDE"
+)
+
+// HTTPDoer is the subset of *http.Client used for refresh. Exposed so
+// tests can inject an httptest server.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Manager owns token loading, refresh, and atomic write-back. It is
+// safe for concurrent use; refresh is serialized by an internal mutex.
+type Manager struct {
+	// HTTPClient performs refresh requests. Nil means http.DefaultClient.
+	HTTPClient HTTPDoer
+	// RefreshURLOverride is used when non-empty; otherwise the env
+	// override or DefaultRefreshURL applies.
+	RefreshURLOverride string
+	// PathOverride is the absolute auth.json path; when empty the
+	// standard resolution applies.
+	PathOverride string
+	// Now is used in tests to control time. Nil means time.Now.
+	Now func() time.Time
+
+	mu       sync.Mutex
+	path     string // resolved on first Load
+	apiKey   *string
+	tokens   *Tokens
+}
+
+// NewManager returns a Manager with default behavior.
+func NewManager() *Manager { return &Manager{} }
+
+// AuthFilePath resolves the location of auth.json without reading it.
+// Resolution order: PathOverride > $GLUE_CODEX_AUTH > $CODEX_HOME/auth.json
+// > ~/.codex/auth.json. The returned path may or may not exist.
+func (m *Manager) AuthFilePath() (string, error) {
+	if m.PathOverride != "" {
+		return m.PathOverride, nil
+	}
+	if p := os.Getenv(envGlueOverride); p != "" {
+		return p, nil
+	}
+	if home := os.Getenv(envCodexHome); home != "" {
+		return filepath.Join(home, authFileBasename), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("auth: resolve $HOME: %w", err)
+	}
+	return filepath.Join(home, ".codex", authFileBasename), nil
+}
+
+// LoadTokens reads auth.json and parses it into Tokens. It returns
+// ErrNoAuthFile (wrapped with the resolved path) if the file does not
+// exist. The Manager caches the loaded tokens for subsequent
+// EnsureFresh calls.
+func (m *Manager) LoadTokens(ctx context.Context) (*Tokens, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.loadLocked()
+}
+
+func (m *Manager) loadLocked() (*Tokens, error) {
+	path, err := m.AuthFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w (looked at %s)", ErrNoAuthFile, path)
+		}
+		return nil, fmt.Errorf("auth: read %s: %w", path, err)
+	}
+	// Pull OPENAI_API_KEY raw so we preserve it on write-back.
+	var raw authFile
+	_ = json.Unmarshal(data, &raw)
+	t, err := ParseAuthFile(data)
+	if err != nil {
+		return nil, err
+	}
+	m.path = path
+	m.tokens = t
+	m.apiKey = raw.OpenAIAPIKey
+	return cloneTokens(t), nil
+}
+
+func (m *Manager) now() time.Time {
+	if m.Now != nil {
+		return m.Now()
+	}
+	return time.Now()
+}
+
+// EnsureFresh returns a Tokens whose AccessToken is not expired and
+// whose LastRefresh is within RefreshCadence of now. When the cached
+// tokens are stale it calls Refresh and atomically writes the result
+// back to disk.
+//
+// The argument may be nil; in that case LoadTokens is invoked first.
+func (m *Manager) EnsureFresh(ctx context.Context, in *Tokens) (*Tokens, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if in == nil && m.tokens == nil {
+		if _, err := m.loadLocked(); err != nil {
+			return nil, err
+		}
+	} else if in != nil {
+		m.tokens = cloneTokens(in)
+	}
+	if m.tokens == nil {
+		return nil, ErrNoAuthFile
+	}
+	if !m.isStale(m.tokens) {
+		return cloneTokens(m.tokens), nil
+	}
+	if m.tokens.RefreshToken == "" {
+		return nil, fmt.Errorf("auth: cannot refresh: no refresh_token in auth.json")
+	}
+	resp, err := m.refreshLocked(ctx, m.tokens.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+	merged := mergeRefresh(m.tokens, resp)
+	merged.LastRefresh = m.now().UTC()
+	if err := m.writeLocked(merged); err != nil {
+		return nil, err
+	}
+	m.tokens = merged
+	return cloneTokens(merged), nil
+}
+
+func (m *Manager) isStale(t *Tokens) bool {
+	now := m.now()
+	if exp, err := AccessTokenExpiry(t.AccessToken); err == nil {
+		if !now.Before(exp) {
+			return true
+		}
+	}
+	if t.LastRefresh.IsZero() {
+		return true
+	}
+	return now.Sub(t.LastRefresh) >= RefreshCadence
+}
+
+// RefreshResponse is the decoded body of a successful refresh.
+type RefreshResponse struct {
+	IDToken      string `json:"id_token,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// Refresh exchanges a refresh_token for new tokens. It is safe to call
+// without holding the Manager (no caching side-effects); EnsureFresh
+// is the usual entry point.
+func (m *Manager) Refresh(ctx context.Context, refreshToken string) (RefreshResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.refreshLocked(ctx, refreshToken)
+}
+
+func (m *Manager) refreshLocked(ctx context.Context, refreshToken string) (RefreshResponse, error) {
+	url := m.refreshURL()
+	body, _ := json.Marshal(map[string]string{
+		"client_id":     ClientID,
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return RefreshResponse{}, fmt.Errorf("auth: build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := m.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	httpResp, err := client.Do(req)
+	if err != nil {
+		return RefreshResponse{}, fmt.Errorf("auth: refresh transport: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode == http.StatusOK {
+		var rr RefreshResponse
+		if err := json.NewDecoder(httpResp.Body).Decode(&rr); err != nil {
+			return RefreshResponse{}, fmt.Errorf("auth: decode refresh body: %w", err)
+		}
+		return rr, nil
+	}
+
+	// Non-2xx: classify.
+	respBody, _ := io.ReadAll(httpResp.Body)
+	var errBody struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	_ = json.Unmarshal(respBody, &errBody)
+
+	switch errBody.Error {
+	case "refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated":
+		return RefreshResponse{}, fmt.Errorf("%w: %s", ErrRefreshPermanent, errBody.Error)
+	}
+	if httpResp.StatusCode == http.StatusUnauthorized || httpResp.StatusCode == http.StatusForbidden {
+		// Treat unclassified 401/403 from the auth endpoint as permanent.
+		return RefreshResponse{}, fmt.Errorf("%w: http %d", ErrRefreshPermanent, httpResp.StatusCode)
+	}
+	return RefreshResponse{}, fmt.Errorf("auth: refresh failed: http %d (%s)", httpResp.StatusCode, errBody.Error)
+}
+
+func (m *Manager) refreshURL() string {
+	if m.RefreshURLOverride != "" {
+		return m.RefreshURLOverride
+	}
+	if v := os.Getenv(envRefreshURL); v != "" {
+		return v
+	}
+	return DefaultRefreshURL
+}
+
+// mergeRefresh applies a RefreshResponse to a Tokens, preserving
+// previous values for any field the upstream omits.
+func mergeRefresh(prev *Tokens, r RefreshResponse) *Tokens {
+	out := cloneTokens(prev)
+	if r.IDToken != "" {
+		out.IDToken = r.IDToken
+		// Re-extract account id when id_token rotates.
+		if id, err := AccountIDFromIDToken(r.IDToken); err == nil {
+			out.AccountID = id
+		}
+	}
+	if r.AccessToken != "" {
+		out.AccessToken = r.AccessToken
+	}
+	if r.RefreshToken != "" {
+		out.RefreshToken = r.RefreshToken
+	}
+	return out
+}
+
+// writeLocked persists tokens to disk via temp-file + atomic rename.
+func (m *Manager) writeLocked(t *Tokens) error {
+	if m.path == "" {
+		p, err := m.AuthFilePath()
+		if err != nil {
+			return err
+		}
+		m.path = p
+	}
+	dir := filepath.Dir(m.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("auth: mkdir %s: %w", dir, err)
+	}
+	data, err := encodeAuthFile(t, m.apiKey)
+	if err != nil {
+		return fmt.Errorf("auth: encode: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".auth.json.*")
+	if err != nil {
+		return fmt.Errorf("auth: tempfile: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("auth: write tempfile: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("auth: chmod tempfile: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("auth: close tempfile: %w", err)
+	}
+	if err := os.Rename(tmpName, m.path); err != nil {
+		cleanup()
+		return fmt.Errorf("auth: rename to %s: %w", m.path, err)
+	}
+	return nil
+}
+
+func cloneTokens(t *Tokens) *Tokens {
+	if t == nil {
+		return nil
+	}
+	c := *t
+	return &c
+}

--- a/providers/codex/auth/auth_test.go
+++ b/providers/codex/auth/auth_test.go
@@ -1,0 +1,430 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeFile writes data to path with 0o600.
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// writeAuthFile writes an auth.json with the given tokens and last_refresh
+// (RFC3339 or empty for none).
+func writeAuthFile(t *testing.T, path string, tk *Tokens, lastRefresh string) {
+	t.Helper()
+	body := map[string]any{
+		"tokens": map[string]any{
+			"id_token":      tk.IDToken,
+			"access_token":  tk.AccessToken,
+			"refresh_token": tk.RefreshToken,
+			"account_id":    tk.AccountID,
+		},
+	}
+	if lastRefresh != "" {
+		body["last_refresh"] = lastRefresh
+	}
+	raw, _ := json.MarshalIndent(body, "", "  ")
+	writeFile(t, path, raw)
+}
+
+// freshAccessToken returns a JWT with an exp in the future.
+func freshAccessToken(t *testing.T) string {
+	t.Helper()
+	return makeJWT(t, map[string]any{"exp": time.Now().Add(24 * time.Hour).Unix()})
+}
+
+// expiredAccessToken returns a JWT with an exp in the past.
+func expiredAccessToken(t *testing.T) string {
+	t.Helper()
+	return makeJWT(t, map[string]any{"exp": time.Now().Add(-time.Hour).Unix()})
+}
+
+// freshIDToken returns an id_token with an account_id claim.
+func freshIDToken(t *testing.T, account string) string {
+	t.Helper()
+	return makeJWT(t, map[string]any{"chatgpt_account_id": account})
+}
+
+func TestAuthFilePath_Resolution(t *testing.T) {
+	t.Run("path-override-wins", func(t *testing.T) {
+		t.Setenv(envGlueOverride, "/env/override")
+		t.Setenv(envCodexHome, "/codex/home")
+		m := &Manager{PathOverride: "/explicit/path"}
+		got, _ := m.AuthFilePath()
+		if got != "/explicit/path" {
+			t.Fatalf("got %s", got)
+		}
+	})
+	t.Run("env-override-wins-over-codex-home", func(t *testing.T) {
+		t.Setenv(envGlueOverride, "/env/override")
+		t.Setenv(envCodexHome, "/codex/home")
+		m := &Manager{}
+		got, _ := m.AuthFilePath()
+		if got != "/env/override" {
+			t.Fatalf("got %s", got)
+		}
+	})
+	t.Run("codex-home-wins-over-home", func(t *testing.T) {
+		t.Setenv(envGlueOverride, "")
+		t.Setenv(envCodexHome, "/codex/home")
+		m := &Manager{}
+		got, _ := m.AuthFilePath()
+		want := filepath.Join("/codex/home", "auth.json")
+		if got != want {
+			t.Fatalf("got %s want %s", got, want)
+		}
+	})
+	t.Run("home-default", func(t *testing.T) {
+		t.Setenv(envGlueOverride, "")
+		t.Setenv(envCodexHome, "")
+		home := t.TempDir()
+		t.Setenv(homeEnv(), home)
+		m := &Manager{}
+		got, _ := m.AuthFilePath()
+		want := filepath.Join(home, ".codex", "auth.json")
+		if got != want {
+			t.Fatalf("got %s want %s", got, want)
+		}
+	})
+}
+
+func homeEnv() string {
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
+func TestLoadTokens_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{PathOverride: filepath.Join(dir, "missing.json")}
+	_, err := m.LoadTokens(context.Background())
+	if !errors.Is(err, ErrNoAuthFile) {
+		t.Fatalf("want ErrNoAuthFile, got %v", err)
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("error should mention resolved path; got %q", err)
+	}
+}
+
+func TestLoadTokens_HappyAndCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{
+		IDToken:      freshIDToken(t, "acct-X"),
+		AccessToken:  freshAccessToken(t),
+		RefreshToken: "rtk",
+		AccountID:    "acct-X",
+	}
+	writeAuthFile(t, path, tk, "2026-05-15T00:00:00Z")
+
+	m := &Manager{PathOverride: path}
+	out, err := m.LoadTokens(context.Background())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if out.AccessToken != tk.AccessToken || out.RefreshToken != "rtk" || out.AccountID != "acct-X" {
+		t.Fatalf("loaded mismatch: %+v", out)
+	}
+	if out.LastRefresh.IsZero() {
+		t.Errorf("expected last_refresh populated")
+	}
+}
+
+func TestEnsureFresh_NotStale_NoCall(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{
+		AccessToken:  freshAccessToken(t),
+		RefreshToken: "rtk",
+		AccountID:    "acct",
+	}
+	writeAuthFile(t, path, tk, time.Now().UTC().Format(time.RFC3339))
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		calls++
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	out, err := m.EnsureFresh(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no refresh, got %d calls", calls)
+	}
+	if out.AccessToken != tk.AccessToken {
+		t.Errorf("token rotated unexpectedly")
+	}
+}
+
+func TestEnsureFresh_JWTExpired_Refreshes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	expired := expiredAccessToken(t)
+	tk := &Tokens{
+		IDToken:      freshIDToken(t, "acct"),
+		AccessToken:  expired,
+		RefreshToken: "old-rtk",
+		AccountID:    "acct",
+	}
+	writeAuthFile(t, path, tk, time.Now().UTC().Format(time.RFC3339))
+
+	newAccess := freshAccessToken(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRefreshRequest(t, r)
+		_ = json.NewEncoder(w).Encode(RefreshResponse{AccessToken: newAccess, RefreshToken: "new-rtk"})
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	out, err := m.EnsureFresh(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	if out.AccessToken != newAccess {
+		t.Errorf("access not rotated")
+	}
+	if out.RefreshToken != "new-rtk" {
+		t.Errorf("refresh not rotated")
+	}
+	// File rewritten?
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Errorf("perm = %o want 0600", st.Mode().Perm())
+	}
+	on, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(on), newAccess) {
+		t.Errorf("file does not contain rotated access token")
+	}
+	if !strings.Contains(string(on), "new-rtk") {
+		t.Errorf("file does not contain rotated refresh token")
+	}
+}
+
+func TestEnsureFresh_StaleCadence_Refreshes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{
+		AccessToken:  freshAccessToken(t), // not JWT-expired
+		RefreshToken: "rtk-1",
+	}
+	old := time.Now().Add(-9 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	writeAuthFile(t, path, tk, old)
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		assertRefreshRequest(t, r)
+		_ = json.NewEncoder(w).Encode(RefreshResponse{AccessToken: freshAccessToken(t)})
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	if _, err := m.EnsureFresh(context.Background(), nil); err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	if !called {
+		t.Fatal("expected refresh due to >8d cadence")
+	}
+}
+
+func TestRefresh_PartialResponsePreservesRefreshToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{
+		AccessToken:  expiredAccessToken(t),
+		RefreshToken: "old-rtk",
+	}
+	writeAuthFile(t, path, tk, time.Now().UTC().Format(time.RFC3339))
+
+	newAccess := freshAccessToken(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Only access_token returned; no refresh_token.
+		_ = json.NewEncoder(w).Encode(RefreshResponse{AccessToken: newAccess})
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	out, err := m.EnsureFresh(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	if out.AccessToken != newAccess {
+		t.Errorf("access not rotated")
+	}
+	if out.RefreshToken != "old-rtk" {
+		t.Errorf("refresh should be preserved when omitted; got %q", out.RefreshToken)
+	}
+}
+
+func TestRefresh_PermanentFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{AccessToken: expiredAccessToken(t), RefreshToken: "rtk"}
+	writeAuthFile(t, path, tk, time.Now().UTC().Format(time.RFC3339))
+
+	cases := []string{"refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated"}
+	for _, code := range cases {
+		t.Run(code, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+			}))
+			defer srv.Close()
+			m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+			_, err := m.EnsureFresh(context.Background(), nil)
+			if !IsPermanentRefreshFailure(err) {
+				t.Fatalf("want permanent, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRefresh_TransientFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{AccessToken: expiredAccessToken(t), RefreshToken: "rtk"}
+	writeAuthFile(t, path, tk, time.Now().UTC().Format(time.RFC3339))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, `{"error":"server_error"}`)
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	_, err := m.EnsureFresh(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if IsPermanentRefreshFailure(err) {
+		t.Fatalf("5xx should not be classified permanent: %v", err)
+	}
+}
+
+func TestRefresh_UnauthorizedClassifiedPermanent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{AccessToken: expiredAccessToken(t), RefreshToken: "rtk"}
+	writeAuthFile(t, path, tk, time.Now().UTC().Format(time.RFC3339))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	_, err := m.EnsureFresh(context.Background(), nil)
+	if !IsPermanentRefreshFailure(err) {
+		t.Fatalf("want permanent for unclassified 401, got %v", err)
+	}
+}
+
+func TestRefreshURL_EnvOverride(t *testing.T) {
+	t.Setenv(envRefreshURL, "https://override.example/oauth")
+	m := &Manager{}
+	if got := m.refreshURL(); got != "https://override.example/oauth" {
+		t.Fatalf("env override ignored: %q", got)
+	}
+	m.RefreshURLOverride = "https://field.example/oauth"
+	if got := m.refreshURL(); got != "https://field.example/oauth" {
+		t.Fatalf("field override should win: %q", got)
+	}
+}
+
+func TestEnsureFresh_NoRefreshToken_Errors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	tk := &Tokens{AccessToken: expiredAccessToken(t)} // no refresh
+	writeAuthFile(t, path, tk, "")
+	m := &Manager{PathOverride: path}
+	_, err := m.EnsureFresh(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "no refresh_token") {
+		t.Fatalf("want refresh-missing error, got %v", err)
+	}
+}
+
+func TestEnsureFresh_PreservesOpenAIAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	// Write a file that includes OPENAI_API_KEY; we should preserve it
+	// across refresh.
+	full := map[string]any{
+		"OPENAI_API_KEY": "sk-preserved",
+		"tokens": map[string]any{
+			"access_token":  expiredAccessToken(t),
+			"refresh_token": "rtk",
+		},
+		"last_refresh": time.Now().UTC().Format(time.RFC3339),
+	}
+	raw, _ := json.MarshalIndent(full, "", "  ")
+	writeFile(t, path, raw)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(RefreshResponse{AccessToken: freshAccessToken(t)})
+	}))
+	defer srv.Close()
+
+	m := &Manager{PathOverride: path, RefreshURLOverride: srv.URL}
+	if _, err := m.EnsureFresh(context.Background(), nil); err != nil {
+		t.Fatalf("EnsureFresh: %v", err)
+	}
+	on, _ := os.ReadFile(path)
+	if !strings.Contains(string(on), "sk-preserved") {
+		t.Fatalf("OPENAI_API_KEY not preserved on writeback: %s", on)
+	}
+}
+
+// assertRefreshRequest verifies the request shape we send to the
+// upstream OAuth endpoint matches ADR-0006 §2.
+func assertRefreshRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("method = %s", r.Method)
+	}
+	if got := r.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	body, _ := io.ReadAll(r.Body)
+	var got map[string]string
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("body not json: %v", err)
+	}
+	if got["client_id"] != ClientID {
+		t.Errorf("client_id = %q", got["client_id"])
+	}
+	if got["grant_type"] != "refresh_token" {
+		t.Errorf("grant_type = %q", got["grant_type"])
+	}
+	if got["refresh_token"] == "" {
+		t.Errorf("refresh_token empty")
+	}
+}

--- a/providers/codex/auth/doc.go
+++ b/providers/codex/auth/doc.go
@@ -1,0 +1,12 @@
+// Package auth handles ChatGPT-subscription OAuth tokens for the
+// providers/codex transport.
+//
+// For v0.1 the package does not run an interactive login: it reads the
+// auth.json file written by OpenAI's upstream Codex CLI (run "codex
+// login" once outside glue) and refreshes stale tokens against
+// auth.openai.com/oauth/token. The transport package in providers/codex
+// uses the access token returned here as a Bearer credential against
+// the Responses endpoint at chatgpt.com/backend-api/codex/responses.
+//
+// Design: docs/adr/0006-codex-provider.md.
+package auth

--- a/providers/codex/auth/errors.go
+++ b/providers/codex/auth/errors.go
@@ -1,0 +1,24 @@
+package auth
+
+import "errors"
+
+// ErrNoAuthFile is returned by LoadTokens when no auth.json was found
+// at any of the configured locations. Callers should print a clear
+// message instructing the user to run "codex login".
+var ErrNoAuthFile = errors.New("auth: no codex auth.json found (run `codex login` first)")
+
+// ErrMalformedAuthFile is returned when auth.json is missing required
+// fields (specifically the tokens object).
+var ErrMalformedAuthFile = errors.New("auth: auth.json missing tokens object")
+
+// ErrRefreshPermanent is returned by Refresh when the upstream
+// classifies the refresh-token as no-longer-valid. The user must run
+// `codex login` again. Errors wrapping this sentinel are also
+// permanent.
+var ErrRefreshPermanent = errors.New("auth: refresh token no longer valid")
+
+// IsPermanentRefreshFailure reports whether err is or wraps
+// ErrRefreshPermanent.
+func IsPermanentRefreshFailure(err error) bool {
+	return errors.Is(err, ErrRefreshPermanent)
+}

--- a/providers/codex/auth/tokens.go
+++ b/providers/codex/auth/tokens.go
@@ -1,0 +1,212 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Tokens is the in-memory shape of the upstream Codex CLI's auth.json
+// "tokens" object plus the last-refresh timestamp.
+//
+// Fields are populated from auth.json and are never logged in full. Use
+// SafeString for debugging output.
+type Tokens struct {
+	IDToken      string    `json:"id_token"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	AccountID    string    `json:"account_id"`
+	LastRefresh  time.Time `json:"-"`
+}
+
+// SafeString returns a redacted single-line summary suitable for logs.
+// It exposes only the presence of each field and the last_refresh
+// timestamp.
+func (t *Tokens) SafeString() string {
+	if t == nil {
+		return "Tokens<nil>"
+	}
+	mark := func(s string) string {
+		if s == "" {
+			return "missing"
+		}
+		return "set"
+	}
+	return fmt.Sprintf("Tokens{id_token:%s access_token:%s refresh_token:%s account_id:%s last_refresh:%s}",
+		mark(t.IDToken), mark(t.AccessToken), mark(t.RefreshToken), mark(t.AccountID), t.LastRefresh.Format(time.RFC3339))
+}
+
+// authFile is the on-disk schema of upstream Codex CLI's auth.json.
+// We deliberately ignore the OPENAI_API_KEY field — subscription
+// transport uses tokens.access_token, not the swapped API key. See
+// ADR-0006 §2.
+type authFile struct {
+	OpenAIAPIKey *string      `json:"OPENAI_API_KEY,omitempty"`
+	Tokens       *fileTokens  `json:"tokens,omitempty"`
+	LastRefresh  *fileISOTime `json:"last_refresh,omitempty"`
+}
+
+type fileTokens struct {
+	IDToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	AccountID    string `json:"account_id"`
+}
+
+// fileISOTime parses the upstream "last_refresh" field which is an
+// RFC3339 timestamp; missing or unparseable values become zero.
+type fileISOTime time.Time
+
+func (f *fileISOTime) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		*f = fileISOTime(time.Time{})
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return fmt.Errorf("auth.json: last_refresh: %w", err)
+	}
+	*f = fileISOTime(t)
+	return nil
+}
+
+func (f fileISOTime) MarshalJSON() ([]byte, error) {
+	t := time.Time(f)
+	if t.IsZero() {
+		return json.Marshal("")
+	}
+	return json.Marshal(t.UTC().Format(time.RFC3339))
+}
+
+// ParseAuthFile decodes the byte contents of an auth.json file into a
+// Tokens struct. It returns ErrMalformedAuthFile when the file is
+// missing the tokens object.
+func ParseAuthFile(data []byte) (*Tokens, error) {
+	var af authFile
+	if err := json.Unmarshal(data, &af); err != nil {
+		return nil, fmt.Errorf("auth.json: %w", err)
+	}
+	if af.Tokens == nil {
+		return nil, ErrMalformedAuthFile
+	}
+	t := &Tokens{
+		IDToken:      af.Tokens.IDToken,
+		AccessToken:  af.Tokens.AccessToken,
+		RefreshToken: af.Tokens.RefreshToken,
+		AccountID:    af.Tokens.AccountID,
+	}
+	if af.LastRefresh != nil {
+		t.LastRefresh = time.Time(*af.LastRefresh)
+	}
+	if t.AccountID == "" {
+		if id, err := AccountIDFromIDToken(t.IDToken); err == nil {
+			t.AccountID = id
+		}
+	}
+	return t, nil
+}
+
+// MarshalAuthFile serializes Tokens back to the upstream auth.json
+// schema. Existing OPENAI_API_KEY values are not preserved by this
+// path because the caller (encodeForWriteback) reads-modifies-writes.
+func encodeAuthFile(t *Tokens, existingAPIKey *string) ([]byte, error) {
+	last := fileISOTime(t.LastRefresh.UTC())
+	af := authFile{
+		OpenAIAPIKey: existingAPIKey,
+		Tokens: &fileTokens{
+			IDToken:      t.IDToken,
+			AccessToken:  t.AccessToken,
+			RefreshToken: t.RefreshToken,
+			AccountID:    t.AccountID,
+		},
+		LastRefresh: &last,
+	}
+	return json.MarshalIndent(&af, "", "  ")
+}
+
+// AccessTokenExpiry decodes the unverified JWT payload of token and
+// returns the exp claim as a time. It returns an error if token is not
+// a JWT or has no exp claim.
+//
+// This is *unverified*. The token's signature is not checked here; the
+// upstream is OpenAI and we treat the auth file's contents as
+// authoritative. We use the exp only to decide whether to refresh.
+func AccessTokenExpiry(token string) (time.Time, error) {
+	if token == "" {
+		return time.Time{}, errors.New("auth: empty token")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return time.Time{}, errors.New("auth: token is not a JWT (no payload segment)")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// Some implementations produce padded base64; tolerate it.
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return time.Time{}, fmt.Errorf("auth: jwt payload base64: %w", err)
+		}
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("auth: jwt payload json: %w", err)
+	}
+	if claims.Exp == 0 {
+		return time.Time{}, errors.New("auth: jwt has no exp claim")
+	}
+	return time.Unix(claims.Exp, 0).UTC(), nil
+}
+
+// AccountIDFromIDToken extracts the ChatGPT account id from the
+// unverified id_token JWT. Returns the first non-empty of the two
+// claim names the upstream Codex CLI accepts:
+//
+//	https://api.openai.com/auth.chatgpt_account_id
+//	chatgpt_account_id
+func AccountIDFromIDToken(idToken string) (string, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return "", errors.New("auth: id_token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return "", fmt.Errorf("auth: id_token base64: %w", err)
+		}
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("auth: id_token json: %w", err)
+	}
+	for _, key := range []string{
+		"https://api.openai.com/auth.chatgpt_account_id",
+		"chatgpt_account_id",
+	} {
+		if v, ok := claims[key]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s, nil
+			}
+			if m, ok := v.(map[string]any); ok {
+				if s, ok := m["chatgpt_account_id"].(string); ok && s != "" {
+					return s, nil
+				}
+			}
+		}
+	}
+	if auth, ok := claims["https://api.openai.com/auth"].(map[string]any); ok {
+		if s, ok := auth["chatgpt_account_id"].(string); ok && s != "" {
+			return s, nil
+		}
+	}
+	return "", errors.New("auth: id_token has no chatgpt_account_id claim")
+}

--- a/providers/codex/auth/tokens_test.go
+++ b/providers/codex/auth/tokens_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeJWT builds an unsigned (alg=none) JWT with the given payload
+// claims. The signature segment is intentionally empty — the package
+// never verifies signatures, only decodes claims.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header, _ := json.Marshal(map[string]string{"alg": "none", "typ": "JWT"})
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc(header) + "." + enc(payload) + "."
+}
+
+func TestAccessTokenExpiry_Happy(t *testing.T) {
+	exp := time.Now().Add(2 * time.Hour).Truncate(time.Second).UTC()
+	tok := makeJWT(t, map[string]any{"exp": exp.Unix()})
+	got, err := AccessTokenExpiry(tok)
+	if err != nil {
+		t.Fatalf("AccessTokenExpiry: %v", err)
+	}
+	if !got.Equal(exp) {
+		t.Fatalf("expiry mismatch: got %s want %s", got, exp)
+	}
+}
+
+func TestAccessTokenExpiry_Errors(t *testing.T) {
+	cases := map[string]string{
+		"empty":      "",
+		"no-payload": "abcdef",
+		"bad-base64": "abc.@@@.def",
+		"no-exp":     makeJWT(t, map[string]any{"sub": "x"}),
+	}
+	for name, tok := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := AccessTokenExpiry(tok); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestAccountIDFromIDToken(t *testing.T) {
+	cases := map[string]map[string]any{
+		"namespaced": {"https://api.openai.com/auth.chatgpt_account_id": "acct-1"},
+		"short":      {"chatgpt_account_id": "acct-2"},
+		"nested":     {"https://api.openai.com/auth": map[string]any{"chatgpt_account_id": "acct-3"}},
+	}
+	want := map[string]string{"namespaced": "acct-1", "short": "acct-2", "nested": "acct-3"}
+	for name, claims := range cases {
+		t.Run(name, func(t *testing.T) {
+			tok := makeJWT(t, claims)
+			id, err := AccountIDFromIDToken(tok)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if id != want[name] {
+				t.Fatalf("got %q want %q", id, want[name])
+			}
+		})
+	}
+}
+
+func TestAccountIDFromIDToken_Missing(t *testing.T) {
+	tok := makeJWT(t, map[string]any{"sub": "user"})
+	if _, err := AccountIDFromIDToken(tok); err == nil {
+		t.Fatal("expected error when claim missing")
+	}
+}
+
+func TestParseAuthFile_Roundtrip(t *testing.T) {
+	idToken := makeJWT(t, map[string]any{"chatgpt_account_id": "acct-7"})
+	src := map[string]any{
+		"OPENAI_API_KEY": "sk-omitted",
+		"tokens": map[string]any{
+			"id_token":      idToken,
+			"access_token":  "atk",
+			"refresh_token": "rtk",
+			"account_id":    "acct-from-file",
+		},
+		"last_refresh": "2026-01-02T03:04:05Z",
+	}
+	raw, _ := json.Marshal(src)
+	got, err := ParseAuthFile(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.IDToken != idToken {
+		t.Errorf("id_token: %q", got.IDToken)
+	}
+	if got.AccessToken != "atk" || got.RefreshToken != "rtk" {
+		t.Errorf("token mismatch: %+v", got)
+	}
+	if got.AccountID != "acct-from-file" {
+		t.Errorf("account_id: %q (expected file value)", got.AccountID)
+	}
+	want, _ := time.Parse(time.RFC3339, "2026-01-02T03:04:05Z")
+	if !got.LastRefresh.Equal(want) {
+		t.Errorf("last_refresh: %s", got.LastRefresh)
+	}
+}
+
+func TestParseAuthFile_FallsBackToIDTokenForAccountID(t *testing.T) {
+	idToken := makeJWT(t, map[string]any{"chatgpt_account_id": "from-id-token"})
+	raw, _ := json.Marshal(map[string]any{
+		"tokens": map[string]any{
+			"id_token":     idToken,
+			"access_token": "x",
+		},
+	})
+	got, err := ParseAuthFile(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.AccountID != "from-id-token" {
+		t.Errorf("account_id: %q want from-id-token", got.AccountID)
+	}
+}
+
+func TestParseAuthFile_Malformed(t *testing.T) {
+	if _, err := ParseAuthFile([]byte(`{"OPENAI_API_KEY":null}`)); !errors.Is(err, ErrMalformedAuthFile) {
+		t.Fatalf("want ErrMalformedAuthFile, got %v", err)
+	}
+	if _, err := ParseAuthFile([]byte(`{`)); err == nil {
+		t.Fatal("want JSON parse error")
+	}
+}
+
+func TestSafeStringRedacts(t *testing.T) {
+	tok := &Tokens{IDToken: "id", AccessToken: "secret", RefreshToken: "rtk"}
+	got := tok.SafeString()
+	if strings.Contains(got, "secret") || strings.Contains(got, "rtk") {
+		t.Fatalf("SafeString leaked tokens: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

First implementation issue under tracker #110 / M1. Lands `providers/codex/auth` — a leaf package that handles ChatGPT-subscription OAuth tokens for the upcoming `providers/codex` transport. v0.1 piggybacks on the upstream Codex CLI's `auth.json` (user runs `codex login` once outside glue) per ADR-0006 §2.

**What's in:**
- `Tokens`, `ParseAuthFile`, atomic encode that preserves the `OPENAI_API_KEY` field (read but unused for subscription routing).
- `Manager.AuthFilePath` with the documented resolution order: explicit override → `$GLUE_CODEX_AUTH` → `$CODEX_HOME/auth.json` → `~/.codex/auth.json`.
- `Manager.EnsureFresh` — checks JWT `exp` + 8-day cadence; refreshes via JSON POST to `auth.openai.com/oauth/token` (with `CODEX_REFRESH_TOKEN_URL_OVERRIDE` for tests).
- Refresh-response merge: missing fields preserve prior values.
- Atomic writeback (temp file + rename + `0o600` chmod) that preserves any existing `OPENAI_API_KEY`.
- Error classification: `refresh_token_expired` / `_reused` / `_invalidated` and unclassified 401/403 → `ErrRefreshPermanent`. 5xx and network failures stay transient. Public `IsPermanentRefreshFailure` helper.
- `AccessTokenExpiry` + `AccountIDFromIDToken` JWT payload decoding (stdlib only; no signature verification — `auth.json` is trusted).
- `SafeString` for redacted logging; no tokens written in non-test code.

**What's out (per ADR-0006 / issue #117):**
- HTTP to the model endpoint — issue #118 (transport).
- Interactive PKCE login — deferred (ADR-0006 appendix).
- OS keyring storage; multi-account selection.

Closes #117. Tracker: #110.

## Verification

```
$ go build ./providers/codex/...
(no output)

$ go vet ./providers/codex/...
(no output)

$ go test ./providers/codex/auth -count=1
ok  github.com/erain/glue/providers/codex/auth  0.026s

$ go test -race ./providers/codex/auth -count=1
ok  github.com/erain/glue/providers/codex/auth  1.069s

$ go test ./...
ok  github.com/erain/glue ...
ok  github.com/erain/glue/agents/glue-review ...
ok  github.com/erain/glue/cli ...
ok  github.com/erain/glue/cmd/glue ...
ok  github.com/erain/glue/examples/echo-provider ...
ok  github.com/erain/glue/examples/local-agent ...
ok  github.com/erain/glue/loop ...
ok  github.com/erain/glue/prompts ...
ok  github.com/erain/glue/providers ...
ok  github.com/erain/glue/providers/codex/auth ...
ok  github.com/erain/glue/providers/gemini ...
ok  github.com/erain/glue/providers/nvidia ...
ok  github.com/erain/glue/providers/openaicompat ...
ok  github.com/erain/glue/providers/openrouter ...
ok  github.com/erain/glue/stores/file ...
ok  github.com/erain/glue/tools/fs ...
ok  github.com/erain/glue/tools/git ...
```

22 new tests:

- `TestAuthFilePath_Resolution/{path-override-wins, env-override-wins-over-codex-home, codex-home-wins-over-home, home-default}`
- `TestLoadTokens_NoFile` (path included in error)
- `TestLoadTokens_HappyAndCache`
- `TestEnsureFresh_NotStale_NoCall`
- `TestEnsureFresh_JWTExpired_Refreshes` (asserts file rewritten, 0o600, contains rotated tokens)
- `TestEnsureFresh_StaleCadence_Refreshes`
- `TestRefresh_PartialResponsePreservesRefreshToken`
- `TestRefresh_PermanentFailure/{refresh_token_expired, _reused, _invalidated}`
- `TestRefresh_TransientFailure` (5xx not classified permanent)
- `TestRefresh_UnauthorizedClassifiedPermanent`
- `TestRefreshURL_EnvOverride` (field override > env override)
- `TestEnsureFresh_NoRefreshToken_Errors`
- `TestEnsureFresh_PreservesOpenAIAPIKey`
- `TestAccessTokenExpiry_{Happy, Errors}` (4 error sub-cases)
- `TestAccountIDFromIDToken` (3 claim shapes) + `_Missing`
- `TestParseAuthFile_{Roundtrip, FallsBackToIDTokenForAccountID, Malformed}`
- `TestSafeStringRedacts`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean
- [x] `go test -race ./providers/codex/auth` clean
- [x] No third-party deps added (`go.mod` unchanged)
- [x] No `fmt.Print` / `log.` of tokens in non-test code (`grep -rn 'fmt.Print\|log\.' providers/codex/auth/*.go | grep -v _test.go` → empty)