### PR TITLE
glue: Executor + LocalExecutor (closes #143)

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -1,0 +1,177 @@
+package glue
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+)
+
+// DefaultExecMaxOutputBytes is the per-stream output cap used by
+// LocalExecutor when ExecCommand.MaxOutputBytes is zero.
+const DefaultExecMaxOutputBytes = 64 * 1024
+
+// Executor abstracts command execution for shell-capable tools. The
+// default implementation, LocalExecutor, runs commands on the local
+// machine; sandboxed or remote executors can implement the same
+// interface without changing tool code.
+type Executor interface {
+	Run(ctx context.Context, cmd ExecCommand) (ExecResult, error)
+}
+
+// ExecCommand describes one argv-style command execution request.
+type ExecCommand struct {
+	// Argv is the executable plus arguments. It must be non-empty and
+	// is never interpreted through a shell.
+	Argv []string
+
+	// Dir, when non-empty, is the child process working directory.
+	Dir string
+
+	// Env is the exact child environment. Nil means inherit no
+	// environment from the agent process.
+	Env []string
+
+	// Stdin, when non-nil, is connected to the child process stdin.
+	Stdin io.Reader
+
+	// Timeout limits this command independently from the caller's
+	// context. Zero means no executor-level timeout.
+	Timeout time.Duration
+
+	// MaxOutputBytes caps stdout and stderr independently. Zero uses
+	// DefaultExecMaxOutputBytes.
+	MaxOutputBytes int
+}
+
+// ExecResult is the captured result of one command execution.
+type ExecResult struct {
+	Stdout    []byte
+	Stderr    []byte
+	ExitCode  int
+	TimedOut  bool
+	Truncated bool
+}
+
+// LocalExecutor runs commands on the local machine with os/exec. It is
+// intentionally not a sandbox.
+type LocalExecutor struct{}
+
+var _ Executor = LocalExecutor{}
+
+// Run implements Executor.
+func (LocalExecutor) Run(ctx context.Context, cmd ExecCommand) (ExecResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if len(cmd.Argv) == 0 || cmd.Argv[0] == "" {
+		return ExecResult{ExitCode: -1}, errors.New("glue: exec argv is required")
+	}
+	if cmd.Timeout < 0 {
+		return ExecResult{ExitCode: -1}, errors.New("glue: exec timeout must be non-negative")
+	}
+	if cmd.MaxOutputBytes < 0 {
+		return ExecResult{ExitCode: -1}, errors.New("glue: exec max output bytes must be non-negative")
+	}
+
+	maxOutput := cmd.MaxOutputBytes
+	if maxOutput == 0 {
+		maxOutput = DefaultExecMaxOutputBytes
+	}
+
+	runCtx := ctx
+	cancel := func() {}
+	if cmd.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+	}
+	defer cancel()
+
+	c := exec.CommandContext(runCtx, cmd.Argv[0], cmd.Argv[1:]...)
+	if cmd.Dir != "" {
+		c.Dir = cmd.Dir
+	}
+	if cmd.Env == nil {
+		c.Env = []string{}
+	} else {
+		c.Env = append([]string(nil), cmd.Env...)
+	}
+	if cmd.Stdin != nil {
+		c.Stdin = cmd.Stdin
+	}
+
+	stdout := &limitedOutput{limit: maxOutput}
+	stderr := &limitedOutput{limit: maxOutput}
+	c.Stdout = stdout
+	c.Stderr = stderr
+
+	err := c.Run()
+	result := ExecResult{
+		Stdout:    stdout.Bytes(),
+		Stderr:    stderr.Bytes(),
+		ExitCode:  exitCode(c),
+		Truncated: stdout.Truncated() || stderr.Truncated(),
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return result, ctxErr
+	}
+	if cmd.Timeout > 0 && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		result.TimedOut = true
+		if result.ExitCode == 0 {
+			result.ExitCode = -1
+		}
+		return result, nil
+	}
+	if err == nil {
+		return result, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		result.ExitCode = exitErr.ExitCode()
+		return result, nil
+	}
+	return result, fmt.Errorf("glue: exec %q: %w", cmd.Argv[0], err)
+}
+
+func exitCode(c *exec.Cmd) int {
+	if c.ProcessState == nil {
+		return -1
+	}
+	return c.ProcessState.ExitCode()
+}
+
+type limitedOutput struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (w *limitedOutput) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	if originalLen == 0 {
+		return 0, nil
+	}
+	remaining := w.limit - w.buf.Len()
+	if remaining <= 0 {
+		w.truncated = true
+		return originalLen, nil
+	}
+	if len(p) > remaining {
+		w.truncated = true
+		p = p[:remaining]
+	}
+	_, _ = w.buf.Write(p)
+	return originalLen, nil
+}
+
+func (w *limitedOutput) Bytes() []byte {
+	return append([]byte(nil), w.buf.Bytes()...)
+}
+
+func (w *limitedOutput) Truncated() bool {
+	return w.truncated
+}

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,0 +1,237 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalExecutorCapturesStdoutStderr(t *testing.T) {
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv: helperArgv(t, "stdout-stderr"),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := string(res.Stdout), "stdout text"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := string(res.Stderr), "stderr text"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", res.ExitCode)
+	}
+}
+
+func TestLocalExecutorRejectsEmptyArgv(t *testing.T) {
+	_, err := LocalExecutor{}.Run(context.Background(), ExecCommand{})
+	if err == nil {
+		t.Fatal("Run returned nil error")
+	}
+}
+
+func TestLocalExecutorReturnsSetupFailureAsError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-executable")
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv: []string{missing},
+	})
+	if err == nil {
+		t.Fatal("Run returned nil error")
+	}
+	if res.ExitCode != -1 {
+		t.Fatalf("exit code = %d, want -1", res.ExitCode)
+	}
+}
+
+func TestLocalExecutorNonZeroExitIsResult(t *testing.T) {
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv: helperArgv(t, "exit", "7"),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ExitCode != 7 {
+		t.Fatalf("exit code = %d, want 7", res.ExitCode)
+	}
+	if got, want := string(res.Stderr), "exiting 7"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestLocalExecutorTimeoutIsResult(t *testing.T) {
+	start := time.Now()
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv:    helperArgv(t, "sleep", "2s"),
+		Timeout: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.TimedOut {
+		t.Fatal("TimedOut = false, want true")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("timeout took %s, want under 1s", elapsed)
+	}
+}
+
+func TestLocalExecutorCallerCancellationIsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := LocalExecutor{}.Run(ctx, ExecCommand{
+		Argv: helperArgv(t, "sleep", "2s"),
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", err)
+	}
+}
+
+func TestLocalExecutorTruncatesEachStream(t *testing.T) {
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv:           helperArgv(t, "large-output"),
+		MaxOutputBytes: 4,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := string(res.Stdout), "aaaa"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := string(res.Stderr), "bbbb"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if !res.Truncated {
+		t.Fatal("Truncated = false, want true")
+	}
+}
+
+func TestLocalExecutorStdin(t *testing.T) {
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv:  helperArgv(t, "stdin"),
+		Stdin: strings.NewReader("hello stdin"),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := string(res.Stdout), "hello stdin"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLocalExecutorDir(t *testing.T) {
+	dir := t.TempDir()
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv: helperArgv(t, "cwd"),
+		Dir:  dir,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := string(res.Stdout), dir; got != want {
+		t.Fatalf("cwd = %q, want %q", got, want)
+	}
+}
+
+func TestLocalExecutorEnvIsExact(t *testing.T) {
+	t.Setenv("GLUE_EXEC_PARENT_ONLY", "secret")
+
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv: helperArgv(t, "env", "GLUE_EXEC_PARENT_ONLY"),
+	})
+	if err != nil {
+		t.Fatalf("Run nil env: %v", err)
+	}
+	if got := string(res.Stdout); got != "" {
+		t.Fatalf("nil Env inherited parent value %q", got)
+	}
+
+	res, err = LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv: helperArgv(t, "env", "GLUE_EXEC_PARENT_ONLY"),
+		Env:  []string{"GLUE_EXEC_PARENT_ONLY=visible"},
+	})
+	if err != nil {
+		t.Fatalf("Run explicit env: %v", err)
+	}
+	if got, want := string(res.Stdout), "visible"; got != want {
+		t.Fatalf("env = %q, want %q", got, want)
+	}
+}
+
+func helperArgv(t *testing.T, mode string, args ...string) []string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	argv := []string{exe, "-test.run=TestLocalExecutorHelper", "--", mode}
+	return append(argv, args...)
+}
+
+func TestLocalExecutorHelper(t *testing.T) {
+	idx := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return
+	}
+	args := os.Args[idx+1:]
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, "missing helper mode")
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "stdout-stderr":
+		fmt.Fprint(os.Stdout, "stdout text")
+		fmt.Fprint(os.Stderr, "stderr text")
+	case "exit":
+		code := 1
+		if len(args) > 1 {
+			_, _ = fmt.Sscanf(args[1], "%d", &code)
+		}
+		fmt.Fprintf(os.Stderr, "exiting %d", code)
+		os.Exit(code)
+	case "sleep":
+		d := 2 * time.Second
+		if len(args) > 1 {
+			parsed, err := time.ParseDuration(args[1])
+			if err == nil {
+				d = parsed
+			}
+		}
+		time.Sleep(d)
+	case "large-output":
+		fmt.Fprint(os.Stdout, "aaaaaaaaaa")
+		fmt.Fprint(os.Stderr, "bbbbbbbbb")
+	case "stdin":
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+	case "cwd":
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "getwd: %v", err)
+			os.Exit(2)
+		}
+		fmt.Fprint(os.Stdout, wd)
+	case "env":
+		if len(args) < 2 {
+			fmt.Fprint(os.Stderr, "missing env key")
+			os.Exit(2)
+		}
+		fmt.Fprint(os.Stdout, os.Getenv(args[1]))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper mode %q", args[0])
+		os.Exit(2)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
## Summary

Adds the core `glue.Executor` contract from ADR-0009 plus `ExecCommand`, `ExecResult`, and the default unsandboxed `LocalExecutor` implementation. `LocalExecutor` runs argv-only commands with exact child env, optional working directory/stdin, timeout handling, separate stdout/stderr capture, non-zero exits as results, and per-stream output truncation.

Closes #143

## Verification

- `go test . -run TestLocalExecutor -count=1` — pass
- `go build ./...` — pass
- `go vet ./...` — pass
- `env -u NVIDIA_API_KEY go test ./...` — pass

One local `go test ./...` run with `NVIDIA_API_KEY` present hit `agents/glue-review/TestLiveReviewSmoke` provider 429 from NVIDIA. That is unrelated to this change; the non-live full suite passes with the local live key unset, and PR CI will report the live provider jobs separately.

## Follow-ups

Next M2 implementation issue after this merges: `glue.Permission` + `glue.Hook` + loop composition from ADR-0009.