### PR TITLE
glue: Permission Hook loop composition (closes #145)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -35,6 +35,8 @@ type AgentOptions struct {
 	Skills       map[string]Skill
 	Roles        []Role
 	Role         string
+	Permission   Permission
+	Hooks        []Hook
 
 	// Compactor, if non-nil and CompactionThreshold > 0, is invoked
 	// before every prompt whenever the in-memory transcript has more
@@ -56,6 +58,8 @@ type Agent struct {
 	store        Store
 	workDir      string
 	role         string
+	permission   Permission
+	hooks        []Hook
 
 	compactor           Compactor
 	compactionThreshold int
@@ -74,17 +78,19 @@ type Agent struct {
 // The Provider must be supplied for [Session.Prompt] to succeed.
 func NewAgent(options AgentOptions) *Agent {
 	return &Agent{
-		provider:     options.Provider,
-		model:        options.Model,
-		systemPrompt: options.SystemPrompt,
-		tools:        cloneTools(options.Tools),
-		options:      cloneMap(options.Options),
-		maxTurns:     options.MaxTurns,
+		provider:            options.Provider,
+		model:               options.Model,
+		systemPrompt:        options.SystemPrompt,
+		tools:               cloneTools(options.Tools),
+		options:             cloneMap(options.Options),
+		maxTurns:            options.MaxTurns,
 		store:               options.Store,
 		workDir:             options.WorkDir,
 		skills:              cloneSkills(options.Skills),
 		roles:               rolesFromSlice(options.Roles),
 		role:                options.Role,
+		permission:          options.Permission,
+		hooks:               cloneHooks(options.Hooks),
 		compactor:           options.Compactor,
 		compactionThreshold: options.CompactionThreshold,
 		sessions:            make(map[string]*Session),
@@ -247,5 +253,14 @@ func cloneMap(in map[string]any) map[string]any {
 	for k, v := range in {
 		out[k] = v
 	}
+	return out
+}
+
+func cloneHooks(in []Hook) []Hook {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Hook, len(in))
+	copy(out, in)
 	return out
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -37,6 +37,31 @@ func textTurn(text string) []ProviderEvent {
 	}
 }
 
+type recordingGluePermission struct {
+	requests []PermissionRequest
+	decision PermissionDecision
+}
+
+func (p *recordingGluePermission) Decide(_ context.Context, req PermissionRequest) (PermissionDecision, error) {
+	p.requests = append(p.requests, req)
+	return p.decision, nil
+}
+
+type recordingGlueHook struct {
+	pre  int
+	post int
+}
+
+func (h *recordingGlueHook) PreTool(context.Context, ToolCall) error {
+	h.pre++
+	return nil
+}
+
+func (h *recordingGlueHook) PostTool(_ context.Context, _ ToolCall, _ *ToolResult) error {
+	h.post++
+	return nil
+}
+
 func TestSessionPromptHappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -72,6 +97,56 @@ func TestSessionPromptHappyPath(t *testing.T) {
 	}
 	if got := provider.requests[0].Model; got != "fake-1" {
 		t.Fatalf("Model = %q, want fake-1", got)
+	}
+}
+
+func TestSessionPromptPassesPermissionHooksAndSessionID(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "c1", Name: "side", Arguments: []byte(`{"x":1}`)}},
+			{Type: ProviderEventDone},
+		},
+		textTurn("done"),
+	}}
+	perm := &recordingGluePermission{decision: PermissionDecision{Allow: true}}
+	hook := &recordingGlueHook{}
+	agent := NewAgent(AgentOptions{
+		Provider: provider,
+		Tools: []Tool{{
+			ToolSpec: ToolSpec{
+				Name:               "side",
+				RequiresPermission: true,
+				PermissionAction:   "touch",
+			},
+			Execute: func(context.Context, ToolCall) (ToolResult, error) {
+				return TextResult("ok"), nil
+			},
+		}},
+		Permission: perm,
+		Hooks:      []Hook{hook},
+	})
+	session, err := agent.Session(context.Background(), "dev-session")
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if _, err := session.Prompt(context.Background(), "go"); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(perm.requests) != 1 {
+		t.Fatalf("permission requests = %d, want 1", len(perm.requests))
+	}
+	if got := perm.requests[0].SessionID; got != "dev-session" {
+		t.Fatalf("SessionID = %q, want dev-session", got)
+	}
+	if got := perm.requests[0].Action; got != "touch" {
+		t.Fatalf("Action = %q, want touch", got)
+	}
+	if hook.pre != 1 || hook.post != 1 {
+		t.Fatalf("hook calls pre=%d post=%d, want 1/1", hook.pre, hook.post)
 	}
 }
 

