### PR TITLE
agents/peggy: remember + recall tools on a dedicated session (closes #131)

### DIFF
--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -115,11 +115,49 @@ An explicit `--config` / `--soul` or `$PEGGY_CONFIG` / `$PEGGY_SOUL`
 that points at a missing file is an error. The XDG / HOME fallbacks
 quietly fall through to defaults when missing.
 
+## Memory
+
+Peggy ships two **model-callable** tools that let the model decide
+when to persist and when to look up across sessions:
+
+- `remember(content, tags?)` — append a curated fact to the
+  `__memories__` session. Phrase content in third person ("the user
+  prefers …"). Tags are optional. The model is told (via the system
+  prompt) to use this sparingly — for facts worth keeping across many
+  future conversations, not one-off context.
+- `recall(query, limit?, only_memories?)` — search prior history and
+  curated memories via FTS5. Default returns up to 5 hits across all
+  sessions; pass `only_memories: true` to restrict to the curated
+  list. Requires a `Searcher`-capable store (`stores/sqlite`); the
+  `file` store surfaces a clear "use sqlite" error.
+
+The model invokes these on its own as the conversation requires. The
+tools are registered by default; disable them via
+`Options.DisableMemoryTools` (library) — there's no CLI flag in v0.1.
+
+A short hint paragraph is appended to your `SOUL.md` content in the
+system prompt so the model knows the tools exist; override via
+`Options.MemoryHint` if you want different phrasing.
+
+Inspecting memories programmatically:
+
+```go
+mems, _ := p.ListMemories(ctx) // newest-first
+for _, m := range mems {
+    fmt.Printf("[%s] %s  (tags=%v)\n",
+        m.Timestamp.Format(time.RFC3339), m.Content, m.Tags)
+}
+```
+
+A `peggy memories` subcommand for list / forget / export is a
+near-term follow-up.
+
 ## What v0.1 supports
 
 - Single-prompt CLI with file or sqlite session persistence.
+- **Model-callable `remember` and `recall` tools** for cross-session memory.
 - Cross-session FTS5 search via `Agent.SearchSessions` (library API
-  only in v0.1; a `peggy recall` subcommand is a near-term follow-up).
+  available directly; CLI subcommand is a near-term follow-up).
 - Token-aware summarizing compaction via the provider you configured.
 - Identity injected from `SOUL.md` into the system prompt.
 - All four shipped providers: `codex` (ChatGPT subscription), `gemini`,

