### PR TITLE
providers/codex: streaming Responses transport (closes #118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,50 @@ The model id matches the `org/name` path on build.nvidia.com (e.g.
 on Kimi K2 can reach tens of seconds for the first chunk; configure your
 HTTP client and context timeouts accordingly.
 
+## Quickstart: Codex (ChatGPT subscription)
+
+The `providers/codex` package routes requests through the Codex
+Responses endpoint
+([`chatgpt.com/backend-api/codex/responses`](https://chatgpt.com)),
+authenticated by your existing ChatGPT subscription rather than an
+OpenAI API key. Useful when your daily-driver agent should bill
+against the subscription you already pay for.
+
+v0.1 piggybacks on the upstream Codex CLI's `auth.json`. Install the
+[OpenAI Codex CLI](https://github.com/openai/codex) and log in once:
+
+```sh
+codex login
+```
+
+Glue reads the same token file (`~/.codex/auth.json` by default;
+overridable via `$GLUE_CODEX_AUTH` or `$CODEX_HOME`) and refreshes
+stale tokens automatically.
+
+```go
+import (
+    "github.com/erain/glue"
+    "github.com/erain/glue/providers/codex"
+)
+
+agent := glue.NewAgent(glue.AgentOptions{
+    Provider: codex.New(codex.Options{}),
+    Model:    codex.DefaultModel, // "gpt-5-codex"
+})
+```
+
+The provider quarantines all subscription-auth fragility (OAuth flow,
+Bearer + `ChatGPT-Account-ID` headers, Cloudflare cookie persistence,
+401-refresh-retry) to the package — the rest of glue is unchanged.
+See [`docs/adr/0006-codex-provider.md`](docs/adr/0006-codex-provider.md)
+for the full design. Subscription-auth use via third-party tools is
+not formally documented by OpenAI; the provider is intended for
+personal use.
+
+The interactive PKCE login flow is deferred for v0.1 (full protocol
+in the ADR appendix). If you cannot install the upstream Codex CLI,
+file an issue.
+
 ## Quickstart: OpenRouter
 
 The `providers/openrouter` package speaks the OpenAI-compatible API at

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -165,14 +165,15 @@ the loop, the agent, and other providers never learn about the auth
 shape.
 
 The pattern is documented in
-[`adr/0006-codex-provider.md`](adr/0006-codex-provider.md), which
-designs `providers/codex` (ChatGPT-subscription auth, Responses
-transport against `chatgpt.com`). New subscription-auth providers
-should follow that same package layout (`providers/<name>/auth` for
-token handling, `providers/<name>` for the `glue.Provider`
-implementation), reference upstream open-source CLIs as the protocol
-spec rather than copying code, and quarantine all vendor-specific
-headers and base URLs in the package.
+[`adr/0006-codex-provider.md`](adr/0006-codex-provider.md) and
+implemented in [`providers/codex`](../providers/codex) (ChatGPT-
+subscription auth, Responses transport against `chatgpt.com`). The
+package layout is the recommended template for future
+subscription-auth providers: `providers/<name>/auth` for token
+handling (OAuth flow, refresh, atomic write-back), `providers/<name>`
+for the `glue.Provider` implementation. Reference upstream
+open-source CLIs as the protocol spec rather than copying code, and
+quarantine all vendor-specific headers and base URLs in the package.
 
 ## Common mistakes
 

--- a/providers/codex/codex.go
+++ b/providers/codex/codex.go
@@ -1,0 +1,425 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/erain/glue/loop"
+	"github.com/erain/glue/providers"
+	"github.com/erain/glue/providers/codex/auth"
+)
+
+// DefaultModel is the registry-level default model id for the codex
+// provider. Callers typically override per-request via
+// glue.WithModel.
+const DefaultModel = "gpt-5-codex"
+
+// DefaultBaseURL is the Codex Responses endpoint root used when
+// Options.BaseURL is empty.
+const DefaultBaseURL = "https://chatgpt.com/backend-api/codex"
+
+const (
+	providerName       = "codex"
+	defaultOriginator  = "codex_cli_rs"
+	defaultOpenAIBeta  = "responses=experimental"
+	defaultContentType = "application/json"
+	streamAccept       = "text/event-stream"
+)
+
+func init() {
+	providers.Register(providerName, providers.Factory{
+		New:          func() loop.Provider { return New(Options{}) },
+		DefaultModel: DefaultModel,
+		// No env key: subscription auth lives in auth.json, not an env
+		// var. providers.KeyAvailable("codex") will always report false
+		// — agents should probe auth.LoadTokens instead.
+	})
+}
+
+// Options configures the codex provider. All fields are optional.
+type Options struct {
+	// Model is the registry-level default model when ProviderRequest.Model
+	// is empty. Empty falls back to DefaultModel.
+	Model string
+
+	// BaseURL overrides the Codex Responses root. Empty falls back to
+	// DefaultBaseURL. Tests inject an httptest URL here.
+	BaseURL string
+
+	// HTTPClient is used for the Responses POST. A cookie jar scoped
+	// to the chatgpt.com host is installed automatically when this is
+	// nil; supply your own client to take ownership.
+	HTTPClient *http.Client
+
+	// OriginatorOverride replaces the "originator" header (default
+	// "codex_cli_rs"). Server-side allowlist may reject other values.
+	OriginatorOverride string
+
+	// Auth is the token manager. When nil a default auth.Manager is
+	// constructed; AuthFile is applied to it when non-empty.
+	Auth *auth.Manager
+
+	// AuthFile sets Auth.PathOverride. Convenient for tests that don't
+	// want to construct a Manager directly.
+	AuthFile string
+}
+
+// Provider implements loop.Provider against the Codex Responses
+// endpoint. Construct via New.
+type Provider struct {
+	model      string
+	baseURL    string
+	httpClient *http.Client
+	originator string
+	auth       *auth.Manager
+	userAgent  string
+	version    string
+}
+
+// New constructs a Provider. Required fields are validated lazily in
+// Stream so that the constructor never returns an error.
+func New(o Options) *Provider {
+	httpClient := o.HTTPClient
+	if httpClient == nil {
+		jar, _ := cookiejar.New(nil)
+		httpClient = &http.Client{
+			Timeout: 5 * time.Minute,
+			Jar:     jar,
+		}
+	}
+	authMgr := o.Auth
+	if authMgr == nil {
+		authMgr = auth.NewManager()
+	}
+	if o.AuthFile != "" {
+		authMgr.PathOverride = o.AuthFile
+	}
+	originator := o.OriginatorOverride
+	if originator == "" {
+		originator = defaultOriginator
+	}
+	baseURL := o.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	ver := readVersion()
+	return &Provider{
+		model:      o.Model,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+		originator: originator,
+		auth:       authMgr,
+		userAgent:  fmt.Sprintf("glue-codex/%s (%s %s) codex-compat", ver, runtime.GOOS, runtime.GOARCH),
+		version:    ver,
+	}
+}
+
+// readVersion returns the module version from build info, falling back
+// to "dev" when running outside a build (e.g. tests).
+func readVersion() string {
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+			return bi.Main.Version
+		}
+	}
+	return "dev"
+}
+
+// Stream implements loop.Provider. See ADR-0006 §3 for the request and
+// SSE shapes.
+func (p *Provider) Stream(ctx context.Context, req loop.ProviderRequest) (<-chan loop.ProviderEvent, error) {
+	if p == nil {
+		return nil, errors.New("codex: nil provider")
+	}
+	model := req.Model
+	if model == "" {
+		model = p.model
+	}
+	if model == "" {
+		model = DefaultModel
+	}
+
+	tokens, err := p.auth.EnsureFresh(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("codex: auth: %w", err)
+	}
+	if tokens.AccountID == "" {
+		return nil, errors.New("codex: auth.json missing ChatGPT account_id (re-run `codex login`)")
+	}
+
+	input, err := messagesToInput(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+	body := responsesRequest{
+		Model:             model,
+		Instructions:      req.SystemPrompt,
+		Input:             input,
+		Tools:             toolSpecsToTools(req.Tools),
+		ToolChoice:        "auto",
+		ParallelToolCalls: false,
+		Stream:            true,
+		Store:             false,
+		Include:           []string{"reasoning.encrypted_content"},
+	}
+	payload, err := json.Marshal(&body)
+	if err != nil {
+		return nil, fmt.Errorf("codex: marshal request: %w", err)
+	}
+
+	sessionID := newUUID()
+	conversationID := newUUID()
+
+	httpResp, err := p.postWithRetry(ctx, tokens, payload, sessionID, conversationID)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make(chan loop.ProviderEvent)
+	go p.consumeStream(ctx, httpResp, model, events)
+	return events, nil
+}
+
+// postWithRetry issues the Responses POST and refreshes-and-retries
+// once on 401, per ADR-0006 §3.
+func (p *Provider) postWithRetry(ctx context.Context, tokens *auth.Tokens, payload []byte, sessionID, conversationID string) (*http.Response, error) {
+	resp, err := p.doPost(ctx, tokens, payload, sessionID, conversationID)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	// 401: try refresh + one retry.
+	_ = drainAndClose(resp)
+	if tokens.RefreshToken == "" {
+		return nil, errors.New("codex: http 401 and no refresh_token available")
+	}
+	refreshed, err := p.auth.EnsureFresh(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("codex: 401 refresh: %w", err)
+	}
+	resp2, err := p.doPost(ctx, refreshed, payload, sessionID, conversationID)
+	if err != nil {
+		return nil, err
+	}
+	if resp2.StatusCode == http.StatusUnauthorized {
+		_ = drainAndClose(resp2)
+		return nil, errors.New("codex: http 401 after refresh (re-run `codex login`)")
+	}
+	return resp2, nil
+}
+
+func (p *Provider) doPost(ctx context.Context, tokens *auth.Tokens, payload []byte, sessionID, conversationID string) (*http.Response, error) {
+	endpoint := p.baseURL + "/responses"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("codex: build request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	httpReq.Header.Set("ChatGPT-Account-ID", tokens.AccountID)
+	httpReq.Header.Set("OpenAI-Beta", defaultOpenAIBeta)
+	httpReq.Header.Set("Content-Type", defaultContentType)
+	httpReq.Header.Set("Accept", streamAccept)
+	httpReq.Header.Set("originator", p.originator)
+	httpReq.Header.Set("User-Agent", p.userAgent)
+	httpReq.Header.Set("version", p.version)
+	httpReq.Header.Set("session_id", sessionID)
+	httpReq.Header.Set("conversation_id", conversationID)
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("codex: send request: %w", err)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Let caller decide whether to refresh.
+		return resp, nil
+	}
+	// Non-401 non-2xx: surface as error.
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+	return nil, fmt.Errorf("codex: http %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+}
+
+func drainAndClose(resp *http.Response) error {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return resp.Body.Close()
+}
+
+// consumeStream reads the SSE event stream, maps each event to a
+// ProviderEvent, and emits Done with the final accumulated message
+// when response.completed arrives.
+func (p *Provider) consumeStream(ctx context.Context, resp *http.Response, model string, events chan<- loop.ProviderEvent) {
+	defer close(events)
+	defer resp.Body.Close()
+
+	out := loop.Message{
+		Role:      loop.MessageRoleAssistant,
+		Provider:  providerName,
+		Model:     model,
+		CreatedAt: time.Now().UTC(),
+		Metadata:  map[string]any{},
+	}
+	if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventStart, Message: &out}) {
+		return
+	}
+
+	var (
+		text     strings.Builder
+		hasText  bool
+		toolCalls []loop.ToolCall
+		completed bool
+		failed    bool
+	)
+
+	frames, errCh := readSSEEvents(ctx, resp.Body)
+	for frame := range frames {
+		switch frame.Event {
+		case "response.created":
+			var payload respCreatedPayload
+			if err := json.Unmarshal([]byte(frame.Data), &payload); err == nil {
+				if payload.Response.ID != "" {
+					out.Metadata["response_id"] = payload.Response.ID
+				}
+				if payload.Response.Model != "" {
+					out.Model = payload.Response.Model
+				}
+			}
+		case "response.output_text.delta":
+			var payload respTextDeltaPayload
+			if err := json.Unmarshal([]byte(frame.Data), &payload); err != nil {
+				continue
+			}
+			if payload.Delta == "" {
+				continue
+			}
+			text.WriteString(payload.Delta)
+			hasText = true
+			if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventTextDelta, Delta: payload.Delta}) {
+				return
+			}
+		case "response.output_item.done":
+			var payload respOutputItemDonePayload
+			if err := json.Unmarshal([]byte(frame.Data), &payload); err != nil {
+				continue
+			}
+			if payload.Item.Type != "function_call" {
+				continue
+			}
+			tc := loop.ToolCall{
+				ID:        payload.Item.CallID,
+				Name:      payload.Item.Name,
+				Arguments: payload.Item.Arguments,
+			}
+			if tc.ID == "" {
+				tc.ID = payload.Item.ID
+			}
+			toolCalls = append(toolCalls, tc)
+			if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventToolCall, ToolCall: &tc}) {
+				return
+			}
+		case "response.completed":
+			var payload respCompletedPayload
+			if err := json.Unmarshal([]byte(frame.Data), &payload); err == nil {
+				if payload.Response.ID != "" {
+					out.Metadata["response_id"] = payload.Response.ID
+				}
+				if payload.Response.Model != "" {
+					out.Model = payload.Response.Model
+				}
+				if payload.Response.Usage != nil {
+					out.Usage = &loop.Usage{
+						InputTokens:     payload.Response.Usage.InputTokens,
+						OutputTokens:    payload.Response.Usage.OutputTokens,
+						TotalTokens:     payload.Response.Usage.TotalTokens,
+						CacheReadTokens: payload.Response.Usage.CachedInputTokens,
+					}
+				}
+			}
+			completed = true
+		case "response.failed":
+			var payload respFailedPayload
+			_ = json.Unmarshal([]byte(frame.Data), &payload)
+			msg := "codex: response.failed"
+			if payload.Response.Error != nil && payload.Response.Error.Message != "" {
+				msg = "codex: " + payload.Response.Error.Message
+			}
+			send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: msg})
+			failed = true
+		default:
+			// Ignored event type (reasoning, queue, etc.). No-op.
+		}
+	}
+
+	if err := <-errCh; err != nil {
+		send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: fmt.Sprintf("codex: %v", err)})
+		return
+	}
+	if failed {
+		return
+	}
+	if !completed {
+		send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: "codex: stream closed before response.completed"})
+		return
+	}
+
+	// Assemble final message content.
+	if hasText && text.Len() > 0 {
+		out.Content = append(out.Content, loop.ContentPart{Type: loop.ContentTypeText, Text: text.String()})
+	}
+	for i := range toolCalls {
+		tc := toolCalls[i]
+		out.Content = append(out.Content, loop.ContentPart{Type: loop.ContentTypeToolCall, ToolCall: &tc})
+	}
+	if len(toolCalls) > 0 {
+		out.StopReason = loop.StopReasonToolUse
+	} else {
+		out.StopReason = loop.StopReasonStop
+	}
+	if len(out.Metadata) == 0 {
+		out.Metadata = nil
+	}
+	send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventDone, Message: &out})
+}
+
+func send(ctx context.Context, ch chan<- loop.ProviderEvent, ev loop.ProviderEvent) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- ev:
+		return true
+	}
+}
+
+// newUUID returns an RFC-4122 v4 UUID using crypto/rand. No third-party
+// dependency.
+func newUUID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// Compile-time assertion that Provider satisfies loop.Provider.
+var _ loop.Provider = (*Provider)(nil)
+
+// Ensure cookiejar import is referenced even when callers supply their
+// own HTTPClient (some builds tree-shake unused symbols).
+var _ = cookiejar.New
+var _ = url.Parse

