### PR TITLE
glue: add SubagentTool primitive (closes #151)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -247,6 +247,13 @@ V1 validation is intentionally limited to JSON decoding into the caller's Go
 type. Full JSON Schema validation is out of scope for the first structured
 result API.
 
+`glue.SubagentTool` adapts a child `*glue.Agent` into a normal `glue.Tool` for
+delegation patterns. Each tool call forwards only the explicit prompt argument
+into a fresh child session, using `SubagentOptions.SessionID` as an optional
+session-id prefix, and returns the child final text as the tool result. Child
+prompt failures are visible to the parent model as error tool results; context
+cancellation and deadlines still abort the parent loop.
+
 ## Gemini Provider
 
 The first provider package is `providers/gemini`, implemented with

--- a/subagent.go
+++ b/subagent.go
@@ -1,0 +1,142 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+)
+
+// SubagentOptions configures [SubagentTool].
+type SubagentOptions struct {
+	// Name is the model-visible tool name.
+	Name string
+
+	// Description is the model-visible tool description.
+	Description string
+
+	// Agent is the child agent invoked when the tool runs. Required.
+	Agent *Agent
+
+	// SessionID is an optional prefix for generated child session ids.
+	// Each tool instance and tool call appends a generated suffix so calls
+	// use isolated transcripts. Empty uses "subagent:<Name>".
+	SessionID string
+
+	// MaxTurns optionally overrides the child prompt's loop turn budget.
+	// Zero uses the child agent/default loop budget.
+	MaxTurns int
+
+	// SystemPrompt optionally overrides the child agent system prompt for
+	// each delegated prompt.
+	SystemPrompt string
+}
+
+var subagentInstanceIDs atomic.Uint64
+
+type subagentArgs struct {
+	Prompt string `json:"prompt"`
+}
+
+// SubagentTool exposes a child Agent as a Tool. Each tool call creates a
+// fresh child session, forwards only the explicit prompt argument, and returns
+// the child agent's final text as the tool result. Child prompt failures become
+// model-visible error results except for context cancellation/deadline errors,
+// which are returned as Go errors so the parent loop stops promptly.
+func SubagentTool(opts SubagentOptions) (Tool, error) {
+	name := strings.TrimSpace(opts.Name)
+	if name == "" {
+		return Tool{}, errors.New("glue: subagent name is required")
+	}
+	description := strings.TrimSpace(opts.Description)
+	if description == "" {
+		return Tool{}, errors.New("glue: subagent description is required")
+	}
+	if opts.Agent == nil {
+		return Tool{}, errors.New("glue: subagent agent is required")
+	}
+	if opts.MaxTurns < 0 {
+		return Tool{}, errors.New("glue: subagent MaxTurns must be non-negative")
+	}
+
+	baseSessionID := strings.TrimSpace(opts.SessionID)
+	if baseSessionID == "" {
+		baseSessionID = "subagent:" + name
+	}
+	systemPrompt := opts.SystemPrompt
+	maxTurns := opts.MaxTurns
+	child := opts.Agent
+	instanceID := subagentInstanceIDs.Add(1)
+	var calls atomic.Uint64
+
+	return NewTool[subagentArgs](
+		ToolSpec{
+			Name:        name,
+			Description: description,
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "prompt": { "type": "string", "description": "The complete task or question to delegate to this subagent." }
+  },
+  "required": ["prompt"]
+}`),
+		},
+		func(ctx context.Context, args subagentArgs) (ToolResult, error) {
+			if strings.TrimSpace(args.Prompt) == "" {
+				return ErrorResult(errors.New("glue: subagent prompt is required")), nil
+			}
+
+			sessionID := fmt.Sprintf("%s:%d:%d", baseSessionID, instanceID, calls.Add(1))
+			session, err := child.Session(ctx, sessionID)
+			if err != nil {
+				if contextErr := subagentContextError(ctx, err); contextErr != nil {
+					return ToolResult{}, contextErr
+				}
+				return subagentErrorResult(fmt.Errorf("subagent %q session: %w", name, err), sessionID), nil
+			}
+
+			promptOptions := make([]PromptOption, 0, 2)
+			if maxTurns > 0 {
+				promptOptions = append(promptOptions, WithMaxTurns(maxTurns))
+			}
+			if systemPrompt != "" {
+				promptOptions = append(promptOptions, WithSystemPrompt(systemPrompt))
+			}
+
+			result, err := session.Prompt(ctx, args.Prompt, promptOptions...)
+			if err != nil {
+				if contextErr := subagentContextError(ctx, err); contextErr != nil {
+					return ToolResult{}, contextErr
+				}
+				return subagentErrorResult(fmt.Errorf("subagent %q: %w", name, err), sessionID), nil
+			}
+
+			toolResult := TextResult(result.Text)
+			toolResult.Metadata = map[string]any{"session_id": sessionID}
+			return toolResult, nil
+		},
+	), nil
+}
+
+func subagentErrorResult(err error, sessionID string) ToolResult {
+	result := ErrorResult(err)
+	if sessionID != "" {
+		result.Metadata = map[string]any{"session_id": sessionID}
+	}
+	return result
+}
+
+func subagentContextError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return ctx.Err()
+}

--- a/subagent_test.go
+++ b/subagent_test.go
@@ -1,0 +1,349 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSubagentToolValidation(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(AgentOptions{Provider: &recordingProvider{turns: [][]ProviderEvent{textTurn("ok")}}})
+	tests := []struct {
+		name string
+		opts SubagentOptions
+		want string
+	}{
+		{
+			name: "missing name",
+			opts: SubagentOptions{Description: "delegate", Agent: agent},
+			want: "name",
+		},
+		{
+			name: "missing description",
+			opts: SubagentOptions{Name: "delegate", Agent: agent},
+			want: "description",
+		},
+		{
+			name: "missing agent",
+			opts: SubagentOptions{Name: "delegate", Description: "delegate work"},
+			want: "agent",
+		},
+		{
+			name: "negative max turns",
+			opts: SubagentOptions{Name: "delegate", Description: "delegate work", Agent: agent, MaxTurns: -1},
+			want: "MaxTurns",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := SubagentTool(tc.opts); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSubagentToolCanBeCalledByParentAgent(t *testing.T) {
+	t.Parallel()
+
+	childProvider := &recordingProvider{turns: [][]ProviderEvent{textTurn("child answer")}}
+	child := NewAgent(AgentOptions{Provider: childProvider})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:        "researcher",
+		Description: "Delegate research work",
+		Agent:       child,
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+
+	parentProvider := &recordingProvider{turns: [][]ProviderEvent{
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "c1", Name: "researcher", Arguments: []byte(`{"prompt":"check this"}`)}},
+			{Type: ProviderEventDone},
+		},
+		textTurn("parent done"),
+	}}
+	parent := NewAgent(AgentOptions{Provider: parentProvider, Tools: []Tool{tool}})
+	session, err := parent.Session(context.Background(), "parent")
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	result, err := session.Prompt(context.Background(), "delegate")
+	if err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if result.Text != "parent done" {
+		t.Fatalf("Text = %q, want parent done", result.Text)
+	}
+	if got := childProvider.requests[0].Messages[0].Content[0].Text; got != "check this" {
+		t.Fatalf("child prompt = %q, want check this", got)
+	}
+	gotMessages := parentProvider.requests[1].Messages
+	if len(gotMessages) != 3 {
+		t.Fatalf("parent continuation messages = %d, want 3", len(gotMessages))
+	}
+	if got := gotMessages[2].Content[0].Text; got != "child answer" {
+		t.Fatalf("tool result text = %q, want child answer", got)
+	}
+}
+
+func TestSubagentToolUsesFreshSessionPerCall(t *testing.T) {
+	t.Parallel()
+
+	childProvider := &recordingProvider{turns: [][]ProviderEvent{textTurn("one"), textTurn("two")}}
+	child := NewAgent(AgentOptions{Provider: childProvider})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:        "coder",
+		Description: "Write code",
+		Agent:       child,
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+
+	first, err := tool.Execute(context.Background(), ToolCall{Name: "coder", Arguments: []byte(`{"prompt":"first task"}`)})
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	second, err := tool.Execute(context.Background(), ToolCall{Name: "coder", Arguments: []byte(`{"prompt":"second task"}`)})
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+
+	if first.IsError || second.IsError {
+		t.Fatalf("unexpected error results: first=%q second=%q", first.Content[0].Text, second.Content[0].Text)
+	}
+	if got := childProvider.requests[0].Messages; len(got) != 1 || got[0].Content[0].Text != "first task" {
+		t.Fatalf("first child messages = %#v, want one explicit prompt", got)
+	}
+	if got := childProvider.requests[1].Messages; len(got) != 1 || got[0].Content[0].Text != "second task" {
+		t.Fatalf("second child messages = %#v, want fresh transcript", got)
+	}
+	firstID, _ := first.Metadata["session_id"].(string)
+	secondID, _ := second.Metadata["session_id"].(string)
+	if firstID == "" || secondID == "" || firstID == secondID {
+		t.Fatalf("session ids first=%q second=%q, want distinct non-empty ids", firstID, secondID)
+	}
+	if !strings.HasPrefix(firstID, "subagent:coder:") || !strings.HasPrefix(secondID, "subagent:coder:") {
+		t.Fatalf("session ids first=%q second=%q, want default subagent prefix", firstID, secondID)
+	}
+}
+
+func TestSubagentToolUsesUniqueSessionIDsAcrossToolInstances(t *testing.T) {
+	t.Parallel()
+
+	childProvider := &recordingProvider{turns: [][]ProviderEvent{textTurn("one"), textTurn("two")}}
+	child := NewAgent(AgentOptions{Provider: childProvider})
+	firstTool, err := SubagentTool(SubagentOptions{
+		Name:        "coder_a",
+		Description: "Write code",
+		Agent:       child,
+		SessionID:   "worker",
+	})
+	if err != nil {
+		t.Fatalf("first SubagentTool: %v", err)
+	}
+	secondTool, err := SubagentTool(SubagentOptions{
+		Name:        "coder_b",
+		Description: "Write code",
+		Agent:       child,
+		SessionID:   "worker",
+	})
+	if err != nil {
+		t.Fatalf("second SubagentTool: %v", err)
+	}
+
+	first, err := firstTool.Execute(context.Background(), ToolCall{Name: "coder_a", Arguments: []byte(`{"prompt":"first task"}`)})
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	second, err := secondTool.Execute(context.Background(), ToolCall{Name: "coder_b", Arguments: []byte(`{"prompt":"second task"}`)})
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+
+	if got := childProvider.requests[1].Messages; len(got) != 1 || got[0].Content[0].Text != "second task" {
+		t.Fatalf("second child messages = %#v, want fresh transcript across tool instances", got)
+	}
+	firstID, _ := first.Metadata["session_id"].(string)
+	secondID, _ := second.Metadata["session_id"].(string)
+	if firstID == secondID || !strings.HasPrefix(firstID, "worker:") || !strings.HasPrefix(secondID, "worker:") {
+		t.Fatalf("session ids first=%q second=%q, want distinct worker-prefixed ids", firstID, secondID)
+	}
+}
+
+func TestSubagentToolCustomSessionIDAndSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	childProvider := &recordingProvider{turns: [][]ProviderEvent{textTurn("done")}}
+	child := NewAgent(AgentOptions{Provider: childProvider})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:         "coder",
+		Description:  "Write code",
+		Agent:        child,
+		SessionID:    "worker",
+		SystemPrompt: "child-only instructions",
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+
+	result, err := tool.Execute(context.Background(), ToolCall{Name: "coder", Arguments: []byte(`{"prompt":"use custom prompt"}`)})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("IsError = true: %q", result.Content[0].Text)
+	}
+	if got := childProvider.requests[0].SystemPrompt; got != "child-only instructions" {
+		t.Fatalf("SystemPrompt = %q, want child-only instructions", got)
+	}
+	sessionID, _ := result.Metadata["session_id"].(string)
+	if !strings.HasPrefix(sessionID, "worker:") {
+		t.Fatalf("session id = %q, want worker prefix", sessionID)
+	}
+	session, err := child.Session(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("Session %q: %v", sessionID, err)
+	}
+	if session.ID() != sessionID {
+		t.Fatalf("child session id = %q, want %q", session.ID(), sessionID)
+	}
+}
+
+func TestSubagentToolMaxTurnsIsErrorResult(t *testing.T) {
+	t.Parallel()
+
+	childProvider := &recordingProvider{turns: [][]ProviderEvent{
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "c1", Name: "echo", Arguments: []byte(`{"value":"x"}`)}},
+			{Type: ProviderEventDone},
+		},
+	}}
+	child := NewAgent(AgentOptions{
+		Provider: childProvider,
+		Tools: []Tool{NewTool[struct {
+			Value string `json:"value"`
+		}](ToolSpec{
+			Name: "echo",
+			Parameters: []byte(`{
+  "type": "object",
+  "properties": { "value": { "type": "string" } },
+  "required": ["value"]
+}`),
+		}, func(context.Context, struct {
+			Value string `json:"value"`
+		}) (ToolResult, error) {
+			return TextResult("echoed"), nil
+		})},
+	})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:        "coder",
+		Description: "Write code",
+		Agent:       child,
+		MaxTurns:    1,
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+
+	result, err := tool.Execute(context.Background(), ToolCall{Name: "coder", Arguments: []byte(`{"prompt":"loop once"}`)})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "maximum turns exceeded (1)") {
+		t.Fatalf("result = %#v, want max-turn error result", result)
+	}
+	sessionID, _ := result.Metadata["session_id"].(string)
+	if !strings.HasPrefix(sessionID, "subagent:coder:") {
+		t.Fatalf("session id = %q, want default subagent prefix", sessionID)
+	}
+}
+
+func TestSubagentToolChildPromptErrorIsToolError(t *testing.T) {
+	t.Parallel()
+
+	child := NewAgent(AgentOptions{Provider: errorProvider{err: errors.New("provider unavailable")}})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:        "worker",
+		Description: "Delegate work",
+		Agent:       child,
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+
+	result, err := tool.Execute(context.Background(), ToolCall{Name: "worker", Arguments: []byte(`{"prompt":"do it"}`)})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "provider unavailable") {
+		t.Fatalf("result = %#v, want provider error result", result)
+	}
+}
+
+func TestSubagentToolPromptValidation(t *testing.T) {
+	t.Parallel()
+
+	childProvider := &recordingProvider{turns: [][]ProviderEvent{textTurn("unused")}}
+	child := NewAgent(AgentOptions{Provider: childProvider})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:        "worker",
+		Description: "Delegate work",
+		Agent:       child,
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+
+	result, err := tool.Execute(context.Background(), ToolCall{Name: "worker", Arguments: []byte(`{"prompt":"   "}`)})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if !result.IsError || !strings.Contains(result.Content[0].Text, "prompt is required") {
+		t.Fatalf("result = %#v, want prompt validation error", result)
+	}
+	if childProvider.calls != 0 {
+		t.Fatalf("child provider calls = %d, want 0", childProvider.calls)
+	}
+}
+
+func TestSubagentToolContextCancellationPropagates(t *testing.T) {
+	t.Parallel()
+
+	child := NewAgent(AgentOptions{Provider: &recordingProvider{turns: [][]ProviderEvent{textTurn("unused")}}})
+	tool, err := SubagentTool(SubagentOptions{
+		Name:        "worker",
+		Description: "Delegate work",
+		Agent:       child,
+	})
+	if err != nil {
+		t.Fatalf("SubagentTool: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = tool.Execute(ctx, ToolCall{Name: "worker", Arguments: []byte(`{"prompt":"do it"}`)})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+type errorProvider struct {
+	err error
+}
+
+func (p errorProvider) Stream(context.Context, ProviderRequest) (<-chan ProviderEvent, error) {
+	return nil, p.err
+}


### PR DESCRIPTION
## Summary

- adds `glue.SubagentTool` and `SubagentOptions` for in-process Agent-as-Tool delegation
- creates fresh child sessions per tool call, including per-tool-instance suffixes for transcript isolation
- surfaces child prompt failures as tool error results while propagating cancellation/deadlines
- documents the new public delegation primitive in `docs/design.md`

## Verification

- `go test . -run 'TestSubagentTool' -count=1`
- `go test .`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- docs/design.md subagent.go subagent_test.go`
- `env -u NVIDIA_API_KEY go test ./...`