--- a/agents/peggy/memory.go
+++ b/agents/peggy/memory.go
@@ -1,0 +1,294 @@
+package peggy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+// MemoriesSessionID is the session id under which Peggy persists
+// curated memories — facts the model decided are worth keeping. The
+// session is searchable through the same FTS5 index as everything
+// else, but isolating it under this id gives Recall an easy way to
+// scope, and protects memories from the SummarizingCompactor (which
+// only runs on whatever session is being prompted).
+const MemoriesSessionID = "__memories__"
+
+// DefaultMemoryHint is appended to the system prompt when memory
+// tools are registered, so the model knows the surface exists. Short
+// on purpose — heavy instructions belong in SOUL.md.
+const DefaultMemoryHint = `
+You have two tools for durable memory:
+
+- remember(content, tags?) — call this when the user shares a fact
+  worth keeping across sessions (their name, a preference, a pet, a
+  project name, etc). Phrase the content as a self-contained
+  statement in third person ("the user prefers …"). Do not over-call;
+  small-talk and one-off context are not memories.
+
+- recall(query, limit?, only_memories?) — call this when answering a
+  question that benefits from prior context you don't have in this
+  session. Hits include the source session id and a snippet; cite
+  them naturally in your answer when relevant.
+`
+
+// Memory is a single curated memory record.
+type Memory struct {
+	Content   string    `json:"content"`
+	Tags      []string  `json:"tags,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// RecallOptions configures a Recall call.
+type RecallOptions struct {
+	Limit         int
+	OnlyMemories  bool
+}
+
+// RecallOption is a functional option for Peggy.Recall.
+type RecallOption func(*RecallOptions)
+
+// WithRecallLimit overrides the default limit (5).
+func WithRecallLimit(n int) RecallOption {
+	return func(o *RecallOptions) { o.Limit = n }
+}
+
+// WithMemoriesOnly restricts Recall to the dedicated __memories__
+// session — useful when the model wants curated facts rather than
+// the full conversational history.
+func WithMemoriesOnly() RecallOption {
+	return func(o *RecallOptions) { o.OnlyMemories = true }
+}
+
+const (
+	defaultRecallLimit = 5
+	maxRecallLimit     = 20
+)
+
+var memoryWriteMu sync.Mutex
+
+// AddMemory appends a curated memory to the __memories__ session.
+//
+// Implementation note: we drive the underlying Store directly rather
+// than going through agent.Session(__memories__).Prompt — that route
+// would register an in-memory *Session in the agent map and conflict
+// with any concurrent ordinary prompt traffic. The Store's atomic
+// write semantics are sufficient (sqlite serializes via
+// MaxOpenConns=1; file does temp+rename).
+func (p *Peggy) AddMemory(ctx context.Context, content string, tags []string) (Memory, error) {
+	if p == nil || p.store == nil {
+		return Memory{}, errors.New("peggy: AddMemory: not initialised")
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return Memory{}, errors.New("peggy: AddMemory: content is required")
+	}
+	memoryWriteMu.Lock()
+	defer memoryWriteMu.Unlock()
+
+	state, _, err := p.store.Load(ctx, MemoriesSessionID)
+	if err != nil {
+		return Memory{}, fmt.Errorf("peggy: load memories: %w", err)
+	}
+	now := time.Now().UTC()
+	if state.ID == "" {
+		state.ID = MemoriesSessionID
+		state.Version = glue.SessionStateVersion
+		state.CreatedAt = now
+	}
+	tagsCopy := append([]string(nil), tags...)
+	state.Messages = append(state.Messages, glue.Message{
+		Role:    glue.MessageRoleAssistant,
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: content}},
+		Metadata: map[string]any{
+			"memory": true,
+			"tags":   tagsCopy,
+		},
+		CreatedAt: now,
+	})
+	state.UpdatedAt = now
+	if err := p.store.Save(ctx, MemoriesSessionID, state); err != nil {
+		return Memory{}, fmt.Errorf("peggy: save memories: %w", err)
+	}
+	return Memory{Content: content, Tags: tagsCopy, Timestamp: now}, nil
+}
+
+// ListMemories returns the curated memory list, newest first. Useful
+// for debugging, tests, and a future `peggy memories` subcommand.
+func (p *Peggy) ListMemories(ctx context.Context) ([]Memory, error) {
+	if p == nil || p.store == nil {
+		return nil, errors.New("peggy: ListMemories: not initialised")
+	}
+	state, _, err := p.store.Load(ctx, MemoriesSessionID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Memory, 0, len(state.Messages))
+	for _, m := range state.Messages {
+		if m.Role != glue.MessageRoleAssistant {
+			continue
+		}
+		mem := Memory{Timestamp: m.CreatedAt}
+		for _, p := range m.Content {
+			if p.Type == glue.ContentTypeText {
+				if mem.Content != "" {
+					mem.Content += "\n"
+				}
+				mem.Content += p.Text
+			}
+		}
+		if mem.Content == "" {
+			continue
+		}
+		if tags, ok := m.Metadata["tags"].([]string); ok {
+			mem.Tags = append([]string(nil), tags...)
+		} else if anyTags, ok := m.Metadata["tags"].([]any); ok {
+			for _, t := range anyTags {
+				if s, ok := t.(string); ok {
+					mem.Tags = append(mem.Tags, s)
+				}
+			}
+		}
+		out = append(out, mem)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Timestamp.After(out[j].Timestamp)
+	})
+	return out, nil
+}
+
+// Recall searches Peggy's history (everything by default; restrict
+// to curated memories with WithMemoriesOnly()).
+func (p *Peggy) Recall(ctx context.Context, query string, opts ...RecallOption) ([]glue.SearchHit, error) {
+	if p == nil || p.agent == nil {
+		return nil, errors.New("peggy: Recall: not initialised")
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, errors.New("peggy: Recall: query is required")
+	}
+	o := RecallOptions{Limit: defaultRecallLimit}
+	for _, fn := range opts {
+		if fn != nil {
+			fn(&o)
+		}
+	}
+	if o.Limit <= 0 {
+		o.Limit = defaultRecallLimit
+	}
+	if o.Limit > maxRecallLimit {
+		o.Limit = maxRecallLimit
+	}
+	gluOpts := []glue.SearchOption{glue.WithLimit(o.Limit)}
+	if o.OnlyMemories {
+		gluOpts = append(gluOpts, glue.WithSessionID(MemoriesSessionID))
+	}
+	return p.agent.SearchSessions(ctx, query, gluOpts...)
+}
+
+// rememberArgs is the argument schema for the remember tool.
+type rememberArgs struct {
+	Content string   `json:"content"`
+	Tags    []string `json:"tags,omitempty"`
+}
+
+// recallArgs is the argument schema for the recall tool.
+type recallArgs struct {
+	Query        string `json:"query"`
+	Limit        int    `json:"limit,omitempty"`
+	OnlyMemories bool   `json:"only_memories,omitempty"`
+}
+
+// RememberTool returns a glue.Tool the model can call to persist a
+// fact. Closes over the supplied *Peggy.
+func RememberTool(p *Peggy) glue.Tool {
+	return glue.NewTool[rememberArgs](
+		glue.ToolSpec{
+			Name:        "remember",
+			Description: "Persist a single fact about the user to durable cross-session memory. Use sparingly: only when the user shares something worth remembering across many future conversations (name, preferences, people, projects, pets, recurring decisions). Phrase content in third person.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "content": {"type": "string", "description": "The fact, as a one- or two-sentence statement in third person (e.g. 'The user's Australian Shepherd is named Inkblot.')."},
+    "tags": {"type": "array", "items": {"type": "string"}, "description": "Optional categorization tags (e.g. 'pet', 'preference', 'person', 'project'). Helpful for later filtering."}
+  },
+  "required": ["content"]
+}`),
+		},
+		func(ctx context.Context, args rememberArgs) (glue.ToolResult, error) {
+			content := strings.TrimSpace(args.Content)
+			if content == "" {
+				return glue.ErrorResult(errors.New("remember: content is required")), nil
+			}
+			mem, err := p.AddMemory(ctx, content, args.Tags)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return glue.TextResult(fmt.Sprintf("Remembered: %q (tags=%v) at %s", mem.Content, mem.Tags, mem.Timestamp.Format(time.RFC3339))), nil
+		},
+	)
+}
+
+// RecallTool returns a glue.Tool the model can call to search prior
+// context. Closes over the supplied *Peggy.
+func RecallTool(p *Peggy) glue.Tool {
+	return glue.NewTool[recallArgs](
+		glue.ToolSpec{
+			Name:        "recall",
+			Description: "Search prior conversational history and curated memories. Returns up to `limit` snippets with their source session id. Use this when answering questions that depend on facts you don't have in the current turn's context.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "query": {"type": "string", "description": "Search query. FTS5 syntax: bare words match exact words, \"quoted phrases\" match a phrase, AND / OR / NOT combine terms. Keep it short."},
+    "limit": {"type": "integer", "description": "Max snippets to return. Default 5, max 20.", "default": 5},
+    "only_memories": {"type": "boolean", "description": "When true, restrict to the curated memory list (results from explicit remember() calls). Default false (searches everything).", "default": false}
+  },
+  "required": ["query"]
+}`),
+		},
+		func(ctx context.Context, args recallArgs) (glue.ToolResult, error) {
+			query := strings.TrimSpace(args.Query)
+			if query == "" {
+				return glue.ErrorResult(errors.New("recall: query is required")), nil
+			}
+			var opts []RecallOption
+			if args.Limit > 0 {
+				opts = append(opts, WithRecallLimit(args.Limit))
+			}
+			if args.OnlyMemories {
+				opts = append(opts, WithMemoriesOnly())
+			}
+			hits, err := p.Recall(ctx, query, opts...)
+			if err != nil {
+				if errors.Is(err, glue.ErrSearchNotSupported) {
+					return glue.ErrorResult(fmt.Errorf("recall: configured store does not support search; use a sqlite store")), nil
+				}
+				return glue.ErrorResult(err), nil
+			}
+			return glue.TextResult(formatRecallHits(hits)), nil
+		},
+	)
+}
+
+// formatRecallHits renders search hits as a numbered text block the
+// model can read inline. One line per hit, source first then a
+// truncated snippet.
+func formatRecallHits(hits []glue.SearchHit) string {
+	if len(hits) == 0 {
+		return "No hits."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d hits:\n", len(hits))
+	for i, h := range hits {
+		fmt.Fprintf(&b, "%d. [%s#%d %s] (score=%.2f) %s\n",
+			i+1, h.SessionID, h.Index, h.Timestamp.Format("2006-01-02"), h.Score, strings.ReplaceAll(h.Snippet, "\n", " "))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/agents/peggy/memory_test.go
+++ b/agents/peggy/memory_test.go
@@ -1,0 +1,404 @@
+package peggy
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+	filestore "github.com/erain/glue/stores/file"
+	sqlitestore "github.com/erain/glue/stores/sqlite"
+)
+
+func newFileBackedPeggy(t *testing.T) *Peggy {
+	t.Helper()
+	store := filestore.New(filepath.Join(t.TempDir(), "sessions"))
+	p, err := New(Options{
+		Settings: Settings{},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    store,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func newSQLitePeggy(t *testing.T) *Peggy {
+	t.Helper()
+	store, err := sqlitestore.Open(sqlitestore.Options{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	p, err := New(Options{
+		Settings: Settings{},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    store,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func TestAddMemory_RoundTripsThroughStore(t *testing.T) {
+	p := newFileBackedPeggy(t)
+	ctx := context.Background()
+
+	if _, err := p.AddMemory(ctx, "User's Aussie is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := p.AddMemory(ctx, "User prefers terse responses.", []string{"preference"}); err != nil {
+		t.Fatalf("AddMemory 2: %v", err)
+	}
+
+	memories, err := p.ListMemories(ctx)
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(memories) != 2 {
+		t.Fatalf("memories = %d, want 2", len(memories))
+	}
+	// Newest first.
+	if !strings.Contains(memories[0].Content, "terse") {
+		t.Errorf("ListMemories not newest-first: %+v", memories)
+	}
+	if memories[0].Tags == nil || memories[0].Tags[0] != "preference" {
+		t.Errorf("tags missing: %+v", memories[0])
+	}
+}
+
+func TestAddMemory_PersistsAcrossPeggyRebuild(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "sessions")
+
+	first, err := New(Options{
+		Settings: Settings{},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(storePath),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := first.AddMemory(context.Background(), "User's Aussie is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	_ = first.Close()
+
+	second, err := New(Options{
+		Settings: Settings{},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(storePath),
+	})
+	if err != nil {
+		t.Fatalf("New 2: %v", err)
+	}
+	defer second.Close()
+
+	got, err := second.ListMemories(context.Background())
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(got) != 1 || !strings.Contains(got[0].Content, "Inkblot") {
+		t.Fatalf("memories not persisted across rebuild: %+v", got)
+	}
+}
+
+func TestAddMemory_RejectsBlankContent(t *testing.T) {
+	p := newFileBackedPeggy(t)
+	if _, err := p.AddMemory(context.Background(), "   ", nil); err == nil {
+		t.Fatal("expected error for blank content")
+	}
+}
+
+func TestRecall_FindsMemoriesViaFTS(t *testing.T) {
+	p := newSQLitePeggy(t)
+	ctx := context.Background()
+
+	if _, err := p.AddMemory(ctx, "User's Australian Shepherd is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.AddMemory(ctx, "User braises pork shoulder at 275 for several hours.", []string{"cooking"}); err != nil {
+		t.Fatal(err)
+	}
+	hits, err := p.Recall(ctx, "Australian", WithMemoriesOnly())
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected at least one hit")
+	}
+	for _, h := range hits {
+		if h.SessionID != MemoriesSessionID {
+			t.Errorf("hit outside memories session: %+v", h)
+		}
+	}
+}
+
+func TestRecall_AcrossAllSessions(t *testing.T) {
+	p := newSQLitePeggy(t)
+	ctx := context.Background()
+	// Drop a memory and run a prompt against an ordinary session so
+	// the conversation history also gets indexed.
+	if _, err := p.AddMemory(ctx, "User's Australian Shepherd is named Inkblot.", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Prompt(ctx, "casual", "Hello", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Recall without WithMemoriesOnly should reach both sessions.
+	hits, err := p.Recall(ctx, "Australian")
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("expected hits across all sessions")
+	}
+}
+
+func TestRecall_LimitClampedAndDefaulted(t *testing.T) {
+	p := newSQLitePeggy(t)
+	ctx := context.Background()
+	for i := 0; i < 25; i++ {
+		if _, err := p.AddMemory(ctx, "fact about cooking onions and garlic", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Default 5.
+	hits, _ := p.Recall(ctx, "cooking", WithMemoriesOnly())
+	if len(hits) != 5 {
+		t.Errorf("default limit hits = %d, want 5", len(hits))
+	}
+	// Over-cap clamped to maxRecallLimit (20).
+	hits, _ = p.Recall(ctx, "cooking", WithMemoriesOnly(), WithRecallLimit(100))
+	if len(hits) != 20 {
+		t.Errorf("clamped hits = %d, want 20", len(hits))
+	}
+}
+
+func TestRecall_BlankQueryErrors(t *testing.T) {
+	p := newSQLitePeggy(t)
+	if _, err := p.Recall(context.Background(), "  "); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMemoryTools_DefaultRegistration(t *testing.T) {
+	p := newSQLitePeggy(t)
+	tools := p.agent
+	if tools == nil {
+		t.Fatal("agent nil")
+	}
+	// Run a prompt to see what tools the provider gets.
+	fp := &fakeProvider{text: "hi"}
+	// Swap provider by wrapping in a custom recall.
+	pCustom, err := New(Options{
+		Settings: Settings{},
+		Provider: fp,
+		Store:    p.store,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pCustom.Close()
+	if _, err := pCustom.Prompt(context.Background(), "x", "hello", nil); err != nil {
+		t.Fatal(err)
+	}
+	names := make(map[string]bool)
+	for _, t := range fp.requests[0].Tools {
+		names[t.Name] = true
+	}
+	if !names["remember"] || !names["recall"] {
+		t.Errorf("memory tools missing from ProviderRequest.Tools: %+v", fp.requests[0].Tools)
+	}
+}
+
+func TestMemoryTools_DisabledViaOption(t *testing.T) {
+	fp := &fakeProvider{text: "hi"}
+	store, _ := sqlitestore.Open(sqlitestore.Options{Path: ":memory:"})
+	p, err := New(Options{
+		Settings:           Settings{},
+		Provider:           fp,
+		Store:              store,
+		DisableMemoryTools: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if _, err := p.Prompt(context.Background(), "x", "hi", nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range fp.requests[0].Tools {
+		if tool.Name == "remember" || tool.Name == "recall" {
+			t.Errorf("memory tool present despite DisableMemoryTools: %s", tool.Name)
+		}
+	}
+	if strings.Contains(fp.requests[0].SystemPrompt, "remember(") {
+		t.Errorf("memory hint leaked into system prompt despite disable: %q", fp.requests[0].SystemPrompt)
+	}
+}
+
+func TestMemoryHint_ReachesSystemPrompt(t *testing.T) {
+	fp := &fakeProvider{text: "hi"}
+	store, _ := sqlitestore.Open(sqlitestore.Options{Path: ":memory:"})
+	p, err := New(Options{
+		Settings: Settings{},
+		Soul:     "# Identity\nYou are Peggy.",
+		Provider: fp,
+		Store:    store,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if _, err := p.Prompt(context.Background(), "x", "hi", nil); err != nil {
+		t.Fatal(err)
+	}
+	sys := fp.requests[0].SystemPrompt
+	if !strings.Contains(sys, "You are Peggy.") {
+		t.Errorf("SOUL.md content missing: %q", sys)
+	}
+	if !strings.Contains(sys, "remember(") {
+		t.Errorf("memory hint missing: %q", sys)
+	}
+}
+
+func TestMemoryHint_CustomOverride(t *testing.T) {
+	fp := &fakeProvider{text: "hi"}
+	store, _ := sqlitestore.Open(sqlitestore.Options{Path: ":memory:"})
+	p, err := New(Options{
+		Settings:   Settings{},
+		Provider:   fp,
+		Store:      store,
+		MemoryHint: "Custom hint: use them wisely.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if _, err := p.Prompt(context.Background(), "x", "hi", nil); err != nil {
+		t.Fatal(err)
+	}
+	sys := fp.requests[0].SystemPrompt
+	if !strings.Contains(sys, "Custom hint") {
+		t.Errorf("custom hint missing: %q", sys)
+	}
+	if strings.Contains(sys, "DefaultMemoryHint") || strings.Contains(sys, "Phrase content in third person") {
+		t.Errorf("default hint should have been replaced; got %q", sys)
+	}
+}
+
+func TestRememberTool_PersistsViaExecutor(t *testing.T) {
+	p := newSQLitePeggy(t)
+	tool := RememberTool(p)
+	args, _ := json.Marshal(rememberArgs{Content: "User likes terse responses.", Tags: []string{"preference"}})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{ID: "c1", Name: "remember", Arguments: args})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	memories, _ := p.ListMemories(context.Background())
+	if len(memories) != 1 {
+		t.Fatalf("memory not stored: %+v", memories)
+	}
+	if !strings.Contains(memories[0].Content, "terse") {
+		t.Errorf("stored content wrong: %+v", memories[0])
+	}
+}
+
+func TestRememberTool_BlankContentErrors(t *testing.T) {
+	p := newSQLitePeggy(t)
+	tool := RememberTool(p)
+	args, _ := json.Marshal(rememberArgs{Content: "   "})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{ID: "c1", Name: "remember", Arguments: args})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error tool result for blank content")
+	}
+}
+
+func TestRememberTool_MalformedArgsSurface(t *testing.T) {
+	p := newSQLitePeggy(t)
+	tool := RememberTool(p)
+	res, err := tool.Execute(context.Background(), glue.ToolCall{ID: "c1", Name: "remember", Arguments: []byte("{not json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected decode error to surface as error result")
+	}
+}
+
+func TestRecallTool_ReturnsHits(t *testing.T) {
+	p := newSQLitePeggy(t)
+	ctx := context.Background()
+	if _, err := p.AddMemory(ctx, "User's dog is an Aussie named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatal(err)
+	}
+	tool := RecallTool(p)
+	args, _ := json.Marshal(recallArgs{Query: "Aussie", OnlyMemories: true})
+	res, err := tool.Execute(ctx, glue.ToolCall{ID: "c1", Name: "recall", Arguments: args})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "hits:") || !strings.Contains(text, "Aussie") {
+		t.Errorf("unexpected result text: %q", text)
+	}
+}
+
+func TestRecallTool_BlankQueryErrors(t *testing.T) {
+	p := newSQLitePeggy(t)
+	tool := RecallTool(p)
+	args, _ := json.Marshal(recallArgs{Query: "  "})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{ID: "c", Name: "recall", Arguments: args})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error tool result for blank query")
+	}
+}
+
+func TestRecallTool_FileStoreSurfaceFriendlyError(t *testing.T) {
+	// stores/file doesn't implement Searcher; the tool should surface
+	// a clear "sqlite store required" message rather than a generic
+	// ErrSearchNotSupported.
+	store := filestore.New(filepath.Join(t.TempDir(), "sessions"))
+	p, err := New(Options{Settings: Settings{}, Provider: &fakeProvider{text: "ok"}, Store: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	tool := RecallTool(p)
+	args, _ := json.Marshal(recallArgs{Query: "anything"})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{ID: "c", Name: "recall", Arguments: args})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error tool result")
+	}
+	if !strings.Contains(res.Content[0].Text, "sqlite store") {
+		t.Errorf("unhelpful error: %q", res.Content[0].Text)
+	}
+}
+
+func TestFormatRecallHits_NoHits(t *testing.T) {
+	if got := formatRecallHits(nil); got != "No hits." {
+		t.Errorf("got %q", got)
+	}
+}

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -43,6 +43,23 @@ type Options struct {
 	// Stderr collects diagnostic warnings (missing SOUL.md etc).
 	// Defaults to os.Stderr.
 	Stderr io.Writer
+
+	// MemoryHint overrides the paragraph appended to the system
+	// prompt describing the remember / recall tools. Empty falls
+	// back to DefaultMemoryHint. Ignored when DisableMemoryTools is
+	// true.
+	MemoryHint string
+
+	// DisableMemoryTools, when true, skips registration of the
+	// remember / recall tools and omits the memory hint from the
+	// system prompt. Useful for tests and out-of-tree integrations
+	// that want to roll their own memory model.
+	DisableMemoryTools bool
+
+	// ExtraTools are appended to the constructed Agent.Tools after
+	// any memory tools registered by default. Order: extra tools
+	// come after remember / recall.
+	ExtraTools []glue.Tool
 }
 
 // Peggy is a constructed personal-assistant agent. Hold one per
@@ -94,22 +111,45 @@ func New(opts Options) (*Peggy, error) {
 		KeepRecent:   settings.Compaction.KeepRecent,
 	}
 
-	agent := glue.NewAgent(glue.AgentOptions{
+	// Construct Peggy first so the memory tools can close over it.
+	// The agent is wired in below after tools are built.
+	p := &Peggy{
+		store:    store,
+		settings: settings,
+		soul:     systemPrompt,
+		stderr:   stderr,
+	}
+
+	var tools []glue.Tool
+	finalSystem := systemPrompt
+	if !opts.DisableMemoryTools {
+		tools = append(tools, RememberTool(p), RecallTool(p))
+		hint := opts.MemoryHint
+		if hint == "" {
+			hint = DefaultMemoryHint
+		}
+		hint = strings.TrimSpace(hint)
+		if hint != "" {
+			if finalSystem != "" {
+				finalSystem = finalSystem + "\n\n" + hint
+			} else {
+				finalSystem = hint
+			}
+		}
+	}
+	tools = append(tools, opts.ExtraTools...)
+
+	p.agent = glue.NewAgent(glue.AgentOptions{
 		Provider:            provider,
 		Model:               settings.Model,
-		SystemPrompt:        systemPrompt,
+		SystemPrompt:        finalSystem,
+		Tools:               tools,
 		Store:               store,
 		Compactor:           compactor,
 		CompactionThreshold: settings.Compaction.Threshold,
 	})
 
-	return &Peggy{
-		agent:    agent,
-		store:    store,
-		settings: settings,
-		soul:     systemPrompt,
-		stderr:   stderr,
-	}, nil
+	return p, nil
 }
 
 // Settings returns the effective settings the Peggy was constructed


### PR DESCRIPTION
## Summary

Gives the model agency over what it persists. Two model-callable `glue.Tool`s are registered by default on every `Peggy`:

- **`remember(content, tags?)`** — persist a curated fact to durable cross-session memory.
- **`recall(query, limit?, only_memories?)`** — search prior history and curated memories via FTS5.

Memories live in a dedicated `__memories__` session — searchable via the existing FTS5 index, isolated so they're immune to the per-session `SummarizingCompactor`. **No schema change** required.

**Public library surface added:**

```go
const MemoriesSessionID = "__memories__"
const DefaultMemoryHint = `...`

