### PR TITLE
agents/peggy: Telegram channel adapter (closes #135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,8 +574,12 @@ itself), not `examples/` (which holds tutorial-grade demos only).
   peggy "Hello — what should I be working on today?"
   ```
 
+  Peggy is also reachable on Telegram via the
+  [`peggy-telegram`](agents/peggy/channels/telegram) binary — a
+  chat-allowlisted bot built on the
+  [channel-adapter pattern](docs/adr/0008-channel-adapter.md).
   See [`agents/peggy/README.md`](agents/peggy/README.md) for the
-  config / identity / CLI surface.
+  config / identity / CLI surface and channels overview.
 
 ## Examples
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -170,7 +170,9 @@ external transports. The pattern is designed in
 [`docs/adr/0008-channel-adapter.md`](../../docs/adr/0008-channel-adapter.md):
 
 - Each channel lives in its own package under
-  `agents/peggy/channels/<name>` (Telegram is first).
+  `agents/peggy/channels/<name>`. Telegram is the first concrete
+  channel — see [`channels/telegram/README.md`](channels/telegram/README.md)
+  for the bot setup and the `peggy-telegram` binary.
 - Channels satisfy a small `peggy.Channel` interface and call into
   the existing `Peggy.Prompt` API. They never modify core `glue`.
 - Channels namespace their session ids (`telegram:12345` etc.) so a
@@ -178,7 +180,8 @@ external transports. The pattern is designed in
   and the curated `__memories__` session without collision.
 - Channels accepting input from anyone reachable (Telegram, public
   webhooks) gate inbound traffic on an allowlist configured in
-  `settings.json` under `channels.<name>`.
+  `settings.json` under `channels.<name>`. Empty allowlist =
+  refuse-all (the safe default).
 
 ## What's coming
 

--- a/agents/peggy/channel.go
+++ b/agents/peggy/channel.go
@@ -1,0 +1,46 @@
+package peggy
+
+import (
+	"context"
+	"strings"
+)
+
+// Channel is one binding from an external transport (Telegram, future
+// TUI / web / IDE clients) to a Peggy agent. Implementations live in
+// agents/peggy/channels/<name>; this package owns the contract.
+//
+// Channels are constructed with the *Peggy and the channel's own
+// config (decoded from settings.json's channels.<name> subtree).
+// Run blocks until the supplied context is cancelled or a fatal
+// error occurs.
+//
+// Designed in docs/adr/0008-channel-adapter.md.
+type Channel interface {
+	// Name returns a stable, lowercase, single-word identifier
+	// ("telegram", "slack", "tui", …). Used in session-id prefixes
+	// and in settings.json's channels map.
+	Name() string
+
+	// Run drives the channel's event loop. It returns nil on graceful
+	// shutdown (ctx cancelled) and a non-nil error only on fatal
+	// setup or steady-state failure the channel cannot recover from.
+	// Run must be safe to call exactly once per Channel value.
+	Run(ctx context.Context) error
+}
+
+// ChannelSessionID returns the conventional namespaced session id for
+// a given channel and channel-native id. Channels are free to ignore
+// this and pick their own scheme; the convention exists so a single
+// store can hold CLI sessions, channel sessions, and the curated
+// __memories__ session without collision.
+//
+// The channel name is lower-cased and trimmed; the id is used as-is.
+// An empty channel name returns the id unchanged so calling
+// ChannelSessionID("", x) is a no-op (useful in tests).
+func ChannelSessionID(channel, id string) string {
+	channel = strings.ToLower(strings.TrimSpace(channel))
+	if channel == "" {
+		return id
+	}
+	return channel + ":" + id
+}

--- a/agents/peggy/channel_test.go
+++ b/agents/peggy/channel_test.go
@@ -1,0 +1,60 @@
+package peggy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChannelSessionID(t *testing.T) {
+	cases := []struct {
+		channel string
+		id      string
+		want    string
+	}{
+		{"telegram", "12345", "telegram:12345"},
+		{"TELEGRAM", "abc", "telegram:abc"},      // lower-cased
+		{"  telegram  ", "9", "telegram:9"},     // trimmed
+		{"", "7", "7"},                           // no-op for empty channel
+		{"slack", "U123", "slack:U123"},
+	}
+	for _, tc := range cases {
+		if got := ChannelSessionID(tc.channel, tc.id); got != tc.want {
+			t.Errorf("ChannelSessionID(%q, %q) = %q, want %q", tc.channel, tc.id, got, tc.want)
+		}
+	}
+}
+
+func TestSettings_ChannelsRoundTrip(t *testing.T) {
+	src := map[string]any{
+		"provider": "openrouter",
+		"channels": map[string]any{
+			"telegram": map[string]any{
+				"bot_token_env": "PEGGY_TELEGRAM_TOKEN",
+				"allow_chats":   []int{12345, 67890},
+			},
+		},
+	}
+	raw, _ := json.Marshal(src)
+	var s Settings
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := s.Channels["telegram"]; !ok {
+		t.Fatalf("Channels[telegram] missing: %+v", s.Channels)
+	}
+	// The raw subtree should preserve the JSON shape verbatim so each
+	// channel package can decode it.
+	var sub struct {
+		BotTokenEnv string  `json:"bot_token_env"`
+		AllowChats  []int64 `json:"allow_chats"`
+	}
+	if err := json.Unmarshal(s.Channels["telegram"], &sub); err != nil {
+		t.Fatalf("decode subtree: %v", err)
+	}
+	if sub.BotTokenEnv != "PEGGY_TELEGRAM_TOKEN" {
+		t.Errorf("bot_token_env = %q", sub.BotTokenEnv)
+	}
+	if len(sub.AllowChats) != 2 || sub.AllowChats[0] != 12345 {
+		t.Errorf("allow_chats = %v", sub.AllowChats)
+	}
+}

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -1,0 +1,106 @@
+# Peggy on Telegram
+
+The first concrete `peggy.Channel`. Text-message-only, long-polling,
+gated by a chat-id allowlist. Built on the pattern designed in
+[`docs/adr/0008-channel-adapter.md`](../../../../docs/adr/0008-channel-adapter.md).
+
+## One-time setup
+
+1. **Create a bot.** Open a chat with
+   [`@BotFather`](https://t.me/BotFather) on Telegram, run `/newbot`,
+   give it a name and a username. Save the token it gives you.
+
+2. **Pick a token environment variable.** The default is
+   `PEGGY_TELEGRAM_TOKEN`; override with
+   `channels.telegram.bot_token_env` in your `settings.json`. Export
+   the variable in your shell or in whatever process supervisor you
+   use:
+
+   ```sh
+   export PEGGY_TELEGRAM_TOKEN='123456:ABCDEF...'
+   ```
+
+3. **Find your chat id.** Send any message to your bot, then run:
+
+   ```sh
+   curl -s "https://api.telegram.org/bot$PEGGY_TELEGRAM_TOKEN/getUpdates" | jq '.result[0].message.chat.id'
+   ```
+
+4. **Configure the allowlist.** Edit `~/.config/peggy/settings.json`:
+
+   ```json
+   {
+     "channels": {
+       "telegram": {
+         "allow_chats": [123456789]
+       }
+     }
+   }
+   ```
+
+   **An empty `allow_chats` means refuse-all.** That's the safe
+   default — running the bot before you've added your chat id won't
+   leak responses to strangers, but it also won't reply to you.
+
+5. **Run.**
+
+   ```sh
+   peggy-telegram
+   ```
+
+   SIGINT / SIGTERM stops cleanly.
+
+## Settings reference
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "bot_token_env": "PEGGY_TELEGRAM_TOKEN",
+      "allow_chats": [123456789],
+      "long_poll_timeout_seconds": 30,
+      "api_base_url": ""
+    }
+  }
+}
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `bot_token_env` | `PEGGY_TELEGRAM_TOKEN` | Env var holding the BotFather token. |
+| `allow_chats` | `[]` (refuse-all) | Telegram chat ids permitted to reach the agent. |
+| `long_poll_timeout_seconds` | `30` | Seconds the server waits before returning an empty update set. Clamped to 60. |
+| `api_base_url` | `https://api.telegram.org` | Override for tests / private mirrors. |
+
+## Session-id namespacing
+
+Each Telegram chat maps to a Peggy session id `telegram:<chat_id>` —
+e.g. `telegram:123456789`. This namespacing keeps Telegram
+conversations distinct from CLI sessions (`default`, `--session foo`)
+and from Peggy's curated `__memories__` session inside a single
+sqlite store. `Agent.SearchSessions` can scope to one channel by
+filtering on the session id (FTS5 prefix search is a planned
+follow-up; exact-match works today).
+
+## What v0.1 supports
+
+- Text-message-only inbound and outbound. Photos / voice / documents /
+  stickers are dropped.
+- Long-polling. Webhook-mode is a follow-up.
+- One Telegram bot per process. Multi-bot in one process is an M3
+  concern.
+- Replies are sent as one message per turn, after the model finishes.
+  Edit-in-place streaming and "thinking…" placeholders are a
+  follow-up (Telegram rate-limits message edits and the trade-offs
+  warrant their own pass).
+- Replies exceeding Telegram's 4096-character limit are truncated
+  with a `… [truncated]` suffix; full responses are still in the
+  session transcript / sqlite store.
+
+## What's coming
+
+- Edit-in-place streaming for replies (delta → edited message).
+- Per-user permission policy (gated by the M2 `Permission` interface).
+- Webhook-mode (push-based) for low-latency hosted setups.
+- `Agent.SearchSessions` channel-prefix filter so the user can scope
+  recall to "things we talked about on Telegram."

--- a/agents/peggy/channels/telegram/api.go
+++ b/agents/peggy/channels/telegram/api.go
@@ -1,0 +1,169 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Update is one entry from getUpdates. Only the fields glue needs are
+// modeled; everything else is ignored.
+type Update struct {
+	UpdateID int64    `json:"update_id"`
+	Message  *Message `json:"message,omitempty"`
+}
+
+// Message is the text message variant we care about. Photo, voice,
+// document, etc. are out of scope for v0.1.
+type Message struct {
+	MessageID int64  `json:"message_id"`
+	From      *User  `json:"from,omitempty"`
+	Chat      Chat   `json:"chat"`
+	Date      int64  `json:"date"`
+	Text      string `json:"text"`
+}
+
+// User is the sender of a message.
+type User struct {
+	ID        int64  `json:"id"`
+	Username  string `json:"username,omitempty"`
+	FirstName string `json:"first_name,omitempty"`
+}
+
+// Chat is the conversation a message belongs to.
+type Chat struct {
+	ID    int64  `json:"id"`
+	Type  string `json:"type"`
+	Title string `json:"title,omitempty"`
+}
+
+// API is the minimal Telegram Bot API client used by the channel.
+// All methods accept ctx; cancellation propagates to the underlying
+// HTTP request.
+type API struct {
+	BaseURL    string
+	Token      string
+	HTTPClient *http.Client
+}
+
+// NewAPI constructs an API with sensible defaults.
+func NewAPI(baseURL, token string, httpClient *http.Client) *API {
+	if baseURL == "" {
+		baseURL = defaultAPIBaseURL
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 0, // long-poll needs no client-level timeout
+		}
+	}
+	return &API{
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		Token:      token,
+		HTTPClient: httpClient,
+	}
+}
+
+// GetUpdates calls the Bot API's getUpdates method (long-poll). offset
+// is the smallest update_id we still want to receive; the server
+// returns updates with id ≥ offset. timeout is the long-poll cap in
+// seconds.
+func (a *API) GetUpdates(ctx context.Context, offset int64, timeoutSeconds int) ([]Update, error) {
+	body, _ := json.Marshal(map[string]any{
+		"offset":  offset,
+		"timeout": timeoutSeconds,
+	})
+	return a.do(ctx, "getUpdates", body, parseUpdates)
+}
+
+// SendMessage sends a text message to chatID. text is truncated to
+// telegramMessageLimit bytes (Telegram's hard cap).
+func (a *API) SendMessage(ctx context.Context, chatID int64, text string) error {
+	if len(text) > telegramMessageLimit {
+		text = text[:telegramMessageLimit-len(truncationSuffix)] + truncationSuffix
+	}
+	body, _ := json.Marshal(map[string]any{
+		"chat_id": chatID,
+		"text":    text,
+	})
+	_, err := a.do(ctx, "sendMessage", body, func(b []byte) ([]Update, error) {
+		// sendMessage's result is the sent Message; we don't need it.
+		return nil, nil
+	})
+	return err
+}
+
+const truncationSuffix = "\n… [truncated]"
+
+// botAPIResponse is the envelope every Bot API method returns.
+type botAPIResponse struct {
+	OK          bool            `json:"ok"`
+	Result      json.RawMessage `json:"result"`
+	Description string          `json:"description"`
+	ErrorCode   int             `json:"error_code"`
+}
+
+func (a *API) do(ctx context.Context, method string, body []byte, parse func([]byte) ([]Update, error)) ([]Update, error) {
+	if a.Token == "" {
+		return nil, errors.New("telegram: API.Token is required")
+	}
+	url := a.BaseURL + "/bot" + a.Token + "/" + method
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("telegram: build %s request: %w", method, redactErr(err, a.Token))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("telegram: %s transport: %w", method, redactErr(err, a.Token))
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("telegram: %s read body: %w", method, err)
+	}
+	var env botAPIResponse
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("telegram: %s decode envelope: %w", method, err)
+	}
+	if !env.OK {
+		return nil, fmt.Errorf("telegram: %s failed: %s (code=%d)", method, env.Description, env.ErrorCode)
+	}
+	return parse(env.Result)
+}
+
+func parseUpdates(b []byte) ([]Update, error) {
+	if len(b) == 0 || string(b) == "null" {
+		return nil, nil
+	}
+	var updates []Update
+	if err := json.Unmarshal(b, &updates); err != nil {
+		return nil, fmt.Errorf("telegram: decode updates: %w", err)
+	}
+	return updates, nil
+}
+
+// redactErr scrubs the bot token from an error's text. URL errors
+// often embed the token as a path segment; we don't want it in logs.
+func redactErr(err error, token string) error {
+	if err == nil || token == "" {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, token) {
+		msg = strings.ReplaceAll(msg, token, "<redacted>")
+		return errors.New(msg)
+	}
+	return err
+}
+
+// Status codes used by the long-poll loop to decide retry behavior.
+const (
+	transientRetryInitial = time.Second
+	transientRetryMax     = 30 * time.Second
+)