--- a/loop/permission_test.go
+++ b/loop/permission_test.go
@@ -1,0 +1,308 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type recordingPermission struct {
+	requests []PermissionRequest
+	decision PermissionDecision
+	err      error
+}
+
+func (p *recordingPermission) Decide(_ context.Context, req PermissionRequest) (PermissionDecision, error) {
+	p.requests = append(p.requests, req)
+	if p.err != nil {
+		return PermissionDecision{}, p.err
+	}
+	return p.decision, nil
+}
+
+type hookFuncs struct {
+	pre  func(context.Context, ToolCall) error
+	post func(context.Context, ToolCall, *ToolResult) error
+}
+
+func (h hookFuncs) PreTool(ctx context.Context, call ToolCall) error {
+	if h.pre == nil {
+		return nil
+	}
+	return h.pre(ctx, call)
+}
+
+func (h hookFuncs) PostTool(ctx context.Context, call ToolCall, result *ToolResult) error {
+	if h.post == nil {
+		return nil
+	}
+	return h.post(ctx, call, result)
+}
+
+func runPermissionCase(t *testing.T, req RunRequest) RunResult {
+	t.Helper()
+	if req.Provider == nil {
+		req.Provider = scriptTwoToolCallsThenStop(ToolCall{ID: "c1", Name: "side", Arguments: json.RawMessage(`{"path":"a.txt"}`)})
+	}
+	res, err := Run(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	return res
+}
+
+func sideTool(executed *bool) Tool {
+	return Tool{
+		ToolSpec: ToolSpec{
+			Name:               "side",
+			RequiresPermission: true,
+			PermissionAction:   "write_file",
+			PermissionTarget: func(call ToolCall) string {
+				var args map[string]string
+				_ = json.Unmarshal(call.Arguments, &args)
+				return args["path"]
+			},
+		},
+		Execute: func(context.Context, ToolCall) (ToolResult, error) {
+			if executed != nil {
+				*executed = true
+			}
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: "ran"}}}, nil
+		},
+	}
+}
+
+func TestPermissionAllowBuildsRequestAndRuns(t *testing.T) {
+	t.Parallel()
+
+	var executed bool
+	perm := &recordingPermission{decision: PermissionDecision{Allow: true, RememberFor: RememberSession}}
+	res := runPermissionCase(t, RunRequest{
+		Provider:   scriptTwoToolCallsThenStop(ToolCall{ID: "c1", Name: "side", Arguments: json.RawMessage(`{"path":"a.txt"}`)}),
+		Tools:      []Tool{sideTool(&executed)},
+		SessionID:  "session-1",
+		Permission: perm,
+	})
+
+	if !executed {
+		t.Fatal("tool did not execute")
+	}
+	if got := res.NewMessages[1].Content[0].Text; got != "ran" {
+		t.Fatalf("tool result = %q, want ran", got)
+	}
+	if len(perm.requests) != 1 {
+		t.Fatalf("permission requests = %d, want 1", len(perm.requests))
+	}
+	req := perm.requests[0]
+	if req.Tool != "side" || req.Action != "write_file" || req.Target != "a.txt" || req.SessionID != "session-1" {
+		t.Fatalf("permission request = %+v", req)
+	}
+	if got := string(req.Args); got != `{"path":"a.txt"}` {
+		t.Fatalf("args = %q, want normalized object", got)
+	}
+}
+
+func TestPermissionNilDeniesSideEffectTool(t *testing.T) {
+	t.Parallel()
+
+	var executed bool
+	res := runPermissionCase(t, RunRequest{Tools: []Tool{sideTool(&executed)}})
+
+	if executed {
+		t.Fatal("tool executed without permission")
+	}
+	tool := res.NewMessages[1]
+	if !tool.IsError {
+		t.Fatal("IsError = false, want true")
+	}
+	if !strings.Contains(tool.Content[0].Text, "no permission handler") {
+		t.Fatalf("content = %q, want no permission handler", tool.Content[0].Text)
+	}
+}
+
+func TestReadOnlyToolBypassesNilPermission(t *testing.T) {
+	t.Parallel()
+
+	var executed bool
+	readOnly := Tool{
+		ToolSpec: ToolSpec{Name: "side"},
+		Execute: func(context.Context, ToolCall) (ToolResult, error) {
+			executed = true
+			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: "read"}}}, nil
+		},
+	}
+	res := runPermissionCase(t, RunRequest{Tools: []Tool{readOnly}})
+
+	if !executed {
+		t.Fatal("read-only tool did not execute")
+	}
+	if res.NewMessages[1].IsError {
+		t.Fatalf("read-only tool returned error: %q", res.NewMessages[1].Content[0].Text)
+	}
+}
+
+func TestPermissionDenyReturnsErrorAndRunsPostHook(t *testing.T) {
+	t.Parallel()
+
+	var executed bool
+	var postCalled bool
+	res := runPermissionCase(t, RunRequest{
+		Tools:      []Tool{sideTool(&executed)},
+		Permission: DenyAll{Reason: "not allowed"},
+		Hooks: []Hook{hookFuncs{post: func(_ context.Context, _ ToolCall, result *ToolResult) error {
+			postCalled = true
+			result.Content[0].Text += " (post)"
+			result.Metadata = map[string]any{"post": true}
+			return nil
+		}}},
+	})
+
+	if executed {
+		t.Fatal("denied tool executed")
+	}
+	if !postCalled {
+		t.Fatal("post hook did not run")
+	}
+	tool := res.NewMessages[1]
+	if !tool.IsError {
+		t.Fatal("IsError = false, want true")
+	}
+	if got, want := tool.Content[0].Text, "not allowed (post)"; got != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+	if tool.Metadata["post"] != true {
+		t.Fatalf("metadata = %#v, want post marker", tool.Metadata)
+	}
+}
+
+func TestHooksRunInOrderAroundTool(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+	h1 := hookFuncs{
+		pre: func(context.Context, ToolCall) error {
+			order = append(order, "pre1")
+			return nil
+		},
+		post: func(_ context.Context, _ ToolCall, result *ToolResult) error {
+			order = append(order, "post1")
+			result.Content[0].Text += ":post1"
+			return nil
+		},
+	}
+	h2 := hookFuncs{
+		pre: func(context.Context, ToolCall) error {
+			order = append(order, "pre2")
+			return nil
+		},
+		post: func(_ context.Context, _ ToolCall, result *ToolResult) error {
+			order = append(order, "post2")
+			result.Content[0].Text += ":post2"
+			return nil
+		},
+	}
+	tool := sideTool(nil)
+	tool.Execute = func(context.Context, ToolCall) (ToolResult, error) {
+		order = append(order, "execute")
+		return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: "base"}}}, nil
+	}
+
+	res := runPermissionCase(t, RunRequest{
+		Tools:      []Tool{tool},
+		Permission: AllowAll{},
+		Hooks:      []Hook{h1, h2},
+	})
+
+	wantOrder := []string{"pre1", "pre2", "execute", "post2", "post1"}
+	if strings.Join(order, ",") != strings.Join(wantOrder, ",") {
+		t.Fatalf("order = %v, want %v", order, wantOrder)
+	}
+	if got, want := res.NewMessages[1].Content[0].Text, "base:post2:post1"; got != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestHookSkipTool(t *testing.T) {
+	t.Parallel()
+
+	var executed bool
+	var permissionCalled bool
+	var postCalled bool
+	perm := permissionFunc(func(context.Context, PermissionRequest) (PermissionDecision, error) {
+		permissionCalled = true
+		return PermissionDecision{Allow: true}, nil
+	})
+	res := runPermissionCase(t, RunRequest{
+		Tools:      []Tool{sideTool(&executed)},
+		Permission: perm,
+		Hooks: []Hook{hookFuncs{
+			pre:  func(context.Context, ToolCall) error { return ErrSkipTool },
+			post: func(context.Context, ToolCall, *ToolResult) error { postCalled = true; return nil },
+		}},
+	})
+
+	if executed || permissionCalled || postCalled {
+		t.Fatalf("executed=%v permissionCalled=%v postCalled=%v, want all false", executed, permissionCalled, postCalled)
+	}
+	tool := res.NewMessages[1]
+	if !tool.IsError || tool.Content[0].Text != "tool skipped by hook" {
+		t.Fatalf("tool result = %+v, want skipped error", tool)
+	}
+}
+
+func TestHookAbortErrorsRun(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("pre failed")
+	_, err := Run(context.Background(), RunRequest{
+		Provider: scriptTwoToolCallsThenStop(ToolCall{ID: "c1", Name: "side", Arguments: json.RawMessage(`{}`)}),
+		Tools:    []Tool{sideTool(nil)},
+		Hooks:    []Hook{hookFuncs{pre: func(context.Context, ToolCall) error { return want }}},
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestPostHookAbortErrorsRun(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("post failed")
+	_, err := Run(context.Background(), RunRequest{
+		Provider:   scriptTwoToolCallsThenStop(ToolCall{ID: "c1", Name: "side", Arguments: json.RawMessage(`{}`)}),
+		Tools:      []Tool{sideTool(nil)},
+		Permission: AllowAll{},
+		Hooks:      []Hook{hookFuncs{post: func(context.Context, ToolCall, *ToolResult) error { return want }}},
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Run error = %v, want %v", err, want)
+	}
+}
+
+func TestToolSpecPermissionMetadataExcludedFromJSON(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(ToolSpec{
+		Name:               "side",
+		Description:        "desc",
+		Parameters:         json.RawMessage(`{"type":"object"}`),
+		RequiresPermission: true,
+		PermissionAction:   "exec",
+		PermissionTarget:   func(ToolCall) string { return "target" },
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(raw)
+	if strings.Contains(s, "RequiresPermission") || strings.Contains(s, "PermissionAction") || strings.Contains(s, "exec") {
+		t.Fatalf("marshaled ToolSpec leaked permission metadata: %s", s)
+	}
+}
+
+type permissionFunc func(context.Context, PermissionRequest) (PermissionDecision, error)
+
+func (f permissionFunc) Decide(ctx context.Context, req PermissionRequest) (PermissionDecision, error) {
+	return f(ctx, req)
+}

--- a/loop/run.go
+++ b/loop/run.go
@@ -33,6 +33,9 @@ type RunRequest struct {
 	Options      map[string]any
 	MaxTurns     int
 	Parallel     bool
+	SessionID    string
+	Permission   Permission
+	Hooks        []Hook
 	Emit         func(Event)
 }
 
@@ -65,6 +68,7 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 
 	messages := cloneMessages(req.Messages)
+	req.Hooks = cloneHooks(req.Hooks)
 	newMessages := make([]Message, 0)
 	emit := func(e Event) {
 		if req.Emit != nil {
@@ -144,6 +148,7 @@ func executeToolCalls(ctx context.Context, req RunRequest, calls []ToolCall, emi
 		call    ToolCall
 		out     ToolResult
 		message Message
+		err     error
 	}
 
 	results := make([]result, len(calls))
@@ -159,11 +164,12 @@ func executeToolCalls(ctx context.Context, req RunRequest, calls []ToolCall, emi
 			wg.Add(1)
 			go func(i int, call ToolCall) {
 				defer wg.Done()
-				normalizedCall, toolResult := executeToolCall(ctx, req.Tools, call)
+				normalizedCall, toolResult, err := executeToolCall(ctx, req, call)
 				results[i] = result{
 					call:    normalizedCall,
 					out:     toolResult,
 					message: toolResultMessage(normalizedCall, toolResult),
+					err:     err,
 				}
 			}(i, call)
 		}
@@ -179,7 +185,10 @@ func executeToolCalls(ctx context.Context, req RunRequest, calls []ToolCall, emi
 				ToolCallID: call.ID,
 				ToolName:   call.Name,
 			})
-			normalizedCall, toolResult := executeToolCall(ctx, req.Tools, call)
+			normalizedCall, toolResult, err := executeToolCall(ctx, req, call)
+			if err != nil {
+				return nil, err
+			}
 			results[i] = result{
 				call:    normalizedCall,
 				out:     toolResult,
@@ -194,6 +203,9 @@ func executeToolCalls(ctx context.Context, req RunRequest, calls []ToolCall, emi
 
 	messages := make([]Message, len(results))
 	for i, r := range results {
+		if r.err != nil {
+			return nil, r.err
+		}
 		messages[i] = r.message
 		emit(Event{
 			Type:       EventToolEnd,
@@ -214,26 +226,103 @@ func executeToolCalls(ctx context.Context, req RunRequest, calls []ToolCall, emi
 //
 // The first return value is the (possibly argument-normalized) tool call
 // that should be referenced by the resulting tool message.
-func executeToolCall(ctx context.Context, tools []Tool, call ToolCall) (ToolCall, ToolResult) {
+func executeToolCall(ctx context.Context, req RunRequest, call ToolCall) (ToolCall, ToolResult, error) {
 	normalizedCall, err := normalizeToolCallArguments(call)
 	if err != nil {
-		return call, errorToolResult(fmt.Sprintf("invalid arguments for tool %q: %v", call.Name, err))
+		return call, errorToolResult(fmt.Sprintf("invalid arguments for tool %q: %v", call.Name, err)), nil
 	}
 
-	for _, tool := range tools {
+	for _, tool := range req.Tools {
 		if tool.Name != normalizedCall.Name {
 			continue
 		}
-		if tool.Execute == nil {
-			return normalizedCall, errorToolResult(fmt.Sprintf("tool %q has no executor", normalizedCall.Name))
-		}
-		result, err := tool.Execute(ctx, normalizedCall)
-		if err != nil {
-			return normalizedCall, errorToolResult(err.Error())
-		}
-		return normalizedCall, result
+		result, err := executeKnownToolCall(ctx, req, tool, normalizedCall)
+		return normalizedCall, result, err
 	}
-	return normalizedCall, errorToolResult(fmt.Sprintf("unknown tool %q", normalizedCall.Name))
+	return normalizedCall, errorToolResult(fmt.Sprintf("unknown tool %q", normalizedCall.Name)), nil
+}
+
+func executeKnownToolCall(ctx context.Context, req RunRequest, tool Tool, call ToolCall) (ToolResult, error) {
+	for _, hook := range req.Hooks {
+		if hook == nil {
+			continue
+		}
+		if err := hook.PreTool(ctx, call); err != nil {
+			if errors.Is(err, ErrSkipTool) {
+				return errorToolResult("tool skipped by hook"), nil
+			}
+			return ToolResult{}, err
+		}
+	}
+
+	var result ToolResult
+	if tool.RequiresPermission {
+		decision, err := decidePermission(ctx, req, tool, call)
+		if err != nil {
+			return ToolResult{}, err
+		}
+		if !decision.Allow {
+			reason := decision.Reason
+			if reason == "" {
+				reason = "permission denied"
+			}
+			result = errorToolResult(reason)
+			return runPostToolHooks(ctx, req.Hooks, call, result)
+		}
+	}
+
+	if tool.Execute == nil {
+		result = errorToolResult(fmt.Sprintf("tool %q has no executor", call.Name))
+		return runPostToolHooks(ctx, req.Hooks, call, result)
+	}
+
+	var err error
+	result, err = tool.Execute(ctx, call)
+	if err != nil {
+		result = errorToolResult(err.Error())
+	}
+	return runPostToolHooks(ctx, req.Hooks, call, result)
+}
+
+func decidePermission(ctx context.Context, req RunRequest, tool Tool, call ToolCall) (PermissionDecision, error) {
+	if req.Permission == nil {
+		return PermissionDecision{Allow: false, Reason: "permission denied: no permission handler configured"}, nil
+	}
+	return req.Permission.Decide(ctx, permissionRequest(req, tool, call))
+}
+
+func permissionRequest(req RunRequest, tool Tool, call ToolCall) PermissionRequest {
+	action := tool.PermissionAction
+	if action == "" {
+		action = tool.Name
+	}
+	target := ""
+	if tool.PermissionTarget != nil {
+		target = tool.PermissionTarget(call)
+	}
+	if target == "" {
+		target = string(call.Arguments)
+	}
+	return PermissionRequest{
+		Tool:      tool.Name,
+		Action:    action,
+		Target:    target,
+		Args:      append(json.RawMessage(nil), call.Arguments...),
+		SessionID: req.SessionID,
+	}
+}
+
+func runPostToolHooks(ctx context.Context, hooks []Hook, call ToolCall, result ToolResult) (ToolResult, error) {
+	for i := len(hooks) - 1; i >= 0; i-- {
+		hook := hooks[i]
+		if hook == nil {
+			continue
+		}
+		if err := hook.PostTool(ctx, call, &result); err != nil {
+			return ToolResult{}, err
+		}
+	}
+	return result, nil
 }
 
 // normalizeToolCallArguments enforces that arguments are a JSON object and
@@ -433,6 +522,15 @@ func toolSpecs(tools []Tool) []ToolSpec {
 		specs = append(specs, tool.ToolSpec)
 	}
 	return specs
+}
+
+func cloneHooks(hooks []Hook) []Hook {
+	if len(hooks) == 0 {
+		return nil
+	}
+	out := make([]Hook, len(hooks))
+	copy(out, hooks)
+	return out
 }
 
 func cloneMessages(messages []Message) []Message {

--- a/loop/types.go
+++ b/loop/types.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 )
 
@@ -100,6 +101,10 @@ type ToolSpec struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	Parameters  json.RawMessage `json:"parameters,omitempty"`
+
+	RequiresPermission bool                  `json:"-"`
+	PermissionAction   string                `json:"-"`
+	PermissionTarget   func(ToolCall) string `json:"-"`
 }
 
 // ToolExecutor runs a tool call locally and returns a normalized result.
@@ -118,6 +123,73 @@ type ToolResult struct {
 	Content  []ContentPart  `json:"content,omitempty"`
 	IsError  bool           `json:"is_error,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// Permission decides whether a side-effecting tool call may run.
+type Permission interface {
+	Decide(ctx context.Context, req PermissionRequest) (PermissionDecision, error)
+}
+
+// PermissionRequest describes one side-effecting tool call for the host.
+type PermissionRequest struct {
+	Tool      string          `json:"tool"`
+	Action    string          `json:"action"`
+	Target    string          `json:"target"`
+	Args      json.RawMessage `json:"args,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
+}
+
+// PermissionDecision is the host's answer to a PermissionRequest.
+type PermissionDecision struct {
+	Allow       bool          `json:"allow"`
+	Reason      string        `json:"reason,omitempty"`
+	RememberFor RememberScope `json:"remember_for,omitempty"`
+}
+
+// RememberScope tells a host permission implementation how broadly a
+// positive decision may be remembered. Core loop code does not cache
+// decisions.
+type RememberScope int
+
+const (
+	RememberNever RememberScope = iota
+	RememberSession
+	RememberSessionTarget
+	RememberForever
+)
+
+// AllowAll allows every PermissionRequest. It is intended for tests and
+// explicitly trusted hosts.
+type AllowAll struct{}
+
+// Decide implements Permission.
+func (AllowAll) Decide(context.Context, PermissionRequest) (PermissionDecision, error) {
+	return PermissionDecision{Allow: true}, nil
+}
+
+// DenyAll denies every PermissionRequest. It is intended for tests and
+// explicitly locked-down hosts.
+type DenyAll struct {
+	Reason string
+}
+
+// Decide implements Permission.
+func (d DenyAll) Decide(context.Context, PermissionRequest) (PermissionDecision, error) {
+	reason := d.Reason
+	if reason == "" {
+		reason = "permission denied"
+	}
+	return PermissionDecision{Allow: false, Reason: reason}, nil
+}
+
+// ErrSkipTool returned from Hook.PreTool records a skipped tool call as
+// an error tool result without executing the tool.
+var ErrSkipTool = errors.New("glue: skip tool")
+
+// Hook observes or alters tool-call execution.
+type Hook interface {
+	PreTool(ctx context.Context, call ToolCall) error
+	PostTool(ctx context.Context, call ToolCall, result *ToolResult) error
 }
 
 // ProviderRequest is the normalized input sent to a provider for one assistant

--- a/session.go
+++ b/session.go
@@ -201,6 +201,9 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 		Tools:        config.tools,
 		Options:      config.options,
 		MaxTurns:     config.maxTurns,
+		SessionID:    s.id,
+		Permission:   s.agent.permission,
+		Hooks:        cloneHooks(s.agent.hooks),
 		Emit: func(event Event) {
 			if config.emit != nil {
 				config.emit(event)

--- a/types.go
+++ b/types.go
@@ -5,18 +5,25 @@ import "github.com/erain/glue/loop"
 // Re-export the loop package's normalized types as part of the public API so
 // callers only need to import `glue`.
 type (
-	Message      = loop.Message
-	MessageRole  = loop.MessageRole
-	ContentPart  = loop.ContentPart
-	ContentType  = loop.ContentType
-	ImageContent = loop.ImageContent
-	ToolCall     = loop.ToolCall
-	ToolResult   = loop.ToolResult
-	ToolSpec     = loop.ToolSpec
-	ToolExecutor = loop.ToolExecutor
-	Tool         = loop.Tool
-	Usage        = loop.Usage
-	StopReason   = loop.StopReason
+	Message            = loop.Message
+	MessageRole        = loop.MessageRole
+	ContentPart        = loop.ContentPart
+	ContentType        = loop.ContentType
+	ImageContent       = loop.ImageContent
+	ToolCall           = loop.ToolCall
+	ToolResult         = loop.ToolResult
+	ToolSpec           = loop.ToolSpec
+	ToolExecutor       = loop.ToolExecutor
+	Tool               = loop.Tool
+	Usage              = loop.Usage
+	StopReason         = loop.StopReason
+	Permission         = loop.Permission
+	PermissionRequest  = loop.PermissionRequest
+	PermissionDecision = loop.PermissionDecision
+	RememberScope      = loop.RememberScope
+	AllowAll           = loop.AllowAll
+	DenyAll            = loop.DenyAll
+	Hook               = loop.Hook
 
 	ProviderRequest   = loop.ProviderRequest
 	Provider          = loop.Provider
@@ -26,6 +33,17 @@ type (
 	Event     = loop.Event
 	EventType = loop.EventType
 )
+
+// RememberScope constants re-exported from package loop.
+const (
+	RememberNever         = loop.RememberNever
+	RememberSession       = loop.RememberSession
+	RememberSessionTarget = loop.RememberSessionTarget
+	RememberForever       = loop.RememberForever
+)
+
+// ErrSkipTool re-exported from package loop.
+var ErrSkipTool = loop.ErrSkipTool
 
 // MessageRole constants re-exported from package loop.
 const (


### PR DESCRIPTION
## Summary

Implements the ADR-0009 Permission + Hook loop layer. Adds Permission/Hook/RememberScope/AllowAll/DenyAll/ErrSkipTool to `loop` and re-exports them through `glue`, marks side-effecting tools through local-only `ToolSpec` metadata, and wires `AgentOptions.Permission` / `AgentOptions.Hooks` into `Session.Prompt` and `loop.RunRequest`.

Known side-effect tools now compose as Pre-Hook -> Permission -> Execute -> Post-Hook. Nil permission denies side-effect tools, read-only tools keep existing behavior, hook skip becomes a model-visible tool result, and hook/permission errors abort the run.

Closes #145

## Verification

- `go test ./loop .` — pass
- `go build ./...` — pass
- `go vet ./...` — pass
- `env -u NVIDIA_API_KEY go test ./...` — pass

The local environment still has `NVIDIA_API_KEY` set; exact `go test ./...` can enter `agents/glue-review/TestLiveReviewSmoke` and hit upstream NVIDIA rate limits. PR CI reports the live provider checks separately.

## Follow-ups

Next M2 implementation issue after this merges: `tools/shell.Exec` built on `glue.Executor` and this permission loop.