type Memory struct { Content string; Tags []string; Timestamp time.Time }

func (p *Peggy) AddMemory(ctx, content string, tags []string) (Memory, error)
func (p *Peggy) ListMemories(ctx) ([]Memory, error)  // newest-first
func (p *Peggy) Recall(ctx, query string, opts ...RecallOption) ([]glue.SearchHit, error)

type RecallOption func(*RecallOptions)
func WithRecallLimit(n int) RecallOption
func WithMemoriesOnly() RecallOption

func RememberTool(*Peggy) glue.Tool
func RecallTool(*Peggy) glue.Tool
```

`Options` gains:
- `MemoryHint string` — override the appended-to-system-prompt hint paragraph.
- `DisableMemoryTools bool` — suppress both tool registration and the hint.
- `ExtraTools []glue.Tool` — append additional tools after memory.

**Wiring**: `New` constructs the Peggy first (no agent yet) so memory tools can close over it; then builds the agent with `[remember, recall, ...extras]` and the final `SystemPrompt = SOUL` + memory hint (when enabled).

**Write discipline**: `AddMemory` drives the `Store` directly (Load → append → Save) rather than going through `agent.Session(__memories__)` — that route would register an in-memory `*Session` and conflict with any concurrent ordinary prompt traffic. A package-level mutex serializes memory writes within a process; the sqlite store already serializes via `MaxOpenConns=1`.

**Failure modes**: `RecallTool` surfaces a friendly "use a sqlite store" error when the configured store doesn't implement `Searcher`, rather than the bare `ErrSearchNotSupported` sentinel. Both tools convert blank/malformed args to `IsError: true` tool results (not Go errors that would crash the loop).

Closes #131. Tracker: #110.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...            (all packages pass)
$ go test -race ./agents/peggy -count=1
ok  github.com/erain/glue/agents/peggy  2.601s
```