--- a/agents/peggy/channels/telegram/api_test.go
+++ b/agents/peggy/channels/telegram/api_test.go
@@ -1,0 +1,123 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetUpdates_ParsesCannedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/getUpdates") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{
+            "ok": true,
+            "result": [
+                {"update_id": 1, "message": {"message_id": 100, "chat": {"id": 555, "type": "private"}, "date": 1700000000, "text": "hello"}},
+                {"update_id": 2, "message": {"message_id": 101, "chat": {"id": 555, "type": "private"}, "date": 1700000001, "text": "hi again"}}
+            ]
+        }`)
+	}))
+	defer srv.Close()
+
+	api := NewAPI(srv.URL, "secret-token", srv.Client())
+	updates, err := api.GetUpdates(context.Background(), 0, 30)
+	if err != nil {
+		t.Fatalf("GetUpdates: %v", err)
+	}
+	if len(updates) != 2 {
+		t.Fatalf("got %d updates: %+v", len(updates), updates)
+	}
+	if updates[0].Message.Text != "hello" || updates[1].Message.Text != "hi again" {
+		t.Errorf("text mismatch: %+v", updates)
+	}
+	if updates[0].Message.Chat.ID != 555 {
+		t.Errorf("chat id = %d", updates[0].Message.Chat.ID)
+	}
+}
+
+func TestSendMessage_PostsCorrectShape(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/sendMessage") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"ok": true, "result": {}}`)
+	}))
+	defer srv.Close()
+
+	api := NewAPI(srv.URL, "tk", srv.Client())
+	if err := api.SendMessage(context.Background(), 555, "hello"); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(capturedBody, &body); err != nil {
+		t.Fatalf("body json: %v", err)
+	}
+	if body["chat_id"].(float64) != 555 {
+		t.Errorf("chat_id = %v", body["chat_id"])
+	}
+	if body["text"] != "hello" {
+		t.Errorf("text = %v", body["text"])
+	}
+}
+
+func TestSendMessage_Truncates(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"ok": true, "result": {}}`)
+	}))
+	defer srv.Close()
+	api := NewAPI(srv.URL, "tk", srv.Client())
+	long := strings.Repeat("x", telegramMessageLimit+1000)
+	if err := api.SendMessage(context.Background(), 1, long); err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(capturedBody, &body)
+	got := body["text"].(string)
+	if len(got) > telegramMessageLimit {
+		t.Errorf("truncation failed: %d bytes", len(got))
+	}
+	if !strings.HasSuffix(got, "[truncated]") {
+		t.Errorf("missing truncation marker: %q", got[len(got)-30:])
+	}
+}
+
+func TestAPI_NotOKResponseSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok": false, "error_code": 401, "description": "Unauthorized"}`)
+	}))
+	defer srv.Close()
+	api := NewAPI(srv.URL, "tk", srv.Client())
+	_, err := api.GetUpdates(context.Background(), 0, 30)
+	if err == nil || !strings.Contains(err.Error(), "Unauthorized") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestAPI_EmptyTokenErrors(t *testing.T) {
+	api := NewAPI("http://example", "", nil)
+	if _, err := api.GetUpdates(context.Background(), 0, 30); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestRedactErr_StripsToken(t *testing.T) {
+	err := errors.New("Get https://api.telegram.org/botSECRET/getUpdates: dial tcp: no route to host")
+	red := redactErr(err, "SECRET")
+	if strings.Contains(red.Error(), "SECRET") {
+		t.Fatalf("token leaked: %v", red)
+	}
+	if !strings.Contains(red.Error(), "<redacted>") {
+		t.Fatalf("no redaction marker: %v", red)
+	}
+}

--- a/agents/peggy/channels/telegram/channel.go
+++ b/agents/peggy/channels/telegram/channel.go
@@ -1,0 +1,201 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/erain/glue/agents/peggy"
+)
+
+// ChannelName is the stable identifier for this channel.
+const ChannelName = "telegram"
+
+// Options configures a Channel. Most fields are optional with sensible
+// defaults; the only required pieces are Peggy and a populated Config.
+type Options struct {
+	// Peggy is the agent that handles inbound messages. Required.
+	Peggy *peggy.Peggy
+
+	// Config is the decoded settings.channels.telegram block.
+	Config Config
+
+	// Token is the bot token. If empty, the channel reads
+	// os.Getenv(Config.BotTokenEnv) at construction time.
+	Token string
+
+	// HTTPClient is forwarded to the API. nil → default.
+	HTTPClient *http.Client
+
+	// Stderr collects diagnostics (rejected messages, transient
+	// errors, etc.). Defaults to os.Stderr. The channel never logs
+	// the bot token here.
+	Stderr io.Writer
+}
+
+// Channel is the peggy.Channel implementation for Telegram.
+type Channel struct {
+	peggy   *peggy.Peggy
+	cfg     Config
+	api     *API
+	allowed map[int64]struct{}
+	stderr  io.Writer
+}
+
+// New constructs a Channel. Returns an error when required fields are
+// missing — the bot token in particular surfaces early rather than
+// failing silently inside the poll loop.
+func New(opts Options) (*Channel, error) {
+	if opts.Peggy == nil {
+		return nil, errors.New("telegram: Peggy is required")
+	}
+	cfg, err := DecodeConfig(nil) // re-apply defaults defensively
+	if err != nil {
+		return nil, err
+	}
+	// Merge user-supplied config over defaults.
+	if opts.Config.BotTokenEnv != "" {
+		cfg.BotTokenEnv = opts.Config.BotTokenEnv
+	}
+	if opts.Config.LongPollTimeoutSeconds > 0 {
+		cfg.LongPollTimeoutSeconds = opts.Config.LongPollTimeoutSeconds
+	}
+	if cfg.LongPollTimeoutSeconds > maxLongPollSecs {
+		cfg.LongPollTimeoutSeconds = maxLongPollSecs
+	}
+	if opts.Config.APIBaseURL != "" {
+		cfg.APIBaseURL = opts.Config.APIBaseURL
+	}
+	cfg.AllowChats = append([]int64(nil), opts.Config.AllowChats...)
+
+	token := opts.Token
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv(cfg.BotTokenEnv))
+	}
+	if token == "" {
+		return nil, fmt.Errorf("telegram: bot token is required (set $%s or Options.Token)", cfg.BotTokenEnv)
+	}
+
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	allowed := make(map[int64]struct{}, len(cfg.AllowChats))
+	for _, id := range cfg.AllowChats {
+		allowed[id] = struct{}{}
+	}
+
+	return &Channel{
+		peggy:   opts.Peggy,
+		cfg:     cfg,
+		api:     NewAPI(cfg.APIBaseURL, token, opts.HTTPClient),
+		allowed: allowed,
+		stderr:  stderr,
+	}, nil
+}
+
+// Name implements peggy.Channel.
+func (c *Channel) Name() string { return ChannelName }
+
+// Run drives the long-poll loop. Returns nil when ctx is cancelled.
+// Run must be called exactly once per Channel value.
+func (c *Channel) Run(ctx context.Context) error {
+	if c == nil || c.api == nil {
+		return errors.New("telegram: channel not initialised")
+	}
+	if len(c.allowed) == 0 {
+		fmt.Fprintln(c.stderr, "telegram: allow_chats is empty — refusing all inbound messages (set allow_chats in settings.json to enable)")
+	}
+	var (
+		offset    int64
+		backoff   = transientRetryInitial
+		maxBackoff = transientRetryMax
+	)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		updates, err := c.api.GetUpdates(ctx, offset, c.cfg.LongPollTimeoutSeconds)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			fmt.Fprintf(c.stderr, "telegram: getUpdates: %v (backing off %s)\n", err, backoff)
+			if !c.sleep(ctx, backoff) {
+				return nil
+			}
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+			continue
+		}
+		backoff = transientRetryInitial
+		for _, u := range updates {
+			if u.UpdateID >= offset {
+				offset = u.UpdateID + 1
+			}
+			c.handleUpdate(ctx, u)
+		}
+	}
+}
+
+func (c *Channel) sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// handleUpdate processes one update. It gates on the allowlist,
+// constructs the session id, drives the prompt, and replies with the
+// model's text.
+func (c *Channel) handleUpdate(ctx context.Context, u Update) {
+	if u.Message == nil || strings.TrimSpace(u.Message.Text) == "" {
+		return
+	}
+	chatID := u.Message.Chat.ID
+	if _, ok := c.allowed[chatID]; !ok {
+		fmt.Fprintf(c.stderr, "telegram: dropping message from non-allowlisted chat %d\n", chatID)
+		return
+	}
+
+	sessionID := peggy.ChannelSessionID(ChannelName, strconv.FormatInt(chatID, 10))
+	var buf bytes.Buffer
+	text, err := c.peggy.Prompt(ctx, sessionID, u.Message.Text, &buf)
+	if err != nil {
+		fmt.Fprintf(c.stderr, "telegram: prompt failed for chat %d: %v\n", chatID, err)
+		// Reply with a short error rather than going silent — the user
+		// sent something and deserves an acknowledgment.
+		_ = c.api.SendMessage(ctx, chatID, "(I hit an error responding. Check the agent logs.)")
+		return
+	}
+	reply := strings.TrimSpace(text)
+	if reply == "" {
+		reply = strings.TrimSpace(buf.String())
+	}
+	if reply == "" {
+		fmt.Fprintf(c.stderr, "telegram: prompt for chat %d produced no text\n", chatID)
+		return
+	}
+	if err := c.api.SendMessage(ctx, chatID, reply); err != nil {
+		fmt.Fprintf(c.stderr, "telegram: send to chat %d: %v\n", chatID, err)
+	}
+}
+
+// Compile-time assertion that *Channel satisfies peggy.Channel.
+var _ peggy.Channel = (*Channel)(nil)

