### PR TITLE
tools/fs: FileWrite tool (closes #149)

### DIFF
--- a/tools/fs/write.go
+++ b/tools/fs/write.go
@@ -1,0 +1,290 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/erain/glue"
+)
+
+// DefaultWriteMaxBytes caps a single write_file call when
+// FileWriteOptions.MaxBytes is zero.
+const DefaultWriteMaxBytes = 1024 * 1024
+
+// FileWriteOptions configures FileWrite.
+type FileWriteOptions struct {
+	// WorkDir is the root the tool writes under. Required.
+	WorkDir string
+
+	// AllowOverwrite is the host-level overwrite policy. Existing files
+	// are overwritten only when this is true and the tool call also sets
+	// overwrite=true.
+	AllowOverwrite bool
+
+	// MaxBytes caps content size. Zero falls back to DefaultWriteMaxBytes.
+	MaxBytes int
+
+	// Blocklist refuses paths matching these glob patterns. Pass
+	// fs.Default().Merge(extras...) to layer extras on top of the
+	// shipped defaults.
+	Blocklist Blocklist
+}
+
+type fileWriteArgs struct {
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Overwrite bool   `json:"overwrite,omitempty"`
+}
+
+// FileWrite returns a glue.Tool named "write_file" that writes UTF-8 text
+// inside opts.WorkDir using a temp-file-plus-rename flow. The tool is
+// permission-gated via ToolSpec metadata.
+func FileWrite(opts FileWriteOptions) (glue.Tool, error) {
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		return glue.Tool{}, errors.New("fs: WorkDir is required")
+	}
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return glue.Tool{}, fmt.Errorf("fs: resolve WorkDir: %w", err)
+	}
+	info, err := os.Stat(absWorkDir)
+	if err != nil {
+		return glue.Tool{}, fmt.Errorf("fs: stat WorkDir: %w", err)
+	}
+	if !info.IsDir() {
+		return glue.Tool{}, fmt.Errorf("fs: WorkDir %q is not a directory", absWorkDir)
+	}
+	max := opts.MaxBytes
+	if max < 0 {
+		return glue.Tool{}, errors.New("fs: MaxBytes must be non-negative")
+	}
+	if max == 0 {
+		max = DefaultWriteMaxBytes
+	}
+	blocklist := opts.Blocklist
+
+	return glue.NewTool[fileWriteArgs](
+		glue.ToolSpec{
+			Name:               "write_file",
+			Description:        "Write UTF-8 text to a file inside the configured workspace. Requires permission. Refuses path escape, symlink escape, oversized content, and overwrites unless explicitly allowed.",
+			RequiresPermission: true,
+			PermissionAction:   "write_file",
+			PermissionTarget:   fileWritePermissionTarget,
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "path": { "type": "string", "description": "Path relative to the configured workspace." },
+    "content": { "type": "string", "description": "Full file content to write." },
+    "overwrite": { "type": "boolean", "description": "Set true only when intentionally replacing an existing file. Host policy must also allow overwrites.", "default": false }
+  },
+  "required": ["path", "content"]
+}`),
+		},
+		func(_ context.Context, args fileWriteArgs) (glue.ToolResult, error) {
+			result, err := writeFile(absWorkDir, args, writePolicy{
+				allowOverwrite: opts.AllowOverwrite,
+				maxBytes:       max,
+				blocklist:      blocklist,
+			})
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return result, nil
+		},
+	), nil
+}
+
+type writePolicy struct {
+	allowOverwrite bool
+	maxBytes       int
+	blocklist      Blocklist
+}
+
+func writeFile(workDir string, args fileWriteArgs, policy writePolicy) (glue.ToolResult, error) {
+	rel := strings.TrimSpace(args.Path)
+	if rel == "" {
+		return glue.ToolResult{}, errors.New("fs: path is required")
+	}
+	if blocked, pat := policy.blocklist.Match(rel); blocked {
+		return glue.ToolResult{}, fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", rel, pat)
+	}
+	contentBytes := []byte(args.Content)
+	if len(contentBytes) > policy.maxBytes {
+		return glue.ToolResult{}, fmt.Errorf("fs: content is %d bytes, exceeds max %d", len(contentBytes), policy.maxBytes)
+	}
+
+	target, err := SafeJoin(workDir, rel)
+	if err != nil {
+		return glue.ToolResult{}, err
+	}
+	parent := filepath.Dir(target)
+	if err := ensureSafeWriteParent(workDir, parent); err != nil {
+		return glue.ToolResult{}, err
+	}
+
+	overwritten := false
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return glue.ToolResult{}, fmt.Errorf("fs: target %q is a symlink; refusing to write", rel)
+		}
+		if info.IsDir() {
+			return glue.ToolResult{}, fmt.Errorf("fs: target %q is a directory; refusing to write", rel)
+		}
+		if !policy.allowOverwrite || !args.Overwrite {
+			return glue.ToolResult{}, fmt.Errorf("fs: target %q exists; set overwrite=true and enable AllowOverwrite to replace it", rel)
+		}
+		overwritten = true
+	} else if !os.IsNotExist(err) {
+		return glue.ToolResult{}, err
+	}
+
+	if err := atomicWriteFile(parent, target, contentBytes, 0o644); err != nil {
+		return glue.ToolResult{}, err
+	}
+
+	cleanRel := filepath.ToSlash(filepath.Clean(rel))
+	return glue.ToolResult{
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: fmt.Sprintf("wrote %d bytes to %s", len(contentBytes), cleanRel)}},
+		Metadata: map[string]any{
+			"path":        cleanRel,
+			"bytes":       len(contentBytes),
+			"overwritten": overwritten,
+		},
+	}, nil
+}
+
+func ensureSafeWriteParent(workDir, parent string) error {
+	baseEval, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		return fmt.Errorf("fs: resolve work directory symlinks: %w", err)
+	}
+	baseEval, err = filepath.Abs(baseEval)
+	if err != nil {
+		return err
+	}
+
+	missing := []string{}
+	cur := parent
+	for {
+		info, err := os.Lstat(cur)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				eval, err := filepath.EvalSymlinks(cur)
+				if err != nil {
+					return err
+				}
+				if !pathWithin(baseEval, eval) {
+					return fmt.Errorf("fs: parent %q escapes work directory through symlink", cur)
+				}
+			} else if !info.IsDir() {
+				return fmt.Errorf("fs: parent %q is not a directory", cur)
+			}
+			eval, err := filepath.EvalSymlinks(cur)
+			if err != nil {
+				return err
+			}
+			if !pathWithin(baseEval, eval) {
+				return fmt.Errorf("fs: parent %q escapes work directory", cur)
+			}
+			break
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+		missing = append(missing, cur)
+		next := filepath.Dir(cur)
+		if next == cur {
+			return fmt.Errorf("fs: no existing parent for %q", parent)
+		}
+		cur = next
+	}
+
+	for i := len(missing) - 1; i >= 0; i-- {
+		dir := missing[i]
+		if err := os.Mkdir(dir, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
+		info, err := os.Lstat(dir)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("fs: parent %q is not a safe directory", dir)
+		}
+		eval, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			return err
+		}
+		if !pathWithin(baseEval, eval) {
+			return fmt.Errorf("fs: parent %q escapes work directory", dir)
+		}
+	}
+	return nil
+}
+
+func pathWithin(base, candidate string) bool {
+	base, err := filepath.Abs(base)
+	if err != nil {
+		return false
+	}
+	candidate, err = filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(base, candidate)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func atomicWriteFile(parent, target string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(parent, ".glue-write-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func fileWritePermissionTarget(call glue.ToolCall) string {
+	var args fileWriteArgs
+	if err := json.Unmarshal(call.Arguments, &args); err != nil || strings.TrimSpace(args.Path) == "" {
+		return "write_file"
+	}
+	target := strings.TrimSpace(args.Path)
+	if args.Overwrite {
+		return target + " (overwrite)"
+	}
+	return target
+}

--- a/tools/fs/write_test.go
+++ b/tools/fs/write_test.go
@@ -1,0 +1,201 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestFileWriteToolSpecPermissionMetadata(t *testing.T) {
+	tool, err := FileWrite(FileWriteOptions{WorkDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("FileWrite: %v", err)
+	}
+	if tool.Name != "write_file" {
+		t.Fatalf("tool name = %q, want write_file", tool.Name)
+	}
+	if !tool.RequiresPermission {
+		t.Fatal("RequiresPermission = false, want true")
+	}
+	if tool.PermissionAction != "write_file" {
+		t.Fatalf("PermissionAction = %q, want write_file", tool.PermissionAction)
+	}
+	got := tool.PermissionTarget(glue.ToolCall{Arguments: json.RawMessage(`{"path":"a.go","overwrite":true}`)})
+	if got != "a.go (overwrite)" {
+		t.Fatalf("PermissionTarget = %q", got)
+	}
+}
+
+func TestFileWriteCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	res := callWrite(t, FileWriteOptions{WorkDir: dir}, `{"path":"a.txt","content":"hello"}`)
+	if res.IsError {
+		t.Fatalf("IsError = true: %q", res.Content[0].Text)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "a.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("content = %q, want hello", got)
+	}
+	if res.Metadata["path"] != "a.txt" || res.Metadata["bytes"] != 5 || res.Metadata["overwritten"] != false {
+		t.Fatalf("metadata = %#v", res.Metadata)
+	}
+}
+
+func TestFileWriteCreatesNestedParents(t *testing.T) {
+	dir := t.TempDir()
+	res := callWrite(t, FileWriteOptions{WorkDir: dir}, `{"path":"nested/deep/a.txt","content":"hello"}`)
+	if res.IsError {
+		t.Fatalf("IsError = true: %q", res.Content[0].Text)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "nested", "deep", "a.txt")); err != nil {
+		t.Fatalf("nested file not created: %v", err)
+	}
+}
+
+func TestFileWriteOverwriteRequiresHostAndArg(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := callWrite(t, FileWriteOptions{WorkDir: dir}, `{"path":"a.txt","content":"new","overwrite":true}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "exists") {
+		t.Fatalf("host-disallowed overwrite result = %+v", res)
+	}
+	res = callWrite(t, FileWriteOptions{WorkDir: dir, AllowOverwrite: true}, `{"path":"a.txt","content":"new"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "exists") {
+		t.Fatalf("arg-disallowed overwrite result = %+v", res)
+	}
+	res = callWrite(t, FileWriteOptions{WorkDir: dir, AllowOverwrite: true}, `{"path":"a.txt","content":"new","overwrite":true}`)
+	if res.IsError {
+		t.Fatalf("allowed overwrite failed: %q", res.Content[0].Text)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "new" {
+		t.Fatalf("content = %q, want new", got)
+	}
+	if res.Metadata["overwritten"] != true {
+		t.Fatalf("overwritten metadata = %#v, want true", res.Metadata["overwritten"])
+	}
+}
+
+func TestFileWriteValidationErrors(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"missing path", `{"content":"x"}`, "path is required"},
+		{"absolute", `{"path":"/tmp/x","content":"x"}`, "absolute paths"},
+		{"traversal", `{"path":"../x","content":"x"}`, "escapes work directory"},
+		{"too large", `{"path":"a.txt","content":"abcd"}`, "exceeds max"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := callWrite(t, FileWriteOptions{WorkDir: dir, MaxBytes: 3}, tc.args)
+			if !res.IsError {
+				t.Fatalf("IsError = false, want true")
+			}
+			if !strings.Contains(res.Content[0].Text, tc.want) {
+				t.Fatalf("content = %q, want %q", res.Content[0].Text, tc.want)
+			}
+		})
+	}
+}
+
+func TestFileWriteBlocklist(t *testing.T) {
+	res := callWrite(t, FileWriteOptions{WorkDir: t.TempDir(), Blocklist: Default()}, `{"path":".env","content":"SECRET=x"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "blocked") {
+		t.Fatalf("blocklist result = %+v", res)
+	}
+}
+
+func TestFileWriteRejectsTargetSymlink(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+
+	res := callWrite(t, FileWriteOptions{WorkDir: dir, AllowOverwrite: true}, `{"path":"link.txt","content":"new","overwrite":true}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "symlink") {
+		t.Fatalf("symlink result = %+v", res)
+	}
+	got, _ := os.ReadFile(outside)
+	if string(got) != "outside" {
+		t.Fatalf("outside content changed to %q", got)
+	}
+}
+
+func TestFileWriteRejectsParentSymlinkEscapeBeforeMkdir(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+
+	res := callWrite(t, FileWriteOptions{WorkDir: dir}, `{"path":"link/newdir/a.txt","content":"x"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "escapes work directory") {
+		t.Fatalf("parent symlink result = %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "newdir")); !os.IsNotExist(err) {
+		t.Fatalf("created directory through symlink, err=%v", err)
+	}
+}
+
+func TestFileWriteNoTempFilesRemainOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	res := callWrite(t, FileWriteOptions{WorkDir: dir}, `{"path":"a.txt","content":"x"}`)
+	if res.IsError {
+		t.Fatalf("IsError = true: %q", res.Content[0].Text)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".glue-write-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temp files remain: %v", matches)
+	}
+}
+
+func TestFileWriteConstructorValidation(t *testing.T) {
+	if _, err := FileWrite(FileWriteOptions{}); err == nil {
+		t.Fatal("empty WorkDir error = nil")
+	}
+	file := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FileWrite(FileWriteOptions{WorkDir: file}); err == nil {
+		t.Fatal("file WorkDir error = nil")
+	}
+	if _, err := FileWrite(FileWriteOptions{WorkDir: t.TempDir(), MaxBytes: -1}); err == nil {
+		t.Fatal("negative MaxBytes error = nil")
+	}
+}
+
+func callWrite(t *testing.T, opts FileWriteOptions, args string) glue.ToolResult {
+	t.Helper()
+	tool, err := FileWrite(opts)
+	if err != nil {
+		t.Fatalf("FileWrite: %v", err)
+	}
+	res, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name, Arguments: json.RawMessage(args)})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return res
+}


### PR DESCRIPTION
## Summary

Adds `tools/fs.FileWrite`, a permission-gated `write_file` tool for atomic workspace-rooted writes. It validates relative paths, enforces content size caps, optionally uses a blocklist, creates nested parents safely, rejects target symlinks and parent symlink escapes, requires both host and tool-call overwrite consent, and writes via temp-file-plus-rename.

Closes #149

## Verification

- `go test ./tools/fs` — pass
- `go build ./...` — pass
- `go vet ./...` — pass
- `env -u NVIDIA_API_KEY go test ./...` — pass

The local environment still has `NVIDIA_API_KEY` set; exact `go test ./...` can enter the live NVIDIA smoke and hit upstream rate limits. PR CI reports live provider checks separately.

## Follow-ups

Next M2 implementation issue after this merges: `glue.SubagentTool`.