19 new tests:

- `AddMemory_RoundTripsThroughStore`
- `AddMemory_PersistsAcrossPeggyRebuild`
- `AddMemory_RejectsBlankContent`
- `Recall_FindsMemoriesViaFTS` (sqlite-backed)
- `Recall_AcrossAllSessions` (memories + ordinary conversation)
- `Recall_LimitClampedAndDefaulted` (default 5, max 20)
- `Recall_BlankQueryErrors`
- `MemoryTools_DefaultRegistration` (asserts `remember` and `recall` reach `ProviderRequest.Tools`)
- `MemoryTools_DisabledViaOption`
- `MemoryHint_ReachesSystemPrompt`
- `MemoryHint_CustomOverride`
- `RememberTool_PersistsViaExecutor`
- `RememberTool_BlankContentErrors`
- `RememberTool_MalformedArgsSurface`
- `RecallTool_ReturnsHits`
- `RecallTool_BlankQueryErrors`
- `RecallTool_FileStoreSurfaceFriendlyError`
- `FormatRecallHits_NoHits`

README gained a "Memory" section explaining the tools, the hint mechanism, and the `ListMemories` programmatic surface. "What v0.1 supports" now lists the new tools.

No new dependencies.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` clean
- [x] `go test -race ./agents/peggy -count=1` clean
- [x] `remember` and `recall` registered by default; reach the provider's tool list
- [x] `DisableMemoryTools` suppresses both tools and hint
- [x] Memory hint reaches SystemPrompt when enabled
- [x] AddMemory persists across Peggy reconstructions
- [x] Recall over `file` store returns a clear "use sqlite" error rather than the sentinel