--- a/agents/peggy/channels/telegram/channel_test.go
+++ b/agents/peggy/channels/telegram/channel_test.go
@@ -1,0 +1,416 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/agents/peggy"
+	filestore "github.com/erain/glue/stores/file"
+)
+
+// fakeProvider is a stripped fakeProvider for channel tests. The
+// fakeProvider in agents/peggy is package-private, so we keep a local
+// copy here.
+type fakeProvider struct {
+	text     string
+	mu       sync.Mutex
+	requests []glue.ProviderRequest
+	calls    int
+}
+
+func (p *fakeProvider) Stream(_ context.Context, req glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, req)
+	p.calls++
+	text := p.text
+	p.mu.Unlock()
+	ch := make(chan glue.ProviderEvent, 4)
+	ch <- glue.ProviderEvent{Type: glue.ProviderEventStart}
+	ch <- glue.ProviderEvent{Type: glue.ProviderEventTextDelta, Delta: text}
+	ch <- glue.ProviderEvent{Type: glue.ProviderEventDone, Message: &glue.Message{
+		Role:    glue.MessageRoleAssistant,
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
+	}}
+	close(ch)
+	return ch, nil
+}
+
+func newTestPeggy(t *testing.T, fp *fakeProvider) *peggy.Peggy {
+	t.Helper()
+	store := filestore.New(filepath.Join(t.TempDir(), "sessions"))
+	p, err := peggy.New(peggy.Options{
+		Settings:           peggy.Settings{},
+		Provider:           fp,
+		Store:              store,
+		DisableMemoryTools: true, // avoid file-store search errors
+	})
+	if err != nil {
+		t.Fatalf("peggy.New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// telegramFixture is a fake Telegram Bot API server. It serves
+// scripted responses to getUpdates and records sendMessage POSTs.
+type telegramFixture struct {
+	server     *httptest.Server
+	mu         sync.Mutex
+	updates    [][]Update // each call to getUpdates pops the next slice
+	updatesCh  chan struct{}
+	sendBodies [][]byte
+}
+
+func newTelegramFixture(t *testing.T, updates [][]Update) *telegramFixture {
+	t.Helper()
+	f := &telegramFixture{updates: updates, updatesCh: make(chan struct{}, 1)}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getUpdates"):
+			f.mu.Lock()
+			var next []Update
+			if len(f.updates) > 0 {
+				next = f.updates[0]
+				f.updates = f.updates[1:]
+			}
+			f.mu.Unlock()
+			payload := struct {
+				OK     bool     `json:"ok"`
+				Result []Update `json:"result"`
+			}{OK: true, Result: next}
+			_ = json.NewEncoder(w).Encode(payload)
+		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
+			body, _ := io.ReadAll(r.Body)
+			f.mu.Lock()
+			f.sendBodies = append(f.sendBodies, body)
+			f.mu.Unlock()
+			_, _ = io.WriteString(w, `{"ok": true, "result": {"message_id": 1, "chat": {"id": 0, "type": "private"}, "date": 0, "text": ""}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *telegramFixture) sendCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sendBodies)
+}
+
+func (f *telegramFixture) lastSendText() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sendBodies) == 0 {
+		return ""
+	}
+	var body map[string]any
+	_ = json.Unmarshal(f.sendBodies[len(f.sendBodies)-1], &body)
+	if s, ok := body["text"].(string); ok {
+		return s
+	}
+	return ""
+}
+
+func messageUpdate(updateID int64, chatID int64, text string) Update {
+	return Update{UpdateID: updateID, Message: &Message{
+		MessageID: updateID, Chat: Chat{ID: chatID, Type: "private"}, Text: text, Date: time.Now().Unix(),
+	}}
+}
+
+func TestChannel_AllowedChatPromptsAndReplies(t *testing.T) {
+	fp := &fakeProvider{text: "Hello back."}
+	p := newTestPeggy(t, fp)
+	fix := newTelegramFixture(t, [][]Update{
+		{messageUpdate(1, 555, "Hi Peggy")},
+	})
+	ch, err := New(Options{
+		Peggy: p,
+		Token: "secret",
+		Config: Config{
+			BotTokenEnv:            "PEGGY_TELEGRAM_TOKEN",
+			AllowChats:             []int64{555},
+			APIBaseURL:             fix.server.URL,
+			LongPollTimeoutSeconds: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- ch.Run(ctx) }()
+
+	// Wait until sendMessage has been hit, then cancel.
+	deadline := time.After(2500 * time.Millisecond)
+	for fix.sendCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for sendMessage")
+		default:
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fp.calls == 0 {
+		t.Fatal("provider not invoked")
+	}
+	if got := fix.lastSendText(); !strings.Contains(got, "Hello back") {
+		t.Errorf("send text = %q", got)
+	}
+	// Session id namespacing is exercised end-to-end here: opening
+	// the namespaced session id on the same agent must return a
+	// non-empty transcript (the message we just routed). The
+	// namespacing helper itself is covered in agents/peggy/channel_test.go.
+	if fp.requests[0].Messages[0].Content[0].Text != "Hi Peggy" {
+		t.Errorf("provider got wrong text: %+v", fp.requests[0].Messages)
+	}
+	sess, err := p.Agent().Session(ctx, "telegram:555")
+	if err != nil {
+		t.Fatalf("namespaced session lookup: %v", err)
+	}
+	if msgs := sess.Messages(); len(msgs) == 0 {
+		t.Errorf("namespaced session has no messages — session-id routing broken")
+	}
+}
+
+func TestChannel_NonAllowedChatDropped(t *testing.T) {
+	fp := &fakeProvider{text: "nope"}
+	p := newTestPeggy(t, fp)
+	fix := newTelegramFixture(t, [][]Update{
+		{messageUpdate(1, 999, "intruder")},
+	})
+	var stderr bytes.Buffer
+	ch, err := New(Options{
+		Peggy: p,
+		Token: "secret",
+		Config: Config{
+			AllowChats:             []int64{555}, // 999 not listed
+			APIBaseURL:             fix.server.URL,
+			LongPollTimeoutSeconds: 1,
+		},
+		Stderr: &stderr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- ch.Run(ctx) }()
+
+	// Wait briefly so the goroutine has time to process the update.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	<-done
+
+	if fp.calls != 0 {
+		t.Errorf("non-allowlisted chat should not call provider; calls=%d", fp.calls)
+	}
+	if fix.sendCount() != 0 {
+		t.Errorf("no reply should be sent; sends=%d", fix.sendCount())
+	}
+	if !strings.Contains(stderr.String(), "non-allowlisted") {
+		t.Errorf("stderr missing drop diagnostic: %q", stderr.String())
+	}
+}
+
+func TestChannel_EmptyAllowChatsRefusesAll(t *testing.T) {
+	fp := &fakeProvider{text: "nope"}
+	p := newTestPeggy(t, fp)
+	fix := newTelegramFixture(t, [][]Update{
+		{messageUpdate(1, 1, "hi")},
+	})
+	var stderr bytes.Buffer
+	ch, err := New(Options{
+		Peggy:  p,
+		Token:  "secret",
+		Config: Config{APIBaseURL: fix.server.URL, LongPollTimeoutSeconds: 1},
+		Stderr: &stderr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	go ch.Run(ctx)
+	time.Sleep(400 * time.Millisecond)
+	cancel()
+	if fp.calls != 0 {
+		t.Errorf("calls = %d, expected 0", fp.calls)
+	}
+	if !strings.Contains(stderr.String(), "refusing all inbound") {
+		t.Errorf("refuse-all diagnostic missing: %q", stderr.String())
+	}
+}
+
+func TestChannel_MultipleUpdatesPerPoll(t *testing.T) {
+	fp := &fakeProvider{text: "ack"}
+	p := newTestPeggy(t, fp)
+	fix := newTelegramFixture(t, [][]Update{
+		{
+			messageUpdate(10, 555, "first"),
+			messageUpdate(11, 555, "second"),
+			messageUpdate(12, 555, "third"),
+		},
+	})
+	ch, err := New(Options{
+		Peggy: p,
+		Token: "tk",
+		Config: Config{
+			AllowChats:             []int64{555},
+			APIBaseURL:             fix.server.URL,
+			LongPollTimeoutSeconds: 1,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- ch.Run(ctx) }()
+	deadline := time.After(2500 * time.Millisecond)
+	for fix.sendCount() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d sends recorded", fix.sendCount())
+		default:
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	cancel()
+	<-done
+	if fp.calls != 3 {
+		t.Errorf("provider calls = %d, want 3", fp.calls)
+	}
+	if fix.sendCount() != 3 {
+		t.Errorf("sends = %d, want 3", fix.sendCount())
+	}
+}
+
+func TestChannel_ContextCancelExitsRun(t *testing.T) {
+	fp := &fakeProvider{text: "ack"}
+	p := newTestPeggy(t, fp)
+	fix := newTelegramFixture(t, nil) // no updates; loop just polls
+	ch, _ := New(Options{
+		Peggy: p, Token: "tk",
+		Config: Config{
+			AllowChats:             []int64{1},
+			APIBaseURL:             fix.server.URL,
+			LongPollTimeoutSeconds: 1,
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- ch.Run(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run err = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not exit after cancel")
+	}
+}
+
+func TestNew_MissingTokenErrors(t *testing.T) {
+	fp := &fakeProvider{}
+	p := newTestPeggy(t, fp)
+	_, err := New(Options{Peggy: p, Config: Config{BotTokenEnv: "NEVER_SET_TOKEN_VAR"}})
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if !strings.Contains(err.Error(), "bot token") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_NilPeggyErrors(t *testing.T) {
+	_, err := New(Options{Token: "x"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestChannel_PromptErrorRepliesWithFallback(t *testing.T) {
+	fp := &errProvider{}
+	p := newTestPeggy2(t, fp)
+	fix := newTelegramFixture(t, [][]Update{
+		{messageUpdate(1, 555, "boom")},
+	})
+	var stderr bytes.Buffer
+	ch, _ := New(Options{
+		Peggy: p, Token: "tk", Stderr: &stderr,
+		Config: Config{
+			AllowChats:             []int64{555},
+			APIBaseURL:             fix.server.URL,
+			LongPollTimeoutSeconds: 1,
+		},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- ch.Run(ctx) }()
+	deadline := time.After(1500 * time.Millisecond)
+	for fix.sendCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("no fallback reply sent")
+		default:
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	cancel()
+	<-done
+	if !strings.Contains(fix.lastSendText(), "error") {
+		t.Errorf("fallback reply text = %q", fix.lastSendText())
+	}
+	if !strings.Contains(stderr.String(), "prompt failed") {
+		t.Errorf("missing diagnostic: %q", stderr.String())
+	}
+}
+
+// errProvider always fails Stream so we can exercise the channel's
+// fallback-reply path.
+type errProvider struct{ count atomic.Int64 }
+
+func (p *errProvider) Stream(_ context.Context, _ glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	p.count.Add(1)
+	return nil, fmt.Errorf("simulated upstream failure")
+}
+
+func newTestPeggy2(t *testing.T, fp glue.Provider) *peggy.Peggy {
+	t.Helper()
+	store := filestore.New(filepath.Join(t.TempDir(), "sessions"))
+	p, err := peggy.New(peggy.Options{
+		Settings:           peggy.Settings{},
+		Provider:           fp,
+		Store:              store,
+		DisableMemoryTools: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}

--- a/agents/peggy/channels/telegram/config.go
+++ b/agents/peggy/channels/telegram/config.go
@@ -1,0 +1,62 @@
+package telegram
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Config is the decoded form of settings.json's
+// channels.telegram subtree.
+type Config struct {
+	// BotTokenEnv names the environment variable that holds the bot
+	// token (issued by BotFather). The variable's value is loaded at
+	// channel construction time. Default: PEGGY_TELEGRAM_TOKEN.
+	BotTokenEnv string `json:"bot_token_env"`
+
+	// AllowChats restricts inbound messages to the listed chat ids.
+	// Empty = refuse-all (no inbound message is processed). Channels
+	// MUST gate on this — see ADR-0008 §5.
+	AllowChats []int64 `json:"allow_chats"`
+
+	// LongPollTimeoutSeconds caps the timeout passed to getUpdates.
+	// 30 is a reasonable default that balances latency vs. Telegram's
+	// connection limits. Zero falls back to the default.
+	LongPollTimeoutSeconds int `json:"long_poll_timeout_seconds"`
+
+	// APIBaseURL overrides the Telegram API root. Empty falls back to
+	// https://api.telegram.org. Used by tests to point at an
+	// httptest.NewServer.
+	APIBaseURL string `json:"api_base_url"`
+}
+
+const (
+	defaultBotTokenEnv   = "PEGGY_TELEGRAM_TOKEN"
+	defaultLongPollSecs  = 30
+	defaultAPIBaseURL    = "https://api.telegram.org"
+	maxLongPollSecs      = 60
+	telegramMessageLimit = 4096
+)
+
+// DecodeConfig parses the raw channels.telegram JSON subtree and fills
+// in defaults. A nil / empty raw payload yields a default Config.
+func DecodeConfig(raw json.RawMessage) (Config, error) {
+	var c Config
+	if len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return Config{}, fmt.Errorf("telegram: decode config: %w", err)
+		}
+	}
+	if c.BotTokenEnv == "" {
+		c.BotTokenEnv = defaultBotTokenEnv
+	}
+	if c.LongPollTimeoutSeconds <= 0 {
+		c.LongPollTimeoutSeconds = defaultLongPollSecs
+	}
+	if c.LongPollTimeoutSeconds > maxLongPollSecs {
+		c.LongPollTimeoutSeconds = maxLongPollSecs
+	}
+	if c.APIBaseURL == "" {
+		c.APIBaseURL = defaultAPIBaseURL
+	}
+	return c, nil
+}

--- a/agents/peggy/channels/telegram/config_test.go
+++ b/agents/peggy/channels/telegram/config_test.go
@@ -1,0 +1,63 @@
+package telegram
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeConfig_Defaults(t *testing.T) {
+	c, err := DecodeConfig(nil)
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	if c.BotTokenEnv != defaultBotTokenEnv {
+		t.Errorf("BotTokenEnv = %q", c.BotTokenEnv)
+	}
+	if c.LongPollTimeoutSeconds != defaultLongPollSecs {
+		t.Errorf("LongPollTimeoutSeconds = %d", c.LongPollTimeoutSeconds)
+	}
+	if c.APIBaseURL != defaultAPIBaseURL {
+		t.Errorf("APIBaseURL = %q", c.APIBaseURL)
+	}
+}
+
+func TestDecodeConfig_HappyPath(t *testing.T) {
+	raw := json.RawMessage(`{
+        "bot_token_env": "MY_TOKEN",
+        "allow_chats": [1, 2, 3],
+        "long_poll_timeout_seconds": 10,
+        "api_base_url": "http://localhost:9999"
+    }`)
+	c, err := DecodeConfig(raw)
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	if c.BotTokenEnv != "MY_TOKEN" || len(c.AllowChats) != 3 || c.AllowChats[2] != 3 ||
+		c.LongPollTimeoutSeconds != 10 || c.APIBaseURL != "http://localhost:9999" {
+		t.Errorf("decoded wrong: %+v", c)
+	}
+}
+
+func TestDecodeConfig_ClampsLongPoll(t *testing.T) {
+	raw := json.RawMessage(`{"long_poll_timeout_seconds": 9999}`)
+	c, _ := DecodeConfig(raw)
+	if c.LongPollTimeoutSeconds != maxLongPollSecs {
+		t.Errorf("clamp failed: %d", c.LongPollTimeoutSeconds)
+	}
+}
+
+func TestDecodeConfig_InvalidJSONErrors(t *testing.T) {
+	if _, err := DecodeConfig([]byte("{not json")); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDecodeConfig_NullPayload(t *testing.T) {
+	c, err := DecodeConfig([]byte("null"))
+	if err != nil {
+		t.Fatalf("null should be tolerated: %v", err)
+	}
+	if c.BotTokenEnv != defaultBotTokenEnv {
+		t.Errorf("defaults not applied on null: %+v", c)
+	}
+}

--- a/agents/peggy/channels/telegram/doc.go
+++ b/agents/peggy/channels/telegram/doc.go
@@ -1,0 +1,10 @@
+// Package telegram is the Telegram-bot channel adapter for Peggy. It
+// implements peggy.Channel against the Telegram Bot API using a
+// stdlib-only HTTP client (no third-party SDK).
+//
+// v0.1 supports text messages with long-polling and a chat-id
+// allowlist. Edit-in-place streaming, image / voice / file messages,
+// and webhook-mode are deferred follow-ups.
+//
+// Design: docs/adr/0008-channel-adapter.md.
+package telegram

--- a/agents/peggy/cmd/peggy-telegram/main.go
+++ b/agents/peggy/cmd/peggy-telegram/main.go
@@ -1,0 +1,111 @@
+// Command peggy-telegram is the binary form of the Telegram channel
+// adapter. It loads Peggy's settings, constructs the agent, decodes
+// the channel config, and runs the Telegram poll loop until SIGINT /
+// SIGTERM.
+//
+// Usage:
+//
+//	export PEGGY_TELEGRAM_TOKEN=<BotFather token>
+//	# Optional: ~/.config/peggy/settings.json with channels.telegram block
+//	peggy-telegram
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/erain/glue/agents/peggy"
+	"github.com/erain/glue/agents/peggy/channels/telegram"
+)
+
+func main() {
+	os.Exit(run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(parent context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy-telegram", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath  = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		soulPath    = fs.String("soul", "", "path to identity Markdown")
+		showVersion = fs.Bool("version", false, "print version and exit")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy-telegram — Peggy reachable on Telegram.
+
+One-time setup:
+  1. Talk to @BotFather on Telegram and create a bot. Save the token.
+  2. Set PEGGY_TELEGRAM_TOKEN to that token (or whatever env var your
+     settings.json names under channels.telegram.bot_token_env).
+  3. Add your chat id to channels.telegram.allow_chats in settings.json.
+     (Send any message to your bot once, then check the getUpdates JSON
+     for your chat id.)
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if *showVersion {
+		fmt.Fprintln(stdout, peggy.Version)
+		return 0
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy-telegram: positional args not supported (the channel takes input from Telegram)")
+		return 2
+	}
+
+	settings, _, err := peggy.LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+		return 1
+	}
+	soul, _, err := peggy.LoadSoul(*soulPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+		return 1
+	}
+
+	p, err := peggy.New(peggy.Options{
+		Settings: settings,
+		Soul:     soul,
+		Stderr:   stderr,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: setup: %v\n", err)
+		return 1
+	}
+	defer p.Close()
+
+	cfg, err := telegram.DecodeConfig(settings.Channels[telegram.ChannelName])
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+		return 1
+	}
+	ch, err := telegram.New(telegram.Options{Peggy: p, Config: cfg, Stderr: stderr})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+		return 1
+	}
+
+	ctx, cancel := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	fmt.Fprintln(stderr, "peggy-telegram: listening for Telegram updates; SIGINT to stop.")
+	if err := ch.Run(ctx); err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stderr, "peggy-telegram: stopped.")
+	return 0
+}

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 )
 
+// ChannelConfig is the raw JSON for one channel's configuration,
+// keyed by channel name in Settings.Channels. Each channel package
+// (agents/peggy/channels/<name>) owns the schema and decodes its own
+// subtree.
+
 // Settings is the on-disk JSON shape of Peggy's config. All fields
 // are optional except where noted. The loader applies sensible
 // defaults via fillDefaults so a minimal `{}` settings.json works.
@@ -30,6 +35,12 @@ type Settings struct {
 	// Compaction tunes the SummarizingCompactor. Zero values fall
 	// back to the framework defaults (target 8000 / keep 8).
 	Compaction CompactionSettings `json:"compaction"`
+
+	// Channels carries per-channel configuration subtrees keyed by
+	// channel name (e.g. "telegram"). Each channel package decodes
+	// its own subtree via a DecodeConfig helper. Empty means "no
+	// channels configured".
+	Channels map[string]json.RawMessage `json:"channels,omitempty"`
 }
 
 // StoreSettings configures session persistence.

--- a/agents/peggy/settings_test.go
+++ b/agents/peggy/settings_test.go
@@ -238,7 +238,7 @@ func TestFillDefaults_NoOpWhenAllSet(t *testing.T) {
 		},
 	}
 	got := fillDefaults(s)
-	if got != s {
+	if got.Provider != s.Provider || got.Model != s.Model || got.Store != s.Store || got.Compaction != s.Compaction {
 		t.Errorf("fillDefaults mutated set values: %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary

After this PR **you can text your Peggy on Telegram** — the headline goal of M1. First concrete `peggy.Channel` adapter built on the ADR-0008 pattern.

**Setup**: BotFather → token → `export PEGGY_TELEGRAM_TOKEN=…` → add your chat id to `~/.config/peggy/settings.json`'s `channels.telegram.allow_chats` → run `peggy-telegram`. Empty `allow_chats` = refuse-all (the safe default).

```
peggy-telegram
peggy-telegram: listening for Telegram updates; SIGINT to stop.
```

**Library additions** (in `agents/peggy`):
- `Channel` interface (`Name() / Run(ctx)`) per ADR-0008.
- `ChannelSessionID(channel, id)` helper for the `<channel>:<id>` namespacing convention.
- `Settings.Channels` is now `map[string]json.RawMessage` — each channel package decodes its own subtree.

**New package `agents/peggy/channels/telegram`**:
- `Config` + `DecodeConfig` with documented defaults (`PEGGY_TELEGRAM_TOKEN`, long-poll 30s clamped to 60, empty `AllowChats` = refuse-all).
- Stdlib-only Bot API client (`api.go`): JSON-over-HTTPS, `getUpdates` and `sendMessage`. No third-party SDK. Bot token is never logged (`redactErr` scrubs `net/url` errors). 4096-byte message truncation with a `… [truncated]` suffix.
- `Channel{}` satisfying `peggy.Channel`. Long-poll loop with exponential backoff (1s → 30s cap) on transient errors, ctx-aware. Allowlist gating per ADR-0008 §5. Reply via `SendMessage` after the prompt completes; prompt-error fallback reply so users aren't left hanging.

**New binary `agents/peggy/cmd/peggy-telegram`**:
- Loads settings + identity (same resolution chain as `peggy` CLI), constructs the channel, runs it under a SIGINT/SIGTERM-cancellable context.

Closes #135. Tracker: #110.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  github.com/erain/glue/agents/peggy ...
ok  github.com/erain/glue/agents/peggy/channels/telegram  1.176s
(all packages pass)

$ go test -race ./agents/peggy/... -count=1 -timeout 120s
ok  github.com/erain/glue/agents/peggy                    2.607s
ok  github.com/erain/glue/agents/peggy/channels/telegram  2.215s

$ go build -o /tmp/peggy-telegram ./agents/peggy/cmd/peggy-telegram
$ /tmp/peggy-telegram --help
peggy-telegram — Peggy reachable on Telegram.
...
```

**20 new tests, race-clean:**

`agents/peggy/channel_test.go`:
- `TestChannelSessionID` — 5 cases including trim, lowercase, empty channel.
- `TestSettings_ChannelsRoundTrip` — raw subtree preserved verbatim for downstream decoding.

`agents/peggy/channels/telegram/config_test.go`:
- defaults, happy decode, long-poll clamp, invalid JSON, null payload tolerance.

`agents/peggy/channels/telegram/api_test.go`:
- `getUpdates` parses canned JSON, `sendMessage` POST shape verified, `sendMessage` truncation, non-OK envelope surfaces description, empty-token errors at call time, `redactErr` scrubs token from `net/url` error text.

`agents/peggy/channels/telegram/channel_test.go`:
- Allowed chat → provider invoked with correct text → reply sent → the namespaced session (`telegram:555`) is reachable via `Agent.Session` and contains the message.
- Non-allowlisted chat dropped (no provider call, no reply, stderr diagnostic).
- Empty `allow_chats` refuses all (with a startup diagnostic).
- Multiple updates per poll dispatched sequentially.
- `ctx.Cancel()` exits `Run` cleanly.
- Missing token errors at `New` time (not silently in the poll loop).
- Nil `Peggy` errors.
- Prompt-error fallback reply sent + diagnostic logged.

**Docs added:**
- `agents/peggy/channels/telegram/README.md`: BotFather setup, finding your chat id, settings reference, namespacing notes, v0.1 limitations, follow-ups (edit-in-place streaming, webhook mode, M2 Permission gate).
- `agents/peggy/README.md` "Channels" section now points concretely at the Telegram README.
- Root `README.md` "Agents" entry mentions `peggy-telegram`.

**No new dependencies.** Stdlib-only Telegram client.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` clean
- [x] `go test -race ./agents/peggy/...` clean
- [x] `peggy-telegram --help` / `--version` work
- [x] Allowlist enforced (refuse-all when empty)
- [x] No third-party deps (`go.mod` unchanged)
- [x] Bot token never appears in error messages (`redactErr` scrubs it)