### PR TITLE
glue: SummarizingCompactor — token-aware provider-summarized compactor (closes #120)

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -2,8 +2,10 @@ package glue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Compactor rewrites a session transcript before it is sent to the
@@ -51,6 +53,322 @@ func KeepRecentMessages(n int) Compactor {
 		out = append(out, messages[dropped:]...)
 		return out, nil
 	})
+}
+
+// DefaultSummarizingSystemPrompt is the instruction the
+// [SummarizingCompactor] sends to the provider when no override is
+// configured. The prompt biases for fact retention over polish.
+const DefaultSummarizingSystemPrompt = `You are summarizing a conversation transcript so it can be replaced with a single compact summary message.
+
+Preserve, in order of importance:
+- facts the user stated (names, dates, numbers, IDs, places)
+- decisions made and their reasons
+- outcomes of any actions taken
+- open questions or pending follow-ups
+- the user's stated preferences
+
+Drop:
+- pleasantries
+- failed tangents
+- verbatim quotes you can paraphrase
+
+Write a single coherent narrative in third person ("the user…", "the assistant…"). Do not invent details. Do not include meta-commentary about summarization.`
+
+// SummarizingCompactor is a token-aware [Compactor] that summarizes
+// older transcript messages by calling the configured Provider. It
+// replaces older messages with a single assistant-role marker whose
+// text content is the summary and whose metadata records the
+// compaction.
+//
+// SummarizingCompactor is the token-aware drop-in anticipated by
+// ADR-0002 and designed in ADR-0007 §1. It composes with — and does
+// not replace — [KeepRecentMessages]; callers pick the policy that
+// matches their agent's lifetime.
+//
+// Provider must be set. The compactor calls Provider.Stream once per
+// invocation with a single user message containing the formatted
+// transcript-to-summarize.
+//
+// Token estimation is intentionally a heuristic in v0.1: a
+// word-count-based proxy that does not need to match any specific
+// tokenizer. A later PR can swap the implementation without changing
+// this type's public surface.
+//
+// Errors from the underlying provider propagate. The compactor does
+// not silently fall back to dropping context; callers that want a
+// degraded-mode behavior should wire a [CompactorFunc] that tries
+// SummarizingCompactor first and falls back to [KeepRecentMessages]
+// explicitly.
+type SummarizingCompactor struct {
+	// Provider streams the summary. Required.
+	Provider Provider
+
+	// Model is the model id used for the summary call. When empty the
+	// provider's default applies.
+	Model string
+
+	// TargetTokens is the soft cap: when the estimated transcript size
+	// is below this value the compactor returns its input unchanged.
+	// Zero or negative falls back to the default (8000).
+	TargetTokens int
+
+	// KeepRecent is the number of most-recent messages retained
+	// verbatim. Zero or negative falls back to the default (8). When
+	// the input transcript has KeepRecent or fewer messages the
+	// compactor returns it unchanged regardless of TargetTokens.
+	KeepRecent int
+
+	// SystemPrompt is the instruction sent to the summarizer. When
+	// empty [DefaultSummarizingSystemPrompt] is used.
+	SystemPrompt string
+}
+
+// Default knobs for SummarizingCompactor. Documented as constants so
+// callers can reason about behavior without reading the source.
+const (
+	defaultSummarizingTargetTokens = 8000
+	defaultSummarizingKeepRecent   = 8
+)
+
+// Compact implements [Compactor]. See the type docs for behavior.
+func (s *SummarizingCompactor) Compact(ctx context.Context, in []Message) ([]Message, error) {
+	if s == nil {
+		return nil, errors.New("glue: SummarizingCompactor: nil receiver")
+	}
+	if s.Provider == nil {
+		return nil, errors.New("glue: SummarizingCompactor: Provider is required")
+	}
+	keep := s.KeepRecent
+	if keep <= 0 {
+		keep = defaultSummarizingKeepRecent
+	}
+	target := s.TargetTokens
+	if target <= 0 {
+		target = defaultSummarizingTargetTokens
+	}
+
+	if len(in) <= keep {
+		return in, nil
+	}
+	if estimateTokens(in) <= target {
+		return in, nil
+	}
+
+	older := in[:len(in)-keep]
+	kept := in[len(in)-keep:]
+
+	systemPrompt := s.SystemPrompt
+	if systemPrompt == "" {
+		systemPrompt = DefaultSummarizingSystemPrompt
+	}
+
+	transcript := renderTranscriptForSummary(older)
+	summaryReq := ProviderRequest{
+		Model:        s.Model,
+		SystemPrompt: systemPrompt,
+		Messages: []Message{{
+			Role:    MessageRoleUser,
+			Content: []ContentPart{{Type: ContentTypeText, Text: transcript}},
+		}},
+	}
+
+	stream, err := s.Provider.Stream(ctx, summaryReq)
+	if err != nil {
+		return nil, fmt.Errorf("glue: SummarizingCompactor: provider.Stream: %w", err)
+	}
+
+	summary, streamErr := collectSummaryText(ctx, stream)
+	if streamErr != nil {
+		return nil, fmt.Errorf("glue: SummarizingCompactor: %w", streamErr)
+	}
+	if strings.TrimSpace(summary) == "" {
+		return nil, errors.New("glue: SummarizingCompactor: provider returned no text")
+	}
+
+	marker := Message{
+		Role:    MessageRoleAssistant,
+		Content: []ContentPart{{Type: ContentTypeText, Text: summary}},
+		Metadata: map[string]any{
+			"compaction":             "summarizing",
+			"original_message_count": len(older),
+		},
+	}
+	if first, last := transcriptTimeBounds(older); !first.IsZero() {
+		marker.Metadata["original_first_ts"] = first.UTC().Format(time.RFC3339)
+		marker.Metadata["original_last_ts"] = last.UTC().Format(time.RFC3339)
+	}
+
+	out := make([]Message, 0, 1+len(kept))
+	out = append(out, marker)
+	out = append(out, kept...)
+	return out, nil
+}
+
+// renderTranscriptForSummary formats older messages into a single
+// plain-text block for the summarizer. Roles are tagged so the
+// provider sees the alternation; tool calls and results are rendered
+// as parenthetical notes rather than dropped, so the summary can
+// reference them.
+func renderTranscriptForSummary(msgs []Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		tag := "user"
+		switch m.Role {
+		case MessageRoleAssistant:
+			tag = "assistant"
+		case MessageRoleTool:
+			tag = "tool"
+		}
+		b.WriteString(strings.ToUpper(tag))
+		b.WriteString(": ")
+		first := true
+		for _, p := range m.Content {
+			switch p.Type {
+			case ContentTypeText:
+				if !first {
+					b.WriteString(" ")
+				}
+				b.WriteString(p.Text)
+				first = false
+			case ContentTypeToolCall:
+				if p.ToolCall == nil {
+					continue
+				}
+				if !first {
+					b.WriteString(" ")
+				}
+				fmt.Fprintf(&b, "[tool_call name=%s args=%s]", p.ToolCall.Name, string(p.ToolCall.Arguments))
+				first = false
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// collectSummaryText drains a provider stream into a single string,
+// preferring the final ProviderEventDone message's text content. The
+// fallback to text-delta accumulation matches providers that omit a
+// final message (none of the shipped providers do, but it keeps the
+// compactor robust against fake providers in tests).
+func collectSummaryText(ctx context.Context, stream <-chan ProviderEvent) (string, error) {
+	var (
+		deltas   strings.Builder
+		finalMsg *Message
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case ev, ok := <-stream:
+			if !ok {
+				if finalMsg != nil {
+					if text := assistantMessageText(finalMsg); text != "" {
+						return text, nil
+					}
+				}
+				return deltas.String(), nil
+			}
+			switch ev.Type {
+			case ProviderEventTextDelta:
+				deltas.WriteString(ev.Delta)
+			case ProviderEventDone:
+				finalMsg = ev.Message
+			case ProviderEventError:
+				if ev.Error != "" {
+					return "", errors.New(ev.Error)
+				}
+				return "", errors.New("provider stream errored")
+			}
+		}
+	}
+}
+
+func assistantMessageText(m *Message) string {
+	if m == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range m.Content {
+		if p.Type == ContentTypeText && p.Text != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+// transcriptTimeBounds returns the earliest and latest CreatedAt of
+// the messages, or the zero time if none carry a timestamp.
+func transcriptTimeBounds(msgs []Message) (first, last time.Time) {
+	for _, m := range msgs {
+		if m.CreatedAt.IsZero() {
+			continue
+		}
+		if first.IsZero() || m.CreatedAt.Before(first) {
+			first = m.CreatedAt
+		}
+		if last.IsZero() || m.CreatedAt.After(last) {
+			last = m.CreatedAt
+		}
+	}
+	return first, last
+}
+
+// estimateTokens returns a heuristic token count for a transcript.
+// Uses words × 0.75, a widely-cited English approximation. This is
+// intentionally cheap and provider-agnostic; a real tokenizer can
+// drop in later without changing the public SummarizingCompactor
+// surface.
+func estimateTokens(msgs []Message) int {
+	words := 0
+	for _, m := range msgs {
+		for _, p := range m.Content {
+			switch p.Type {
+			case ContentTypeText:
+				words += countWords(p.Text)
+			case ContentTypeThinking:
+				words += countWords(p.Thinking)
+			case ContentTypeToolCall:
+				if p.ToolCall != nil {
+					words += countWords(p.ToolCall.Name)
+					words += countWords(string(p.ToolCall.Arguments))
+				}
+			}
+		}
+	}
+	if words == 0 {
+		return 0
+	}
+	// 0.75 tokens per word; round up so a 1-word transcript still
+	// scores ≥1 token.
+	tokens := (words*3 + 3) / 4
+	if tokens < 1 {
+		tokens = 1
+	}
+	return tokens
+}
+
+// countWords returns the number of whitespace-separated runs in s.
+// Conservative: treats any whitespace as a separator and ignores
+// empty trailing tokens.
+func countWords(s string) int {
+	n := 0
+	inWord := false
+	for _, r := range s {
+		switch r {
+		case ' ', '\t', '\n', '\r', '\v', '\f':
+			inWord = false
+		default:
+			if !inWord {
+				n++
+				inWord = true
+			}
+		}
+	}
+	return n
 }
 
 // buildCompactionSummary produces a short, role-assistant note describing

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func textMessage(role MessageRole, body string) Message {
@@ -217,5 +218,349 @@ func TestSessionCompactionPersistsViaStore(t *testing.T) {
 	}
 	if state.Messages[0].Metadata["compaction"] != "keep_recent" {
 		t.Fatalf("persisted summary metadata = %v, want compaction=keep_recent", state.Messages[0].Metadata)
+	}
+}
+
+// ---- SummarizingCompactor ----
+
+// summarizingProvider is a fake Provider tailored to the
+// SummarizingCompactor's call pattern. It records every received
+// ProviderRequest and emits a configurable summary text on Done.
+type summarizingProvider struct {
+	summary  string
+	requests []ProviderRequest
+	calls    int
+	failWith error
+	// Block holds the goroutine until released; used to test ctx cancel.
+	Block chan struct{}
+}
+
+func (p *summarizingProvider) Stream(ctx context.Context, req ProviderRequest) (<-chan ProviderEvent, error) {
+	p.requests = append(p.requests, req)
+	p.calls++
+	if p.failWith != nil {
+		return nil, p.failWith
+	}
+	ch := make(chan ProviderEvent, 4)
+	go func() {
+		defer close(ch)
+		ch <- ProviderEvent{Type: ProviderEventStart}
+		if p.Block != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case <-p.Block:
+			}
+		}
+		ch <- ProviderEvent{Type: ProviderEventDone, Message: &Message{
+			Role:    MessageRoleAssistant,
+			Content: []ContentPart{{Type: ContentTypeText, Text: p.summary}},
+		}}
+	}()
+	return ch, nil
+}
+
+func TestSummarizingCompactor_BelowBudgetPassThrough(t *testing.T) {
+	t.Parallel()
+	p := &summarizingProvider{summary: "should not be called"}
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1_000_000, KeepRecent: 2}
+	in := []Message{
+		textMessage(MessageRoleUser, "u1"),
+		textMessage(MessageRoleAssistant, "a1"),
+		textMessage(MessageRoleUser, "u2"),
+		textMessage(MessageRoleAssistant, "a2"),
+		textMessage(MessageRoleUser, "u3"),
+	}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("len(out) = %d, want %d (unchanged below budget)", len(out), len(in))
+	}
+	if p.calls != 0 {
+		t.Fatalf("provider called %d times; expected 0 when below budget", p.calls)
+	}
+}
+
+func TestSummarizingCompactor_BelowKeepRecentPassThrough(t *testing.T) {
+	t.Parallel()
+	p := &summarizingProvider{summary: "x"}
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 3}
+	in := []Message{textMessage(MessageRoleUser, "u1"), textMessage(MessageRoleAssistant, "a1")}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("len(out) = %d, want %d (input ≤ KeepRecent)", len(out), len(in))
+	}
+	if p.calls != 0 {
+		t.Fatalf("provider called %d times; expected 0 below KeepRecent", p.calls)
+	}
+}
+
+func TestSummarizingCompactor_BoundaryEqualsKeepRecentPassThrough(t *testing.T) {
+	t.Parallel()
+	// Exactly KeepRecent messages — should pass through even if over budget.
+	p := &summarizingProvider{summary: "x"}
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 3}
+	in := []Message{
+		textMessage(MessageRoleUser, "u1"),
+		textMessage(MessageRoleAssistant, "a1"),
+		textMessage(MessageRoleUser, "u2"),
+	}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("len(out) = %d, want %d (boundary == KeepRecent)", len(out), len(in))
+	}
+	if p.calls != 0 {
+		t.Fatalf("provider called %d times; expected 0 at boundary", p.calls)
+	}
+}
+
+func TestSummarizingCompactor_OverBudgetPartitionAndMarker(t *testing.T) {
+	t.Parallel()
+	summary := "Earlier the user introduced themselves as Yu and asked about Australian Shepherds. The assistant explained shedding."
+	p := &summarizingProvider{summary: summary}
+	c := &SummarizingCompactor{
+		Provider:     p,
+		TargetTokens: 1, // trip over budget on any non-trivial input
+		KeepRecent:   2,
+	}
+	in := []Message{
+		textMessage(MessageRoleUser, "hi I am Yu"),
+		textMessage(MessageRoleAssistant, "hello Yu"),
+		textMessage(MessageRoleUser, "tell me about Aussies"),
+		textMessage(MessageRoleAssistant, "they shed a lot"),
+		textMessage(MessageRoleUser, "what about exercise"),
+		textMessage(MessageRoleAssistant, "lots needed"),
+	}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3 (marker + last 2)", len(out))
+	}
+	marker := out[0]
+	if marker.Role != MessageRoleAssistant {
+		t.Fatalf("marker role = %s", marker.Role)
+	}
+	if len(marker.Content) == 0 || marker.Content[0].Text != summary {
+		t.Fatalf("marker text = %q, want summary", marker.Content[0].Text)
+	}
+	if marker.Metadata["compaction"] != "summarizing" {
+		t.Fatalf("marker metadata.compaction = %v", marker.Metadata["compaction"])
+	}
+	if marker.Metadata["original_message_count"] != 4 {
+		t.Fatalf("original_message_count = %v, want 4", marker.Metadata["original_message_count"])
+	}
+	if _, hasFirst := marker.Metadata["original_first_ts"]; hasFirst {
+		t.Errorf("first_ts should be absent when messages have no CreatedAt; got %v", marker.Metadata["original_first_ts"])
+	}
+	// Kept tail = last 2 originals.
+	if out[1].Content[0].Text != "what about exercise" {
+		t.Errorf("kept[0] = %q", out[1].Content[0].Text)
+	}
+	if out[2].Content[0].Text != "lots needed" {
+		t.Errorf("kept[1] = %q", out[2].Content[0].Text)
+	}
+	// Provider was called once with the older 4 messages rendered into
+	// the user prompt.
+	if p.calls != 1 {
+		t.Fatalf("provider calls = %d", p.calls)
+	}
+	req := p.requests[0]
+	if req.SystemPrompt == "" {
+		t.Errorf("expected SummarizingCompactor system prompt")
+	}
+	if len(req.Messages) != 1 || req.Messages[0].Role != MessageRoleUser {
+		t.Fatalf("provider request shape: %+v", req.Messages)
+	}
+	body := req.Messages[0].Content[0].Text
+	for _, want := range []string{"USER:", "ASSISTANT:", "hi I am Yu", "they shed"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered transcript missing %q\n--\n%s", want, body)
+		}
+	}
+}
+
+func TestSummarizingCompactor_TimestampMetadata(t *testing.T) {
+	t.Parallel()
+	t1 := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	t2 := t1.Add(time.Hour)
+	in := []Message{
+		{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "early"}}, CreatedAt: t2},
+		{Role: MessageRoleAssistant, Content: []ContentPart{{Type: ContentTypeText, Text: "mid"}}, CreatedAt: t1},
+		{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "u2"}}},
+		{Role: MessageRoleAssistant, Content: []ContentPart{{Type: ContentTypeText, Text: "a2"}}},
+	}
+	p := &summarizingProvider{summary: "s"}
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 2}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	first := out[0].Metadata["original_first_ts"]
+	last := out[0].Metadata["original_last_ts"]
+	if first != t1.Format(time.RFC3339) {
+		t.Errorf("first_ts = %v, want %s (earliest)", first, t1.Format(time.RFC3339))
+	}
+	if last != t2.Format(time.RFC3339) {
+		t.Errorf("last_ts = %v, want %s (latest)", last, t2.Format(time.RFC3339))
+	}
+}
+
+func TestSummarizingCompactor_ProviderStreamErrorPropagates(t *testing.T) {
+	t.Parallel()
+	p := &summarizingProvider{summary: "x", failWith: errors.New("upstream down")}
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 1}
+	_, err := c.Compact(context.Background(), []Message{
+		textMessage(MessageRoleUser, "older"),
+		textMessage(MessageRoleAssistant, "older2"),
+		textMessage(MessageRoleUser, "kept"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "upstream down") {
+		t.Fatalf("err = %v, want upstream down propagated", err)
+	}
+}
+
+func TestSummarizingCompactor_ProviderEventErrorPropagates(t *testing.T) {
+	t.Parallel()
+	provider := &erroringProvider{errMsg: "model refused"}
+	c := &SummarizingCompactor{Provider: provider, TargetTokens: 1, KeepRecent: 1}
+	_, err := c.Compact(context.Background(), []Message{
+		textMessage(MessageRoleUser, "older"),
+		textMessage(MessageRoleAssistant, "older2"),
+		textMessage(MessageRoleUser, "kept"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "model refused") {
+		t.Fatalf("err = %v, want model refused propagated", err)
+	}
+}
+
+type erroringProvider struct{ errMsg string }
+
+func (p *erroringProvider) Stream(_ context.Context, _ ProviderRequest) (<-chan ProviderEvent, error) {
+	ch := make(chan ProviderEvent, 2)
+	ch <- ProviderEvent{Type: ProviderEventStart}
+	ch <- ProviderEvent{Type: ProviderEventError, Error: p.errMsg}
+	close(ch)
+	return ch, nil
+}
+
+func TestSummarizingCompactor_NoSilentFallbackOnEmptySummary(t *testing.T) {
+	t.Parallel()
+	p := &summarizingProvider{summary: "   "} // whitespace only
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 1}
+	_, err := c.Compact(context.Background(), []Message{
+		textMessage(MessageRoleUser, "older"),
+		textMessage(MessageRoleAssistant, "older2"),
+		textMessage(MessageRoleUser, "kept"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "no text") {
+		t.Fatalf("err = %v, want no-text error", err)
+	}
+}
+
+func TestSummarizingCompactor_NilProviderErrors(t *testing.T) {
+	t.Parallel()
+	c := &SummarizingCompactor{TargetTokens: 1, KeepRecent: 1}
+	_, err := c.Compact(context.Background(), []Message{
+		textMessage(MessageRoleUser, "older"),
+		textMessage(MessageRoleAssistant, "older2"),
+		textMessage(MessageRoleUser, "kept"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "Provider is required") {
+		t.Fatalf("err = %v, want Provider required", err)
+	}
+}
+
+func TestSummarizingCompactor_DefaultKnobs(t *testing.T) {
+	t.Parallel()
+	// Zero TargetTokens and KeepRecent fall back to defaults; we exercise
+	// that path by passing a tiny transcript that fits below either knob.
+	p := &summarizingProvider{summary: "x"}
+	c := &SummarizingCompactor{Provider: p}
+	in := []Message{textMessage(MessageRoleUser, "hi"), textMessage(MessageRoleAssistant, "hello")}
+	out, err := c.Compact(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("default knobs should pass through small transcript; got %d", len(out))
+	}
+	if p.calls != 0 {
+		t.Fatalf("provider unexpectedly called: %d", p.calls)
+	}
+}
+
+func TestSummarizingCompactor_RendersToolCallsInTranscript(t *testing.T) {
+	t.Parallel()
+	args := []byte(`{"q":"NYC"}`)
+	in := []Message{
+		textMessage(MessageRoleUser, "weather please"),
+		{Role: MessageRoleAssistant, Content: []ContentPart{
+			{Type: ContentTypeText, Text: "checking"},
+			{Type: ContentTypeToolCall, ToolCall: &ToolCall{ID: "c1", Name: "weather", Arguments: args}},
+		}},
+		{Role: MessageRoleTool, ToolCallID: "c1", Content: []ContentPart{{Type: ContentTypeText, Text: "sunny"}}},
+		textMessage(MessageRoleUser, "thanks"),
+		textMessage(MessageRoleAssistant, "you're welcome"),
+		textMessage(MessageRoleUser, "newest"),
+	}
+	p := &summarizingProvider{summary: "summary"}
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 2}
+	if _, err := c.Compact(context.Background(), in); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	body := p.requests[0].Messages[0].Content[0].Text
+	for _, want := range []string{"[tool_call name=weather", `args={"q":"NYC"}`, "TOOL:", "sunny"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("transcript missing %q\n--\n%s", want, body)
+		}
+	}
+}
+
+func TestSummarizingCompactor_ContextCancelAbortsStream(t *testing.T) {
+	t.Parallel()
+	p := &summarizingProvider{summary: "ignored", Block: make(chan struct{})}
+	defer close(p.Block) // release the goroutine on test exit
+	c := &SummarizingCompactor{Provider: p, TargetTokens: 1, KeepRecent: 1}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.Compact(ctx, []Message{
+			textMessage(MessageRoleUser, "older"),
+			textMessage(MessageRoleAssistant, "older2"),
+			textMessage(MessageRoleUser, "kept"),
+		})
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Compact did not return after ctx cancel")
+	}
+}
+
+func TestEstimateTokens_HeuristicScales(t *testing.T) {
+	t.Parallel()
+	small := estimateTokens([]Message{textMessage(MessageRoleUser, "one two three four")})
+	big := estimateTokens([]Message{textMessage(MessageRoleUser, strings.Repeat("word ", 1000))})
+	if small <= 0 || big <= small {
+		t.Fatalf("expected big > small > 0; got small=%d big=%d", small, big)
+	}
+	// 4 words ≈ 3 tokens.
+	if small < 2 || small > 4 {
+		t.Errorf("small estimate = %d, want around 3", small)
 	}
 }


### PR DESCRIPTION
## Summary

Lands the token-aware `Compactor` that ADR-0002 anticipated as a drop-in and ADR-0007 §1 designed. Composes with the existing `Compactor` interface; `KeepRecentMessages` stays as the cheap default for short-lived agents.

**Public surface** (added to `glue/compactor.go`):

```go
type SummarizingCompactor struct {
    Provider     Provider // required
    Model        string   // optional override
    TargetTokens int      // default 8000
    KeepRecent   int      // default 8
    SystemPrompt string   // default DefaultSummarizingSystemPrompt
}

func (s *SummarizingCompactor) Compact(ctx context.Context, in []Message) ([]Message, error)

const DefaultSummarizingSystemPrompt = `...`
```

**Behavior** (per ADR-0007 §1): below-threshold pass-through; over-threshold partitions into `older / kept = in[:N-keep] / in[N-keep:]`, renders `older` into a `USER:` / `ASSISTANT:` / `TOOL:` tagged transcript (including `tool_call` args), calls `Provider.Stream` with a single user message and a fact-retention-biased system prompt, then replaces `older` with one assistant marker whose text is the summary and whose metadata carries `compaction=summarizing`, `original_message_count`, and `original_first_ts` / `original_last_ts` when timestamps are available.

**Token estimation** is a private `estimateTokens` using words×0.75 — replaceable without changing the public surface.

**No silent fallback** to dropping context: provider construction errors, `ProviderEventError`, whitespace-only summaries, and ctx cancellation all propagate. Callers wire `KeepRecentMessages` as a fallback explicitly if they want degraded behavior.

Closes #120. Tracker: #110.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
$ go test -race -count=1 -run "Summarizing|EstimateTokens|KeepRecentMessages"
ok  github.com/erain/glue  1.033s
```

12 new tests covering every scenario in the issue spec §3:

- `TestSummarizingCompactor_BelowBudgetPassThrough` — no provider call
- `TestSummarizingCompactor_BelowKeepRecentPassThrough`
- `TestSummarizingCompactor_BoundaryEqualsKeepRecentPassThrough` — exactly `KeepRecent` passes through even over budget
- `TestSummarizingCompactor_OverBudgetPartitionAndMarker` — asserts marker metadata, kept tail, and the provider request shape (system prompt, single user message, transcript tagged)
- `TestSummarizingCompactor_TimestampMetadata` — `original_first_ts` / `_last_ts` use earliest/latest `CreatedAt` regardless of order
- `TestSummarizingCompactor_ProviderStreamErrorPropagates`
- `TestSummarizingCompactor_ProviderEventErrorPropagates`
- `TestSummarizingCompactor_NoSilentFallbackOnEmptySummary` — whitespace-only summary → error, not silent drop
- `TestSummarizingCompactor_NilProviderErrors`
- `TestSummarizingCompactor_DefaultKnobs` — zero values fall back to defaults
- `TestSummarizingCompactor_RendersToolCallsInTranscript` — tool calls and tool results both appear in the summarizer's input
- `TestSummarizingCompactor_ContextCancelAbortsStream` — returns `context.Canceled` and unblocks promptly
- `TestEstimateTokens_HeuristicScales`

No new dependencies. `docs/design.md` already lists `SummarizingCompactor` (added in PR #119); no further docs edits required.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` clean
- [x] `go test -race ./glue/compactor*` clean
- [x] All 12 new tests pass
- [x] Implements `Compactor` interface (existing `errorCompactor` style assertion plus direct use)
- [x] No silent fallback paths added