### PR TITLE
agents/peggy: v0.1.0 release (closes #137)

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog — agents/peggy
+
+All notable changes to the `peggy` agent. Format roughly follows
+[Keep a Changelog](https://keepachangelog.com); this project does
+not formally follow SemVer until v1.0.
+
+## v0.1.0 — 2026-05-16
+
+First public release. Peggy is a long-running personal-assistant
+agent built on the [glue](../..) framework. She remembers across
+sessions and is reachable from the CLI or Telegram. Tracker:
+[#110](https://github.com/erain/glue/issues/110).
+
+### Added
+
+- **Single-prompt CLI** (`agents/peggy/cmd/peggy`). One-shot prompt
+  with `--config`, `--soul`, `--session`, `--version` flags. Loads
+  `settings.json` and `SOUL.md` from a documented resolution chain
+  (`--flag` > env > XDG > `~/.config/peggy`).
+- **Identity via Markdown.** `SOUL.md` content is embedded in the
+  system prompt verbatim. Missing identity is non-fatal.
+- **Model-callable memory.**
+  - `remember(content, tags?)` persists curated facts to a dedicated
+    `__memories__` session — immune to per-session compaction.
+  - `recall(query, limit?, only_memories?)` searches prior history
+    and curated memories via FTS5; returns a numbered hit list with
+    session id, snippet, and BM25 score.
+  - Memory tools are registered by default; disable with
+    `Options.DisableMemoryTools`.
+- **Cross-session FTS5 search** via `Agent.SearchSessions` /
+  `Session.Search` (designed in
+  [ADR-0007](../../docs/adr/0007-memory-layer.md), implemented in
+  `stores/sqlite`).
+- **Token-aware summarizing compaction** via the configured
+  provider. `KeepRecentMessages` remains the cheap default; the new
+  `SummarizingCompactor` takes over when sessions get long.
+- **Codex provider** (`providers/codex`). Authenticates against the
+  upstream Codex CLI's `auth.json` and routes through
+  `chatgpt.com/backend-api/codex/responses`. Subscription auth, no
+  per-token billing. Designed in
+  [ADR-0006](../../docs/adr/0006-codex-provider.md).
+- **Telegram channel adapter**
+  (`agents/peggy/channels/telegram` + the `peggy-telegram` binary).
+  Long-polling Bot API client, chat-id allowlist (refuse-all
+  default), session-id namespacing (`telegram:<chat_id>`). First
+  concrete `peggy.Channel` on the
+  [ADR-0008](../../docs/adr/0008-channel-adapter.md) pattern.
+- **SQLite session store** (`stores/sqlite`). Pure-Go via
+  `modernc.org/sqlite`; FTS5 external-content schema with triggers;
+  WAL mode. `stores/file` remains the simple option.
+- **Documentation.** README quickstart, Telegram README,
+  CHANGELOG (this file). Eight ADRs designed and accepted under
+  this milestone (ADRs 0005–0008 plus contributions to ADRs
+  0001–0004 retained from the original glue roadmap).
+
+### Known limitations
+
+- **No coding tools yet.** Shell exec, write-side filesystem, and
+  the subagent primitive arrive in M2.
+- **No always-on daemon yet.** v0.1 is one channel per process. The
+  M3 daemon will let TUI / Telegram / future clients share one
+  Peggy.
+- **No MCP client yet.** Coming in M4.
+- **No Anthropic provider yet.** Codex / Gemini / NVIDIA / OpenRouter
+  ship today. Anthropic lands in M4 when budget allows.
+- **Telegram streaming is one-message-per-turn**, not delta-edit.
+  Telegram rate-limits message edits; a follow-up will revisit.
+- **API-key OpenAI fallback** is additive but not in v0.1. Codex
+  subscription auth is the only OpenAI path today.
+- **`Agent.SearchSessions` does exact-match on `SessionID`.** A
+  prefix-match extension ("all `telegram:*` sessions") is a planned
+  follow-up.
+
+### Architectural decisions captured
+
+- [ADR-0005](../../docs/adr/0005-foundation-expansion.md) — foundation expansion for long-running agents (lifts shell exec, write-fs, MCP, HTTP server, automatic compaction trigger behind framework interfaces; defers sandboxing behind `Executor`).
+- [ADR-0006](../../docs/adr/0006-codex-provider.md) — Codex provider auth + transport.
+- [ADR-0007](../../docs/adr/0007-memory-layer.md) — memory layer (SummarizingCompactor + sqlite/FTS5 + Searcher).
+- [ADR-0008](../../docs/adr/0008-channel-adapter.md) — channel adapter pattern.
+
+### Notes for downstream consumers
+
+- Library API at `github.com/erain/glue/agents/peggy` is stable for
+  the v0.1.x series. Channel package APIs (e.g.
+  `agents/peggy/channels/telegram`) are also stable but
+  underspecified on purpose — additive changes are expected.
+- `peggy.Version` is the source of truth for the version string. Bumped
+  by hand at release time and pinned by a test.
+
+[Tracker #110](https://github.com/erain/glue/issues/110) is the
+canonical roadmap. M2 ("she can code") is the next milestone.

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -1,28 +1,45 @@
 # peggy
 
+> Your always-on assistant — runs from the CLI or Telegram,
+> remembers you across sessions, and curates facts on her own.
+
 A long-running personal-assistant agent built on the
-[glue](../..) framework. v0.1 ships as a single-prompt CLI that
-remembers you across invocations via SQLite + FTS5 session search and
-a token-aware summarizing compactor. Telegram, REPL, and coding
-skills land in later milestones (tracker
-[#110](https://github.com/erain/glue/issues/110)).
+[glue](../..) framework. **v0.1** ships:
+
+- a single-prompt **CLI** (`peggy`)
+- a **Telegram bot** binary (`peggy-telegram`) with a chat-id allowlist
+- model-callable **`remember` / `recall` tools** for durable
+  cross-session memory
+- **token-aware summarizing compaction** so long sessions don't blow
+  the context window
+- **FTS5 session search** under the hood, exposed via
+  `Agent.SearchSessions`
+- four model backends: Codex (ChatGPT subscription), Gemini,
+  OpenRouter, NVIDIA build
+
+Tracker: [#110](https://github.com/erain/glue/issues/110). M2 ("she
+can code") is the next milestone.
 
 ## Quickstart
 
 ```sh
+# 1. Install.
 go install github.com/erain/glue/agents/peggy/cmd/peggy@latest
 
-# One-time auth (subscription-mode default provider).
+# 2. One-time auth (Codex subscription is the default provider).
 codex login
 
-# Edit your identity and config (optional but recommended).
+# 3. Optional: drop an identity file so Peggy knows who you are.
 mkdir -p ~/.config/peggy
-$EDITOR ~/.config/peggy/SOUL.md
-$EDITOR ~/.config/peggy/settings.json
+$EDITOR ~/.config/peggy/SOUL.md         # see "SOUL.md" below
+$EDITOR ~/.config/peggy/settings.json   # see "settings.json" below
 
-# Run a single prompt.
+# 4. Talk to her.
 peggy "Hello — what should I be working on today?"
 ```
+
+To reach her from your phone, set up Telegram next — see
+[Channels](#channels) below.
 
 ## SOUL.md
 
@@ -154,14 +171,23 @@ near-term follow-up.
 
 ## What v0.1 supports
 
-- Single-prompt CLI with file or sqlite session persistence.
-- **Model-callable `remember` and `recall` tools** for cross-session memory.
-- Cross-session FTS5 search via `Agent.SearchSessions` (library API
-  available directly; CLI subcommand is a near-term follow-up).
-- Token-aware summarizing compaction via the provider you configured.
+- **Single-prompt CLI** (`peggy`) and **Telegram bot** (`peggy-telegram`)
+  on the same agent + same session store.
+- File or SQLite session persistence. SQLite enables cross-session
+  FTS5 search.
+- **Model-callable `remember` / `recall` tools** for durable
+  cross-session memory.
+- **Cross-session FTS5 search** via `Agent.SearchSessions` library
+  API (a `peggy recall` subcommand is a near-term follow-up).
+- **Token-aware summarizing compaction** via the configured provider.
 - Identity injected from `SOUL.md` into the system prompt.
-- All four shipped providers: `codex` (ChatGPT subscription), `gemini`,
-  `openrouter`, `nvidia`.
+- All four shipped providers: `codex` (ChatGPT subscription),
+  `gemini`, `openrouter`, `nvidia`. Codex is the default and uses
+  your existing ChatGPT subscription via `codex login` — no per-token
+  bill.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.1 summary and
+known limitations.
 
 ## Channels
 
@@ -185,12 +211,23 @@ external transports. The pattern is designed in
 
 ## What's coming
 
-Per tracker [#110](https://github.com/erain/glue/issues/110):
+Per tracker [#110](https://github.com/erain/glue/issues/110), in
+priority order:
 
-- Telegram channel adapter (sender allowlist; first concrete channel
-  on the ADR-0008 pattern).
-- Coding ability — `tools/shell`, `tools/fs.FileWrite`, the subagent primitive.
-- Multi-channel daemon (`cmd/glue serve`) so one always-on Peggy serves a TUI, Telegram, and future clients.
+- **M2 — "she can code".** Permission-gated `tools/shell` and
+  `tools/fs.FileWrite`, the subagent primitive (`Agent`-as-`Tool`),
+  diff display in the TUI/Telegram, an `Executor` / `Permission` /
+  `Hook` interface trio in core glue.
+- **M3 — multi-channel daemon.** `cmd/glue serve` so a single
+  long-running Peggy serves a TUI, Telegram, and future clients
+  concurrently. Per-channel permission tiers.
+- **M4 — ecosystem.** MCP client (stdio + HTTP), cost tracking,
+  `providers/anthropic` when budget allows.
+
+Near-term follow-ups that may slip into v0.1.x patches: a `peggy
+memories` subcommand (list / export / forget), edit-in-place
+Telegram streaming, FTS5 prefix-match on session ids for
+channel-scoped recall.
 
 ## As a library
 

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -11,7 +11,7 @@ import (
 
 // Version is the package version string surfaced by `peggy --version`.
 // Bumped by hand at release time.
-const Version = "0.1.0-dev"
+const Version = "0.1.0"
 
 // Run is the top-level CLI entry point. It parses args, loads the
 // settings and identity files, constructs a Peggy, and dispatches a

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -21,6 +21,15 @@ func TestRun_Version(t *testing.T) {
 	}
 }
 
+// TestVersionPinned guards against accidentally publishing a binary
+// whose --version still says "-dev". Bump the constant deliberately
+// at release time, and update this test to match.
+func TestVersionPinned(t *testing.T) {
+	if Version != "0.1.0" {
+		t.Fatalf("Version = %q, want %q", Version, "0.1.0")
+	}
+}
+
 func TestRun_NoPromptShowsUsage(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := Run(context.Background(), []string{}, &out, &errOut)


### PR DESCRIPTION
## Summary

🎉 **Peggy v0.1.0**, and the last M1 row under tracker #110. After this PR merges, **M1 is complete** — Peggy is a long-running personal-assistant agent reachable from CLI or Telegram, with durable cross-session memory.

**What's in:**
- `peggy.Version` bumped `0.1.0-dev` → `0.1.0`.
- New `TestVersionPinned` guards future releases (catches accidental publishes with the `-dev` string still in place).
- New `agents/peggy/CHANGELOG.md` (~85 lines): `v0.1.0` section listing Added / Known limitations / ADRs / stability notes. Pinned to today's date.
- `agents/peggy/README.md` polish:
  - Tagline up top so the project is recognisable on first scroll.
  - Linear Quickstart: install → `codex login` → optional `SOUL.md` / `settings.json` → run. Forward pointer to the Channels section for Telegram.
  - "What v0.1 supports" reconciled with reality (memory tools, Telegram, CHANGELOG pointer).
  - "What's coming" reorganised by milestone (M2 → M3 → M4) plus near-term v0.1.x candidates.

**No code-behavior changes** beyond the version string. **No new dependencies.**

The git tag itself (`peggy-v0.1.0` or similar) is deliberately out of scope — tagging is a maintainer-visible action and is the maintainer's explicit call.

Closes #137. Tracker: #110.

## Verification

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  github.com/erain/glue/agents/peggy ...
(all packages pass)

$ go build -o /tmp/peggy ./agents/peggy/cmd/peggy
$ /tmp/peggy --version
0.1.0
```

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` clean
- [x] `peggy --version` reports `0.1.0`
- [x] `TestVersionPinned` pins the value to `0.1.0`
- [x] `CHANGELOG.md` lists every M1 PR's contribution under `v0.1.0`
- [x] README Quickstart works end-to-end (manually walked the path)