### PR TITLE
tools/shell: Exec tool (closes #147)

### DIFF
--- a/tools/shell/shell.go
+++ b/tools/shell/shell.go
@@ -1,0 +1,234 @@
+// Package shell provides permission-gated command execution tools for
+// agents that explicitly opt into local coding workflows.
+package shell
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/erain/glue"
+	tfs "github.com/erain/glue/tools/fs"
+)
+
+const (
+	// ToolName is the model-visible name of the shell execution tool.
+	ToolName = "shell_exec"
+
+	// DefaultTimeout caps a single shell_exec call when ExecOptions.Timeout
+	// is zero.
+	DefaultTimeout = 30 * time.Second
+)
+
+// ExecOptions configures Exec.
+type ExecOptions struct {
+	// Executor runs the validated command. Nil uses glue.LocalExecutor{}.
+	Executor glue.Executor
+
+	// WorkDir is the workspace root. Required.
+	WorkDir string
+
+	// Env is the exact child environment. The model cannot add env vars.
+	Env []string
+
+	// AllowedBinaries is a basename allowlist. Empty means deny all.
+	AllowedBinaries []string
+
+	// Timeout caps each command. Zero falls back to DefaultTimeout.
+	Timeout time.Duration
+
+	// MaxOutputBytes caps stdout and stderr independently. Zero falls
+	// back to glue.DefaultExecMaxOutputBytes.
+	MaxOutputBytes int
+}
+
+type execArgs struct {
+	Argv           []string `json:"argv"`
+	Dir            string   `json:"dir,omitempty"`
+	Stdin          string   `json:"stdin,omitempty"`
+	MaxOutputBytes int      `json:"max_output_bytes,omitempty"`
+}
+
+// Exec returns a glue.Tool named "shell_exec" that runs argv-style
+// commands through a glue.Executor after validating workspace and binary
+// bounds. The tool is permission-gated via ToolSpec metadata.
+func Exec(opts ExecOptions) (glue.Tool, error) {
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		return glue.Tool{}, errors.New("shell: WorkDir is required")
+	}
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return glue.Tool{}, fmt.Errorf("shell: resolve WorkDir: %w", err)
+	}
+	timeout := opts.Timeout
+	if timeout < 0 {
+		return glue.Tool{}, errors.New("shell: Timeout must be non-negative")
+	}
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+	maxOutput := opts.MaxOutputBytes
+	if maxOutput < 0 {
+		return glue.Tool{}, errors.New("shell: MaxOutputBytes must be non-negative")
+	}
+	if maxOutput == 0 {
+		maxOutput = glue.DefaultExecMaxOutputBytes
+	}
+	allowed, err := allowedBinaries(opts.AllowedBinaries)
+	if err != nil {
+		return glue.Tool{}, err
+	}
+	executor := opts.Executor
+	if executor == nil {
+		executor = glue.LocalExecutor{}
+	}
+	env := append([]string(nil), opts.Env...)
+
+	return glue.NewTool[execArgs](
+		glue.ToolSpec{
+			Name:               ToolName,
+			Description:        "Run a bounded argv-style command in the configured workspace. Requires permission. Commands are not run through a shell; argv[0] must be an allowed binary basename.",
+			RequiresPermission: true,
+			PermissionAction:   "exec",
+			PermissionTarget:   permissionTarget,
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "argv": { "type": "array", "items": { "type": "string" }, "description": "Executable basename plus arguments, e.g. [\"go\", \"test\", \"./...\"]. argv[0] must be allowlisted." },
+    "dir": { "type": "string", "description": "Optional working directory relative to the configured workspace root." },
+    "stdin": { "type": "string", "description": "Optional stdin text." },
+    "max_output_bytes": { "type": "integer", "description": "Optional per-stream output cap. May only lower the host-configured cap." }
+  },
+  "required": ["argv"]
+}`),
+		},
+		func(ctx context.Context, args execArgs) (glue.ToolResult, error) {
+			cmd, err := buildCommand(args, absWorkDir, env, timeout, maxOutput, allowed)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			result, err := executor.Run(ctx, cmd)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return formatResult(cmd, result), nil
+		},
+	), nil
+}
+
+func buildCommand(args execArgs, workDir string, env []string, timeout time.Duration, maxOutput int, allowed map[string]struct{}) (glue.ExecCommand, error) {
+	if len(args.Argv) == 0 {
+		return glue.ExecCommand{}, errors.New("shell: argv is required")
+	}
+	argv := append([]string(nil), args.Argv...)
+	bin := strings.TrimSpace(argv[0])
+	if bin == "" {
+		return glue.ExecCommand{}, errors.New("shell: argv[0] is required")
+	}
+	if hasPathSeparator(bin) {
+		return glue.ExecCommand{}, fmt.Errorf("shell: argv[0] %q must be a binary basename, not a path", argv[0])
+	}
+	if _, ok := allowed[bin]; !ok {
+		return glue.ExecCommand{}, fmt.Errorf("shell: binary %q is not allowed", bin)
+	}
+	argv[0] = bin
+
+	dir := workDir
+	if strings.TrimSpace(args.Dir) != "" {
+		resolved, err := tfs.SafeJoin(workDir, args.Dir)
+		if err != nil {
+			return glue.ExecCommand{}, err
+		}
+		dir = resolved
+	}
+
+	effectiveMax := maxOutput
+	if args.MaxOutputBytes < 0 {
+		return glue.ExecCommand{}, errors.New("shell: max_output_bytes must be non-negative")
+	}
+	if args.MaxOutputBytes > 0 && args.MaxOutputBytes < effectiveMax {
+		effectiveMax = args.MaxOutputBytes
+	}
+
+	var stdin io.Reader
+	if args.Stdin != "" {
+		stdin = strings.NewReader(args.Stdin)
+	}
+	return glue.ExecCommand{
+		Argv:           argv,
+		Dir:            dir,
+		Env:            append([]string(nil), env...),
+		Stdin:          stdin,
+		Timeout:        timeout,
+		MaxOutputBytes: effectiveMax,
+	}, nil
+}
+
+func allowedBinaries(in []string) (map[string]struct{}, error) {
+	out := make(map[string]struct{}, len(in))
+	for _, raw := range in {
+		bin := strings.TrimSpace(raw)
+		if bin == "" {
+			continue
+		}
+		if hasPathSeparator(bin) {
+			return nil, fmt.Errorf("shell: allowed binary %q must be a basename", raw)
+		}
+		out[bin] = struct{}{}
+	}
+	return out, nil
+}
+
+func hasPathSeparator(s string) bool {
+	return strings.ContainsAny(s, `/\`)
+}
+
+func permissionTarget(call glue.ToolCall) string {
+	var args execArgs
+	if err := json.Unmarshal(call.Arguments, &args); err != nil || len(args.Argv) == 0 {
+		return ToolName
+	}
+	return strings.Join(args.Argv, " ")
+}
+
+func formatResult(cmd glue.ExecCommand, result glue.ExecResult) glue.ToolResult {
+	text := renderResult(result)
+	return glue.ToolResult{
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
+		IsError: result.ExitCode != 0 || result.TimedOut,
+		Metadata: map[string]any{
+			"argv":         append([]string(nil), cmd.Argv...),
+			"dir":          cmd.Dir,
+			"exit_code":    result.ExitCode,
+			"timed_out":    result.TimedOut,
+			"truncated":    result.Truncated,
+			"stdout_bytes": len(result.Stdout),
+			"stderr_bytes": len(result.Stderr),
+		},
+	}
+}
+
+func renderResult(result glue.ExecResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit_code: %d\n", result.ExitCode)
+	fmt.Fprintf(&b, "timed_out: %t\n", result.TimedOut)
+	fmt.Fprintf(&b, "truncated: %t\n\n", result.Truncated)
+	writeStream(&b, "stdout", result.Stdout)
+	b.WriteByte('\n')
+	writeStream(&b, "stderr", result.Stderr)
+	return b.String()
+}
+
+func writeStream(b *strings.Builder, name string, data []byte) {
+	if len(data) == 0 {
+		fmt.Fprintf(b, "%s: (empty)\n", name)
+		return
+	}
+	fmt.Fprintf(b, "%s:\n%s\n", name, string(data))
+}

--- a/tools/shell/shell_test.go
+++ b/tools/shell/shell_test.go
@@ -1,0 +1,240 @@
+package shell
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+type fakeExecutor struct {
+	result glue.ExecResult
+	err    error
+
+	commands []glue.ExecCommand
+	stdin    []string
+}
+
+func (f *fakeExecutor) Run(_ context.Context, cmd glue.ExecCommand) (glue.ExecResult, error) {
+	f.commands = append(f.commands, cmd)
+	if cmd.Stdin != nil {
+		data, _ := io.ReadAll(cmd.Stdin)
+		f.stdin = append(f.stdin, string(data))
+	} else {
+		f.stdin = append(f.stdin, "")
+	}
+	if f.err != nil {
+		return glue.ExecResult{}, f.err
+	}
+	return f.result, nil
+}
+
+func TestExecToolSpecPermissionMetadata(t *testing.T) {
+	tool, err := Exec(ExecOptions{WorkDir: t.TempDir(), AllowedBinaries: []string{"go"}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if tool.Name != ToolName {
+		t.Fatalf("tool name = %q, want %q", tool.Name, ToolName)
+	}
+	if !tool.RequiresPermission {
+		t.Fatal("RequiresPermission = false, want true")
+	}
+	if tool.PermissionAction != "exec" {
+		t.Fatalf("PermissionAction = %q, want exec", tool.PermissionAction)
+	}
+	got := tool.PermissionTarget(glue.ToolCall{Arguments: json.RawMessage(`{"argv":["go","test","./..."]}`)})
+	if got != "go test ./..." {
+		t.Fatalf("PermissionTarget = %q, want command preview", got)
+	}
+}
+
+func TestExecBuildsCommand(t *testing.T) {
+	work := t.TempDir()
+	fake := &fakeExecutor{result: glue.ExecResult{Stdout: []byte("ok\n"), Stderr: []byte("warn\n")}}
+	tool, err := Exec(ExecOptions{
+		Executor:        fake,
+		WorkDir:         work,
+		Env:             []string{"A=B"},
+		AllowedBinaries: []string{"go"},
+		Timeout:         5 * time.Second,
+		MaxOutputBytes:  100,
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	res := callTool(t, tool, `{"argv":["go","test","./pkg"],"dir":"sub","stdin":"input","max_output_bytes":10}`)
+	if res.IsError {
+		t.Fatalf("IsError = true, want false; text=%q", res.Content[0].Text)
+	}
+	if len(fake.commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(fake.commands))
+	}
+	cmd := fake.commands[0]
+	if !reflect.DeepEqual(cmd.Argv, []string{"go", "test", "./pkg"}) {
+		t.Fatalf("argv = %#v", cmd.Argv)
+	}
+	if want := filepath.Join(work, "sub"); cmd.Dir != want {
+		t.Fatalf("dir = %q, want %q", cmd.Dir, want)
+	}
+	if !reflect.DeepEqual(cmd.Env, []string{"A=B"}) {
+		t.Fatalf("env = %#v", cmd.Env)
+	}
+	if cmd.Timeout != 5*time.Second {
+		t.Fatalf("timeout = %s, want 5s", cmd.Timeout)
+	}
+	if cmd.MaxOutputBytes != 10 {
+		t.Fatalf("max output = %d, want 10", cmd.MaxOutputBytes)
+	}
+	if fake.stdin[0] != "input" {
+		t.Fatalf("stdin = %q, want input", fake.stdin[0])
+	}
+	if got := res.Metadata["stdout_bytes"]; got != 3 {
+		t.Fatalf("stdout_bytes = %#v, want 3", got)
+	}
+}
+
+func TestExecMaxOutputCannotRaiseHostCap(t *testing.T) {
+	fake := &fakeExecutor{}
+	tool, err := Exec(ExecOptions{
+		Executor:        fake,
+		WorkDir:         t.TempDir(),
+		AllowedBinaries: []string{"go"},
+		MaxOutputBytes:  10,
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	callTool(t, tool, `{"argv":["go"],"max_output_bytes":100}`)
+	if got := fake.commands[0].MaxOutputBytes; got != 10 {
+		t.Fatalf("max output = %d, want host cap 10", got)
+	}
+}
+
+func TestExecValidationErrors(t *testing.T) {
+	work := t.TempDir()
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"missing argv", `{}`, "argv is required"},
+		{"empty binary", `{"argv":[""]}`, "argv[0] is required"},
+		{"path binary", `{"argv":["./go"]}`, "must be a binary basename"},
+		{"disallowed binary", `{"argv":["rm","-rf","."]}`, "not allowed"},
+		{"dir escape", `{"argv":["go"],"dir":"../outside"}`, "escapes work directory"},
+		{"negative max output", `{"argv":["go"],"max_output_bytes":-1}`, "non-negative"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeExecutor{}
+			tool, err := Exec(ExecOptions{Executor: fake, WorkDir: work, AllowedBinaries: []string{"go"}})
+			if err != nil {
+				t.Fatalf("Exec: %v", err)
+			}
+			res := callTool(t, tool, tc.args)
+			if !res.IsError {
+				t.Fatalf("IsError = false, want true")
+			}
+			if !strings.Contains(res.Content[0].Text, tc.want) {
+				t.Fatalf("content = %q, want %q", res.Content[0].Text, tc.want)
+			}
+			if len(fake.commands) != 0 {
+				t.Fatalf("executor called for invalid request")
+			}
+		})
+	}
+}
+
+func TestExecConstructorValidation(t *testing.T) {
+	if _, err := Exec(ExecOptions{}); err == nil {
+		t.Fatal("empty WorkDir error = nil")
+	}
+	if _, err := Exec(ExecOptions{WorkDir: t.TempDir(), Timeout: -1}); err == nil {
+		t.Fatal("negative Timeout error = nil")
+	}
+	if _, err := Exec(ExecOptions{WorkDir: t.TempDir(), MaxOutputBytes: -1}); err == nil {
+		t.Fatal("negative MaxOutputBytes error = nil")
+	}
+	if _, err := Exec(ExecOptions{WorkDir: t.TempDir(), AllowedBinaries: []string{"./go"}}); err == nil {
+		t.Fatal("path-shaped allowed binary error = nil")
+	}
+}
+
+func TestExecNonZeroExitAndTimeoutAreErrorResults(t *testing.T) {
+	nonzero := callWithFakeResult(t, glue.ExecResult{ExitCode: 2, Stdout: []byte("fail\n")})
+	if !nonzero.IsError {
+		t.Fatal("nonzero IsError = false, want true")
+	}
+	if nonzero.Metadata["exit_code"] != 2 {
+		t.Fatalf("exit_code metadata = %#v, want 2", nonzero.Metadata["exit_code"])
+	}
+
+	timedOut := callWithFakeResult(t, glue.ExecResult{ExitCode: -1, TimedOut: true, Stderr: []byte("killed\n")})
+	if !timedOut.IsError {
+		t.Fatal("timeout IsError = false, want true")
+	}
+	if timedOut.Metadata["timed_out"] != true {
+		t.Fatalf("timed_out metadata = %#v, want true", timedOut.Metadata["timed_out"])
+	}
+}
+
+func TestExecExecutorErrorIsToolError(t *testing.T) {
+	fake := &fakeExecutor{err: errors.New("spawn failed")}
+	tool, err := Exec(ExecOptions{Executor: fake, WorkDir: t.TempDir(), AllowedBinaries: []string{"go"}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	res := callTool(t, tool, `{"argv":["go"]}`)
+	if !res.IsError {
+		t.Fatal("IsError = false, want true")
+	}
+	if !strings.Contains(res.Content[0].Text, "spawn failed") {
+		t.Fatalf("content = %q, want spawn failed", res.Content[0].Text)
+	}
+}
+
+func TestExecOutputFormatting(t *testing.T) {
+	res := callWithFakeResult(t, glue.ExecResult{
+		Stdout:    []byte("out"),
+		Stderr:    []byte("err"),
+		ExitCode:  0,
+		Truncated: true,
+	})
+	text := res.Content[0].Text
+	for _, want := range []string{"exit_code: 0", "timed_out: false", "truncated: true", "stdout:\nout", "stderr:\nerr"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output %q missing %q", text, want)
+		}
+	}
+	if res.Metadata["truncated"] != true {
+		t.Fatalf("truncated metadata = %#v, want true", res.Metadata["truncated"])
+	}
+}
+
+func callWithFakeResult(t *testing.T, result glue.ExecResult) glue.ToolResult {
+	t.Helper()
+	fake := &fakeExecutor{result: result}
+	tool, err := Exec(ExecOptions{Executor: fake, WorkDir: t.TempDir(), AllowedBinaries: []string{"go"}})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	return callTool(t, tool, `{"argv":["go"]}`)
+}
+
+func callTool(t *testing.T, tool glue.Tool, args string) glue.ToolResult {
+	t.Helper()
+	res, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name, Arguments: json.RawMessage(args)})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return res
+}


### PR DESCRIPTION
## Summary

Adds `tools/shell.Exec`, a permission-gated `shell_exec` tool built on `glue.Executor`. The tool validates argv-only commands, rejects path-shaped binaries, enforces a basename allowlist, keeps cwd under a configured workspace root, uses host-provided env only, applies timeout/output caps, and returns stdout/stderr/exit/timed-out/truncation in text plus metadata.

Closes #147

## Verification

- `go test ./tools/shell` — pass
- `go build ./...` — pass
- `go vet ./...` — pass
- `env -u NVIDIA_API_KEY go test ./...` — pass

The local environment still has `NVIDIA_API_KEY` set; exact `go test ./...` can enter the live NVIDIA smoke and hit upstream rate limits. PR CI reports the live provider checks separately.

## Follow-ups

Next M2 implementation issue after this merges: `tools/fs.FileWrite`.