--- a/providers/codex/codex_test.go
+++ b/providers/codex/codex_test.go
@@ -1,0 +1,481 @@
+package codex
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erain/glue/loop"
+	"github.com/erain/glue/providers"
+	"github.com/erain/glue/providers/codex/auth"
+)
+
+// makeJWT builds an unsigned JWT with the given claims. Mirror of the
+// helper in providers/codex/auth/tokens_test.go.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header, _ := json.Marshal(map[string]string{"alg": "none", "typ": "JWT"})
+	payload, _ := json.Marshal(claims)
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc(header) + "." + enc(payload) + "."
+}
+
+// writeAuthFile drops a minimal auth.json into dir with a fresh access
+// token and the given refresh token. Returns the file path.
+func writeAuthFile(t *testing.T, dir, refresh string) string {
+	t.Helper()
+	id := makeJWT(t, map[string]any{"chatgpt_account_id": "acct-7"})
+	access := makeJWT(t, map[string]any{"exp": time.Now().Add(24 * time.Hour).Unix()})
+	body := map[string]any{
+		"tokens": map[string]any{
+			"id_token":      id,
+			"access_token":  access,
+			"refresh_token": refresh,
+			"account_id":    "acct-7",
+		},
+		"last_refresh": time.Now().UTC().Format(time.RFC3339),
+	}
+	raw, _ := json.MarshalIndent(body, "", "  ")
+	path := filepath.Join(dir, "auth.json")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	return path
+}
+
+// canonicalSSE is a representative SSE stream covering the four events
+// glue cares about. Each block ends with a blank line.
+func canonicalSSE() string {
+	return "" +
+		"event: response.created\n" +
+		"data: {\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5-codex\"}}\n\n" +
+		"event: response.output_text.delta\n" +
+		"data: {\"delta\":\"Hello\"}\n\n" +
+		"event: response.output_text.delta\n" +
+		"data: {\"delta\":\" world\"}\n\n" +
+		"event: response.completed\n" +
+		"data: {\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5-codex\",\"usage\":{\"input_tokens\":12,\"output_tokens\":3,\"total_tokens\":15}}}\n\n"
+}
+
+func TestStream_HappyPath_HeadersAndEvents(t *testing.T) {
+	authDir := t.TempDir()
+	authPath := writeAuthFile(t, authDir, "rtk")
+
+	var captured *http.Request
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Clone(r.Context())
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, canonicalSSE())
+	}))
+	defer srv.Close()
+
+	p := New(Options{BaseURL: srv.URL, AuthFile: authPath})
+	ev, err := p.Stream(context.Background(), loop.ProviderRequest{
+		Model:        "gpt-5-codex",
+		SystemPrompt: "be helpful",
+		Messages: []loop.Message{{
+			Role:    loop.MessageRoleUser,
+			Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "Hi"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collectEvents(t, ev)
+
+	// Event sequence: Start, TextDelta, TextDelta, Done.
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != loop.ProviderEventStart {
+		t.Errorf("first event = %s", events[0].Type)
+	}
+	if events[1].Type != loop.ProviderEventTextDelta || events[1].Delta != "Hello" {
+		t.Errorf("second event = %+v", events[1])
+	}
+	if events[2].Type != loop.ProviderEventTextDelta || events[2].Delta != " world" {
+		t.Errorf("third event = %+v", events[2])
+	}
+	if events[3].Type != loop.ProviderEventDone {
+		t.Fatalf("final event = %s", events[3].Type)
+	}
+	final := events[3].Message
+	if final == nil {
+		t.Fatal("Done event missing message")
+	}
+	if final.Provider != "codex" {
+		t.Errorf("provider = %s", final.Provider)
+	}
+	if final.Model != "gpt-5-codex" {
+		t.Errorf("model = %s", final.Model)
+	}
+	if final.Usage == nil || final.Usage.InputTokens != 12 || final.Usage.OutputTokens != 3 || final.Usage.TotalTokens != 15 {
+		t.Errorf("usage = %+v", final.Usage)
+	}
+	if got, _ := final.Metadata["response_id"].(string); got != "resp_1" {
+		t.Errorf("response_id = %q", got)
+	}
+	if final.StopReason != loop.StopReasonStop {
+		t.Errorf("stop_reason = %s", final.StopReason)
+	}
+	if len(final.Content) != 1 || final.Content[0].Text != "Hello world" {
+		t.Errorf("content = %+v", final.Content)
+	}
+
+	// Headers required by ADR-0006 §3.
+	if captured == nil {
+		t.Fatal("no request captured")
+	}
+	want := map[string]string{
+		"Accept":             "text/event-stream",
+		"Content-Type":       "application/json",
+		"Openai-Beta":        "responses=experimental",
+		"Originator":         "codex_cli_rs",
+		"Chatgpt-Account-Id": "acct-7",
+	}
+	for h, v := range want {
+		if got := captured.Header.Get(h); got != v {
+			t.Errorf("header %s = %q, want %q", h, got, v)
+		}
+	}
+	if got := captured.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
+		t.Errorf("Authorization not Bearer: %q", got)
+	}
+	for _, h := range []string{"User-Agent", "version", "session_id", "conversation_id"} {
+		if captured.Header.Get(h) == "" {
+			t.Errorf("missing header %s", h)
+		}
+	}
+
+	// Request body sanity.
+	var sent map[string]any
+	if err := json.Unmarshal(capturedBody, &sent); err != nil {
+		t.Fatalf("body json: %v", err)
+	}
+	if sent["model"] != "gpt-5-codex" {
+		t.Errorf("model in body = %v", sent["model"])
+	}
+	if sent["instructions"] != "be helpful" {
+		t.Errorf("instructions in body = %v", sent["instructions"])
+	}
+	if sent["stream"] != true {
+		t.Errorf("stream should be true")
+	}
+	if sent["store"] != false {
+		t.Errorf("store should be false")
+	}
+}
+
+func TestStream_ToolCallRoundTrip(t *testing.T) {
+	authPath := writeAuthFile(t, t.TempDir(), "rtk")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ""+
+			"event: response.created\ndata: {\"response\":{\"id\":\"r2\"}}\n\n"+
+			"event: response.output_item.done\n"+
+			"data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"call_X\",\"name\":\"weather\",\"arguments\":{\"q\":\"NYC\"}}}\n\n"+
+			"event: response.completed\ndata: {\"response\":{\"id\":\"r2\"}}\n\n")
+	}))
+	defer srv.Close()
+
+	p := New(Options{BaseURL: srv.URL, AuthFile: authPath})
+	ev, err := p.Stream(context.Background(), loop.ProviderRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collectEvents(t, ev)
+
+	var sawCall *loop.ToolCall
+	var final *loop.Message
+	for _, e := range events {
+		if e.Type == loop.ProviderEventToolCall {
+			sawCall = e.ToolCall
+		}
+		if e.Type == loop.ProviderEventDone {
+			final = e.Message
+		}
+	}
+	if sawCall == nil {
+		t.Fatal("missing tool_call event")
+	}
+	if sawCall.ID != "call_X" || sawCall.Name != "weather" {
+		t.Errorf("tool call: %+v", sawCall)
+	}
+	if !strings.Contains(string(sawCall.Arguments), "NYC") {
+		t.Errorf("args: %s", sawCall.Arguments)
+	}
+	if final == nil || final.StopReason != loop.StopReasonToolUse {
+		t.Errorf("stop_reason should be tool_use, got %+v", final)
+	}
+}
+
+func TestStream_StreamClosedBeforeCompleted(t *testing.T) {
+	authPath := writeAuthFile(t, t.TempDir(), "rtk")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// No completed event; just text + close.
+		_, _ = io.WriteString(w, "event: response.created\ndata: {}\n\nevent: response.output_text.delta\ndata: {\"delta\":\"x\"}\n\n")
+	}))
+	defer srv.Close()
+
+	p := New(Options{BaseURL: srv.URL, AuthFile: authPath})
+	ev, err := p.Stream(context.Background(), loop.ProviderRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collectEvents(t, ev)
+	var sawErr bool
+	for _, e := range events {
+		if e.Type == loop.ProviderEventError && strings.Contains(e.Error, "stream closed before response.completed") {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatalf("expected stream-closed error, got %+v", events)
+	}
+}
+
+func TestStream_FailedEvent(t *testing.T) {
+	authPath := writeAuthFile(t, t.TempDir(), "rtk")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ""+
+			"event: response.created\ndata: {}\n\n"+
+			"event: response.failed\ndata: {\"response\":{\"error\":{\"message\":\"upstream boom\"}}}\n\n")
+	}))
+	defer srv.Close()
+
+	p := New(Options{BaseURL: srv.URL, AuthFile: authPath})
+	ev, _ := p.Stream(context.Background(), loop.ProviderRequest{Model: "m"})
+	events := collectEvents(t, ev)
+	if events[len(events)-1].Type != loop.ProviderEventError {
+		t.Fatalf("expected error as last event, got %+v", events)
+	}
+	if !strings.Contains(events[len(events)-1].Error, "upstream boom") {
+		t.Errorf("error message: %q", events[len(events)-1].Error)
+	}
+}
+
+func TestStream_401RefreshAndRetry(t *testing.T) {
+	authDir := t.TempDir()
+	authPath := writeAuthFile(t, authDir, "rtk-original")
+
+	// Refresh server returns rotated tokens.
+	refreshHits := int32(0)
+	refreshSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&refreshHits, 1)
+		_ = json.NewEncoder(w).Encode(auth.RefreshResponse{AccessToken: makeJWT(t, map[string]any{"exp": time.Now().Add(time.Hour).Unix()})})
+	}))
+	defer refreshSrv.Close()
+
+	// Responses server: 401 first, then 200 with valid completion.
+	hits := int32(0)
+	respSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			io.WriteString(w, `{"error":"expired"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, canonicalSSE())
+	}))
+	defer respSrv.Close()
+
+	mgr := &auth.Manager{PathOverride: authPath, RefreshURLOverride: refreshSrv.URL}
+	// Force the manager to think tokens are stale on next EnsureFresh so
+	// refresh runs.
+	mgr.Now = func() time.Time { return time.Now().Add(10 * 24 * time.Hour) } // > 8d cadence
+	p := New(Options{BaseURL: respSrv.URL, Auth: mgr})
+
+	ev, err := p.Stream(context.Background(), loop.ProviderRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collectEvents(t, ev)
+	if events[len(events)-1].Type != loop.ProviderEventDone {
+		t.Fatalf("expected Done, got %+v", events[len(events)-1])
+	}
+	if atomic.LoadInt32(&hits) != 2 {
+		t.Errorf("expected 2 responses hits (401 then 200), got %d", hits)
+	}
+	// At least one refresh call from the proactive cadence; the 401-driven
+	// path also triggers one. Either way the refresh server is exercised.
+	if atomic.LoadInt32(&refreshHits) < 1 {
+		t.Errorf("expected at least one refresh call, got %d", refreshHits)
+	}
+}
+
+func TestStream_Non2xxNon401Errors(t *testing.T) {
+	authPath := writeAuthFile(t, t.TempDir(), "rtk")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, `{"error":"boom"}`)
+	}))
+	defer srv.Close()
+
+	p := New(Options{BaseURL: srv.URL, AuthFile: authPath})
+	if _, err := p.Stream(context.Background(), loop.ProviderRequest{Model: "m"}); err == nil {
+		t.Fatal("expected error for 5xx")
+	}
+}
+
+func TestStream_NoAuthFileErrors(t *testing.T) {
+	p := New(Options{BaseURL: "http://example", AuthFile: filepath.Join(t.TempDir(), "missing.json")})
+	_, err := p.Stream(context.Background(), loop.ProviderRequest{Model: "m"})
+	if err == nil || !strings.Contains(err.Error(), "codex: auth") {
+		t.Fatalf("want codex: auth error, got %v", err)
+	}
+}
+
+func TestStream_ContextCancel(t *testing.T) {
+	authPath := writeAuthFile(t, t.TempDir(), "rtk")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Send a started event then block.
+		_, _ = io.WriteString(w, "event: response.created\ndata: {}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := New(Options{BaseURL: srv.URL, AuthFile: authPath})
+	ev, err := p.Stream(ctx, loop.ProviderRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	cancel()
+	// Drain until the channel closes; it must close promptly after cancel.
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-ev:
+			if !ok {
+				return
+			}
+		case <-timeout:
+			t.Fatal("event channel did not close after ctx cancel")
+		}
+	}
+}
+
+func TestRegistryRegistersCodex(t *testing.T) {
+	if _, ok := providers.Lookup("codex"); !ok {
+		t.Fatal("codex not registered")
+	}
+	prov, def, env, err := providers.New("codex")
+	if err != nil {
+		t.Fatalf("providers.New: %v", err)
+	}
+	if prov == nil {
+		t.Fatal("nil provider")
+	}
+	if def != DefaultModel {
+		t.Errorf("default model = %q", def)
+	}
+	if env != "" {
+		t.Errorf("codex should not advertise an env key, got %q", env)
+	}
+}
+
+func TestNewUUIDV4Format(t *testing.T) {
+	id := newUUID()
+	if len(id) != 36 {
+		t.Fatalf("uuid length = %d", len(id))
+	}
+	parts := strings.Split(id, "-")
+	if len(parts) != 5 {
+		t.Fatalf("uuid groups = %d", len(parts))
+	}
+	if len(parts[2]) != 4 || parts[2][0] != '4' {
+		t.Errorf("version nibble: %s", parts[2])
+	}
+	switch parts[3][0] {
+	case '8', '9', 'a', 'b':
+	default:
+		t.Errorf("variant nibble: %s", parts[3])
+	}
+}
+
+func collectEvents(t *testing.T, ch <-chan loop.ProviderEvent) []loop.ProviderEvent {
+	t.Helper()
+	timeout := time.After(5 * time.Second)
+	var out []loop.ProviderEvent
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-timeout:
+			t.Fatalf("timeout draining events; got so far: %+v", out)
+		}
+	}
+}
+
+// TestLiveSmoke runs against the real Codex endpoint when
+// GLUE_CODEX_LIVE=1 and a token file is available. Manual /
+// workflow_dispatch only — never in default CI per ADR-0006 §7.
+func TestLiveSmoke(t *testing.T) {
+	if os.Getenv("GLUE_CODEX_LIVE") == "" {
+		t.Skip("GLUE_CODEX_LIVE not set")
+	}
+	mgr := auth.NewManager()
+	if _, err := mgr.LoadTokens(context.Background()); err != nil {
+		t.Skipf("no codex auth.json: %v", err)
+	}
+	p := New(Options{Auth: mgr})
+	ev, err := p.Stream(context.Background(), loop.ProviderRequest{
+		Model: DefaultModel,
+		Messages: []loop.Message{{
+			Role:    loop.MessageRoleUser,
+			Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "Reply with the single word: ok."}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collectEvents(t, ev)
+	last := events[len(events)-1]
+	if last.Type != loop.ProviderEventDone || last.Message == nil {
+		t.Fatalf("expected Done with message, got %+v", last)
+	}
+	if len(last.Message.Content) == 0 {
+		t.Fatalf("empty content")
+	}
+	t.Logf("model=%s usage=%+v text=%q", last.Message.Model, last.Message.Usage, snippet(last.Message))
+}
+
+func snippet(m *loop.Message) string {
+	for _, p := range m.Content {
+		if p.Type == loop.ContentTypeText {
+			s := p.Text
+			if len(s) > 80 {
+				s = s[:80] + "…"
+			}
+			return s
+		}
+	}
+	return ""
+}
+
+var _ = fmt.Sprintf // keep fmt import when not otherwise used

--- a/providers/codex/convert.go
+++ b/providers/codex/convert.go
@@ -1,0 +1,196 @@
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/erain/glue/loop"
+)
+
+// responsesRequest is the JSON body sent to the Codex Responses
+// endpoint. Fields mirror Codex CLI's ResponsesApiRequest in
+// codex-rs/core/src/client.rs.
+type responsesRequest struct {
+	Model              string           `json:"model"`
+	Instructions       string           `json:"instructions,omitempty"`
+	Input              []responsesInput `json:"input"`
+	Tools              []responsesTool  `json:"tools,omitempty"`
+	ToolChoice         string           `json:"tool_choice,omitempty"`
+	ParallelToolCalls  bool             `json:"parallel_tool_calls"`
+	Stream             bool             `json:"stream"`
+	Store              bool             `json:"store"`
+	Include            []string         `json:"include,omitempty"`
+}
+
+// responsesInput is one item in the Responses input array. The active
+// fields depend on Type:
+//
+//   - "message": Role + Content
+//   - "function_call": CallID + Name + Arguments
+//   - "function_call_output": CallID + Output
+type responsesInput struct {
+	Type      string             `json:"type"`
+	Role      string             `json:"role,omitempty"`
+	Content   []responsesContent `json:"content,omitempty"`
+	CallID    string             `json:"call_id,omitempty"`
+	Name      string             `json:"name,omitempty"`
+	Arguments string             `json:"arguments,omitempty"`
+	Output    string             `json:"output,omitempty"`
+}
+
+// responsesContent is one content part inside a Responses message item.
+// Type is "input_text" on user messages and "output_text" on assistant
+// messages.
+type responsesContent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// responsesTool is the Responses tools-array shape. Note this is *not*
+// the Chat Completions shape ({type:function, function:{...}}).
+type responsesTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// messagesToInput converts a normalized message transcript into the
+// Responses input array. Tool-call messages from the assistant become
+// "function_call" items keyed by call_id; tool-role messages (results)
+// become "function_call_output" items keyed by the same call_id.
+//
+// Returns an error if a message contains non-text user/assistant
+// content (image / thinking are not supported in v0.1 per ADR-0006
+// §3). Thinking content from assistant messages is silently dropped.
+func messagesToInput(msgs []loop.Message) ([]responsesInput, error) {
+	out := make([]responsesInput, 0, len(msgs)+1)
+	for i, m := range msgs {
+		switch m.Role {
+		case loop.MessageRoleUser:
+			parts, err := textPartsOnly(m.Content, "user")
+			if err != nil {
+				return nil, fmt.Errorf("message %d: %w", i, err)
+			}
+			if len(parts) == 0 {
+				continue
+			}
+			out = append(out, responsesInput{
+				Type:    "message",
+				Role:    "user",
+				Content: toInputContent("input_text", parts),
+			})
+		case loop.MessageRoleAssistant:
+			text := assistantText(m.Content)
+			if text != "" {
+				out = append(out, responsesInput{
+					Type:    "message",
+					Role:    "assistant",
+					Content: toInputContent("output_text", []string{text}),
+				})
+			}
+			for _, p := range m.Content {
+				if p.Type == loop.ContentTypeToolCall && p.ToolCall != nil {
+					out = append(out, responsesInput{
+						Type:      "function_call",
+						CallID:    p.ToolCall.ID,
+						Name:      p.ToolCall.Name,
+						Arguments: string(p.ToolCall.Arguments),
+					})
+				}
+			}
+		case loop.MessageRoleTool:
+			callID := m.ToolCallID
+			if callID == "" {
+				return nil, fmt.Errorf("message %d: tool result missing tool_call_id", i)
+			}
+			out = append(out, responsesInput{
+				Type:   "function_call_output",
+				CallID: callID,
+				Output: toolResultText(m.Content),
+			})
+		}
+	}
+	return out, nil
+}
+
+// textPartsOnly returns the text fields of content, refusing image
+// parts (which are out of scope for v0.1). Thinking parts on user
+// messages are unusual and treated the same way.
+func textPartsOnly(parts []loop.ContentPart, role string) ([]string, error) {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		switch p.Type {
+		case loop.ContentTypeText:
+			if p.Text != "" {
+				out = append(out, p.Text)
+			}
+		case loop.ContentTypeImage:
+			return nil, fmt.Errorf("%s: image content not supported by codex provider v0.1", role)
+		}
+	}
+	return out, nil
+}
+
+// assistantText concatenates all text-typed content parts from an
+// assistant message. Tool calls and thinking are ignored here; tool
+// calls are emitted as separate function_call items.
+func assistantText(parts []loop.ContentPart) string {
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Type == loop.ContentTypeText && p.Text != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+// toolResultText flattens a tool result's content parts into a single
+// string the Responses API can carry on a function_call_output item.
+func toolResultText(parts []loop.ContentPart) string {
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Type == loop.ContentTypeText && p.Text != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+func toInputContent(contentType string, texts []string) []responsesContent {
+	out := make([]responsesContent, 0, len(texts))
+	for _, t := range texts {
+		out = append(out, responsesContent{Type: contentType, Text: t})
+	}
+	return out
+}
+
+// toolSpecsToTools converts glue tool specs to Responses tools.
+// Parameters is forwarded as-is; an empty parameters block becomes
+// "{}" so the schema validates.
+func toolSpecsToTools(specs []loop.ToolSpec) []responsesTool {
+	if len(specs) == 0 {
+		return nil
+	}
+	out := make([]responsesTool, 0, len(specs))
+	for _, s := range specs {
+		params := s.Parameters
+		if len(params) == 0 {
+			params = json.RawMessage(`{}`)
+		}
+		out = append(out, responsesTool{
+			Type:        "function",
+			Name:        s.Name,
+			Description: s.Description,
+			Parameters:  params,
+		})
+	}
+	return out
+}

--- a/providers/codex/convert_test.go
+++ b/providers/codex/convert_test.go
@@ -1,0 +1,138 @@
+package codex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue/loop"
+)
+
+func TestMessagesToInput_UserAndAssistantText(t *testing.T) {
+	msgs := []loop.Message{
+		{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "hi"}}},
+		{Role: loop.MessageRoleAssistant, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "hello!"}}},
+	}
+	got, err := messagesToInput(msgs)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d items: %+v", len(got), got)
+	}
+	if got[0].Type != "message" || got[0].Role != "user" || got[0].Content[0].Type != "input_text" || got[0].Content[0].Text != "hi" {
+		t.Errorf("user item wrong: %+v", got[0])
+	}
+	if got[1].Type != "message" || got[1].Role != "assistant" || got[1].Content[0].Type != "output_text" || got[1].Content[0].Text != "hello!" {
+		t.Errorf("assistant item wrong: %+v", got[1])
+	}
+}
+
+func TestMessagesToInput_FunctionCallRoundTrip(t *testing.T) {
+	args := json.RawMessage(`{"q":"weather"}`)
+	msgs := []loop.Message{
+		{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "ask"}}},
+		{
+			Role: loop.MessageRoleAssistant,
+			Content: []loop.ContentPart{
+				{Type: loop.ContentTypeText, Text: "I'll check."},
+				{Type: loop.ContentTypeToolCall, ToolCall: &loop.ToolCall{
+					ID: "call_42", Name: "weather", Arguments: args,
+				}},
+			},
+		},
+		{
+			Role:       loop.MessageRoleTool,
+			ToolCallID: "call_42",
+			ToolName:   "weather",
+			Content:    []loop.ContentPart{{Type: loop.ContentTypeText, Text: "sunny"}},
+		},
+	}
+	got, err := messagesToInput(msgs)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	// Expect: user message, assistant message, function_call, function_call_output
+	if len(got) != 4 {
+		t.Fatalf("got %d items: %+v", len(got), got)
+	}
+	if got[2].Type != "function_call" || got[2].CallID != "call_42" || got[2].Name != "weather" {
+		t.Errorf("function_call item wrong: %+v", got[2])
+	}
+	if !strings.Contains(got[2].Arguments, "weather") {
+		t.Errorf("function_call arguments not forwarded: %q", got[2].Arguments)
+	}
+	if got[3].Type != "function_call_output" || got[3].CallID != "call_42" || got[3].Output != "sunny" {
+		t.Errorf("function_call_output item wrong: %+v", got[3])
+	}
+}
+
+func TestMessagesToInput_ToolResultWithoutCallIDErrors(t *testing.T) {
+	msgs := []loop.Message{{Role: loop.MessageRoleTool, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "x"}}}}
+	if _, err := messagesToInput(msgs); err == nil {
+		t.Fatal("want error for tool result without call id")
+	}
+}
+
+func TestMessagesToInput_RefusesImageContent(t *testing.T) {
+	msgs := []loop.Message{{
+		Role:    loop.MessageRoleUser,
+		Content: []loop.ContentPart{{Type: loop.ContentTypeImage, Image: &loop.ImageContent{Data: "Zg==", MIMEType: "image/png"}}},
+	}}
+	if _, err := messagesToInput(msgs); err == nil {
+		t.Fatal("want error for image content (out of scope v0.1)")
+	}
+}
+
+func TestMessagesToInput_DropsEmptyUserText(t *testing.T) {
+	msgs := []loop.Message{{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: ""}}}}
+	got, err := messagesToInput(msgs)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %+v", got)
+	}
+}
+
+func TestMessagesToInput_AssistantWithOnlyToolCall(t *testing.T) {
+	msgs := []loop.Message{
+		{
+			Role: loop.MessageRoleAssistant,
+			Content: []loop.ContentPart{{Type: loop.ContentTypeToolCall, ToolCall: &loop.ToolCall{
+				ID: "c", Name: "fn", Arguments: json.RawMessage(`{}`),
+			}}},
+		},
+	}
+	got, err := messagesToInput(msgs)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	// Only function_call should be emitted; no empty assistant message.
+	if len(got) != 1 || got[0].Type != "function_call" {
+		t.Errorf("expected single function_call, got %+v", got)
+	}
+}
+
+func TestToolSpecsToTools(t *testing.T) {
+	specs := []loop.ToolSpec{
+		{Name: "weather", Description: "look up", Parameters: json.RawMessage(`{"type":"object"}`)},
+		{Name: "no_params", Description: ""}, // empty parameters → "{}"
+	}
+	got := toolSpecsToTools(specs)
+	if len(got) != 2 {
+		t.Fatalf("got %d", len(got))
+	}
+	if got[0].Type != "function" || got[0].Name != "weather" || got[0].Description != "look up" {
+		t.Errorf("first tool: %+v", got[0])
+	}
+	if string(got[1].Parameters) != "{}" {
+		t.Errorf("empty params should default to '{}', got %q", got[1].Parameters)
+	}
+}
+
+func TestToolSpecsToTools_NilForNoSpecs(t *testing.T) {
+	if got := toolSpecsToTools(nil); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}

--- a/providers/codex/doc.go
+++ b/providers/codex/doc.go
@@ -1,0 +1,10 @@
+// Package codex is a glue.Provider that routes through the Codex
+// Responses endpoint at chatgpt.com/backend-api/codex/responses,
+// authenticated with a ChatGPT subscription via OAuth tokens read from
+// the upstream Codex CLI's auth.json (run "codex login" once outside
+// glue).
+//
+// Design: docs/adr/0006-codex-provider.md. Token handling lives in
+// providers/codex/auth; this package owns request construction, the
+// SSE event stream, and the 401-refresh-retry loop.
+package codex

--- a/providers/codex/sse.go
+++ b/providers/codex/sse.go
@@ -1,0 +1,134 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// sseEvent is one parsed Server-Sent-Event frame. Event is the value of
+// the "event:" line; Data is the JSON payload from the (possibly
+// multi-line) "data:" lines, joined with newlines per the SSE spec.
+type sseEvent struct {
+	Event string
+	Data  string
+}
+
+// readSSEEvents pulls one sseEvent at a time from r, sending them to
+// the returned channel. The channel is closed when r EOFs, ctx is
+// cancelled, or a read error occurs.
+//
+// The reader respects ctx.Done() between event blocks.
+func readSSEEvents(ctx context.Context, r io.Reader) (<-chan sseEvent, <-chan error) {
+	events := make(chan sseEvent)
+	errs := make(chan error, 1)
+	go func() {
+		defer close(events)
+		defer close(errs)
+
+		scanner := bufio.NewScanner(r)
+		// SSE event lines can be large (Codex SSE carries full
+		// output items in a single data: line). Allow up to 4 MiB.
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+		var (
+			event string
+			data  strings.Builder
+		)
+		flush := func() bool {
+			if event == "" && data.Len() == 0 {
+				return true
+			}
+			select {
+			case <-ctx.Done():
+				return false
+			case events <- sseEvent{Event: event, Data: data.String()}:
+				event = ""
+				data.Reset()
+				return true
+			}
+		}
+
+		for scanner.Scan() {
+			if err := ctx.Err(); err != nil {
+				errs <- err
+				return
+			}
+			line := scanner.Text()
+			switch {
+			case line == "":
+				if !flush() {
+					return
+				}
+			case strings.HasPrefix(line, ":"):
+				// SSE comment; keep-alive. Ignore.
+			case strings.HasPrefix(line, "event:"):
+				event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				if data.Len() > 0 {
+					data.WriteByte('\n')
+				}
+				data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		// Flush any final event that wasn't terminated by a blank line.
+		if event != "" || data.Len() > 0 {
+			_ = flush()
+		}
+		if err := scanner.Err(); err != nil && !errors.Is(err, context.Canceled) {
+			errs <- fmt.Errorf("codex: read sse: %w", err)
+		}
+	}()
+	return events, errs
+}
+
+// Responses SSE event payloads. Only the fields glue actually uses are
+// modeled; everything else is ignored.
+
+type respCreatedPayload struct {
+	Response struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+	} `json:"response"`
+}
+
+type respTextDeltaPayload struct {
+	Delta string `json:"delta"`
+}
+
+type respOutputItemDonePayload struct {
+	Item struct {
+		Type      string          `json:"type"`
+		ID        string          `json:"id"`
+		CallID    string          `json:"call_id"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"item"`
+}
+
+type respCompletedPayload struct {
+	Response struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+		Usage *struct {
+			InputTokens         int64 `json:"input_tokens"`
+			OutputTokens        int64 `json:"output_tokens"`
+			TotalTokens         int64 `json:"total_tokens"`
+			CachedInputTokens   int64 `json:"cached_input_tokens,omitempty"`
+		} `json:"usage"`
+	} `json:"response"`
+}
+
+type respFailedPayload struct {
+	Response struct {
+		ID    string `json:"id"`
+		Error *struct {
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	} `json:"response"`
+}

--- a/providers/codex/sse_test.go
+++ b/providers/codex/sse_test.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestReadSSEEvents_BasicFraming(t *testing.T) {
+	body := "event: response.created\ndata: {\"response\":{\"id\":\"r1\"}}\n\n" +
+		"event: response.output_text.delta\ndata: {\"delta\":\"hi\"}\n\n" +
+		"event: response.completed\ndata: {\"response\":{\"id\":\"r1\"}}\n\n"
+	ch, errs := readSSEEvents(context.Background(), strings.NewReader(body))
+	var got []sseEvent
+	for ev := range ch {
+		got = append(got, ev)
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d events: %+v", len(got), got)
+	}
+	if got[0].Event != "response.created" || !strings.Contains(got[0].Data, "r1") {
+		t.Errorf("first event: %+v", got[0])
+	}
+	if got[1].Event != "response.output_text.delta" || !strings.Contains(got[1].Data, "hi") {
+		t.Errorf("second event: %+v", got[1])
+	}
+	if got[2].Event != "response.completed" {
+		t.Errorf("third event: %+v", got[2])
+	}
+}
+
+func TestReadSSEEvents_IgnoresCommentsAndBlankPrefix(t *testing.T) {
+	body := ": keep-alive\n\n" +
+		"event: response.created\ndata: {\"ok\":true}\n\n"
+	ch, _ := readSSEEvents(context.Background(), strings.NewReader(body))
+	got := drainSSE(ch)
+	// Comments don't produce events; blank line after them is harmless.
+	if len(got) != 1 || got[0].Event != "response.created" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestReadSSEEvents_MultilineData(t *testing.T) {
+	body := "event: x\ndata: line1\ndata: line2\n\n"
+	ch, _ := readSSEEvents(context.Background(), strings.NewReader(body))
+	got := drainSSE(ch)
+	if len(got) != 1 {
+		t.Fatalf("got %d", len(got))
+	}
+	if got[0].Data != "line1\nline2" {
+		t.Errorf("data = %q", got[0].Data)
+	}
+}
+
+func TestReadSSEEvents_FlushesTrailingEventWithoutBlankLine(t *testing.T) {
+	body := "event: a\ndata: {}\n" // no trailing blank line
+	ch, _ := readSSEEvents(context.Background(), strings.NewReader(body))
+	got := drainSSE(ch)
+	if len(got) != 1 {
+		t.Fatalf("trailing event not flushed: %+v", got)
+	}
+}
+
+func drainSSE(ch <-chan sseEvent) []sseEvent {
+	var out []sseEvent
+	for ev := range ch {
+		out = append(out, ev)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Lands the `glue.Provider` that routes through the Codex Responses endpoint at `chatgpt.com/backend-api/codex/responses`, authenticated by access tokens from `providers/codex/auth` (PR #123). With this PR the codex provider is end-to-end usable: `codex login` once with the upstream CLI, then `codex.New(codex.Options{})` is a working `glue.Provider`.

Designed in [ADR-0006](https://github.com/erain/glue/blob/main/docs/adr/0006-codex-provider.md). Closes #118. Tracker: #110.

**Request build** (per ADR-0006 §3): `responsesRequest` body (model / instructions / input / tools / `tool_choice="auto"` / `parallel_tool_calls=false` / `stream=true` / `store=false` / `include=reasoning.encrypted_content`). `messagesToInput` translates user/assistant text into `message` items with `input_text` / `output_text` content; assistant tool calls become `function_call` items keyed by `call_id`; tool-role results become `function_call_output` items. Refuses image content (v0.1 scope per ADR-0006). `toolSpecsToTools` flattens glue specs into the Responses tool schema (`{type, name, description, parameters}`).

**Headers**: every required header from ADR-0006 §3 — `Authorization: Bearer`, `ChatGPT-Account-ID`, `OpenAI-Beta: responses=experimental`, `Accept: text/event-stream`, `Content-Type: application/json`, `originator: codex_cli_rs`, `User-Agent: glue-codex/<ver> (<GOOS> <GOARCH>) codex-compat`, `version`, per-turn UUIDv4 `session_id` / `conversation_id`. UUIDs come from `crypto/rand`; no third-party UUID dep.

**Auth integration**: `EnsureFresh` runs on every Stream call. On HTTP 401 the provider refreshes once via `auth.Manager.Refresh` and retries; second 401 surfaces with a re-login hint.

**Cookie jar**: the default HTTPClient installs `net/http/cookiejar` scoped per-Provider — chatgpt.com is fronted by Cloudflare and persistent cookies avoid challenges. Callers passing their own HTTPClient take ownership.

**SSE handling** (`sse.go`): generic `event:` / `data:` framing, multi-line `data:` joined with `\n` per spec, comment lines skipped, trailing event flushed when the stream closes without a blank line, 4 MiB scanner buffer to handle large `response.output_item.done` payloads. Ctx-aware between event blocks.

**Event mapping**:

| SSE event | Glue event |
|---|---|
| `response.created` | `ProviderEventStart` (capture id/model) |
| `response.output_text.delta` | `ProviderEventTextDelta` |
| `response.output_item.done` (type=function_call) | `ProviderEventToolCall` |
| `response.completed` | `ProviderEventDone` (usage attached) |
| `response.failed` | `ProviderEventError` |
| anything else | ignored |

Stream-closed-before-`response.completed` is surfaced as a clear error. Final message carries `Provider="codex"`, `Model`, `Metadata["response_id"]`, `Usage{Input,Output,Total,CacheRead}`. `StopReason` is `ToolUse` when any function_call appeared, else `Stop`.

**No third-party deps** added.

## Verification

```
$ go build ./...
(no output)

$ go vet ./...
(no output)

$ go test ./...
ok  github.com/erain/glue                            ...
ok  github.com/erain/glue/agents/glue-review         ...
ok  github.com/erain/glue/cli                        ...
ok  github.com/erain/glue/cmd/glue                   ...
ok  github.com/erain/glue/examples/echo-provider     ...
ok  github.com/erain/glue/examples/local-agent       ...
ok  github.com/erain/glue/loop                       ...
ok  github.com/erain/glue/prompts                    ...
ok  github.com/erain/glue/providers                  ...
ok  github.com/erain/glue/providers/codex            2.021s
ok  github.com/erain/glue/providers/codex/auth       ...
ok  github.com/erain/glue/providers/gemini           ...
ok  github.com/erain/glue/providers/nvidia           ...
ok  github.com/erain/glue/providers/openaicompat     ...
ok  github.com/erain/glue/providers/openrouter       ...
ok  github.com/erain/glue/stores/file                ...
ok  github.com/erain/glue/tools/fs                   ...
ok  github.com/erain/glue/tools/git                  ...

$ go test -race ./providers/codex -count=1
ok  github.com/erain/glue/providers/codex  3.038s
```

14 new tests in `providers/codex` (race-clean):

- **convert_test.go** — user/assistant text, function-call round-trip via `call_id`, tool-result-without-call-id error, image-content refusal, empty-user-text drop, tool-only assistant.
- **sse_test.go** — basic framing, comment + blank-prefix skip, multi-line data, trailing event flush.
- **codex_test.go** — happy-path HTTP integration (asserts every required header + request body shape), tool-call HTTP integration, stream-closed-before-completed surfaces an error, `response.failed` surfaces with message, 401 → refresh → 200 retry with rotated tokens, 5xx surfaces, missing auth.json surfaces, context cancel closes the event channel promptly, registry lookup, uuidv4 format.

Plus a gated live smoke (`GLUE_CODEX_LIVE=1`) for manual verification against the real endpoint.

README gained a "Quickstart: Codex (ChatGPT subscription)" section after the Gemini quickstart. `docs/provider-guide.md` subscription-auth section now points to `providers/codex` as the concrete reference implementation.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean
- [x] `go test -race ./providers/codex` clean
- [x] No `fmt.Print` / `log.` of tokens in non-test code
- [x] No third-party deps added (`go.mod` unchanged)
- [x] Provider self-registers under name `codex` with `DefaultModel = "gpt-5-codex"`