### PR TITLE
agents/peggy: wire coding tools and CLI permission (closes #153)

### DIFF
--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -101,6 +101,10 @@ and emits a stderr diagnostic.
 | `compaction.threshold` | `200` | Message-count gate. Compaction only runs when the in-memory transcript exceeds this. |
 | `compaction.target_tokens` | `8000` | Soft cap on transcript size before summarization. Word-count heuristic; not a real tokenizer. |
 | `compaction.keep_recent` | `8` | Most-recent messages retained verbatim through compaction. |
+| `coding.enabled` | `false` | Register local coding tools. Enable only for trusted local workspaces. |
+| `coding.work_dir` | current directory | Workspace root for `read_file`, `write_file`, `shell_exec`, and git helpers. `~` and `$HOME` expand. |
+| `coding.allowed_binaries` | `go`, `git`, `make`, `node`, `npm`, `python`, `python3` | Basename allowlist for `shell_exec`; model calls cannot run arbitrary paths. |
+| `coding.allow_overwrite` | `false` | Host policy for replacing existing files. The model must still pass `overwrite: true`, and the permission prompt must allow the call. |
 
 Missing `settings.json` is non-fatal — Peggy uses the built-in
 defaults above and emits a stderr diagnostic.
@@ -116,12 +120,49 @@ peggy [flags] "<prompt text>"
                      transcripts key off this; a fresh id starts a
                      new conversation while still allowing search
                      across all sessions.
+  --coding           Enable local coding tools for this prompt.
+  --workdir <path>   Workspace root for --coding (default ".").
+  --coding-allow-overwrite
+                     Allow write_file to replace existing files after
+                     model intent and user permission.
   --version          Print the version and exit.
   --help             Print this help.
 ```
 
 The prompt is whatever non-flag args you pass — quoting is your
 shell's job. Multi-word prompts work without quoting too.
+
+## Coding Tools
+
+Coding mode is opt-in. Enable it in `settings.json` with
+`"coding": {"enabled": true, "work_dir": "/path/to/repo"}` or for one
+CLI call with:
+
+```sh
+peggy --coding --workdir . "run the tests and fix the failure"
+```
+
+Peggy registers these model-callable tools:
+
+- `read_file` — read UTF-8 text inside the workspace. Read-only, no
+  permission prompt.
+- `write_file` — write UTF-8 text inside the workspace. Permission
+  required. Existing files require both `coding.allow_overwrite` /
+  `--coding-allow-overwrite` and model argument `overwrite: true`.
+- `shell_exec` — run argv-style commands inside the workspace.
+  Permission required. `argv[0]` must be a configured binary basename.
+- `git_diff_branch` / `git_log_branch` — read-only branch context via
+  the local `git` binary.
+
+For `write_file` and `shell_exec`, the CLI asks on stderr/stdin:
+
+```text
+Allow? [y] once, [s] session, [t] target, [n] deny:
+```
+
+Remembered choices last only for the current `peggy` process. If stdin
+is unavailable or reaches EOF, Peggy denies the side effect and surfaces
+that denial to the model as a tool error.
 
 ### Config resolution
 
@@ -169,7 +210,7 @@ for _, m := range mems {
 A `peggy memories` subcommand for list / forget / export is a
 near-term follow-up.
 
-## What v0.1 supports
+## What Peggy supports today
 
 - **Single-prompt CLI** (`peggy`) and **Telegram bot** (`peggy-telegram`)
   on the same agent + same session store.
@@ -181,6 +222,9 @@ near-term follow-up.
   API (a `peggy recall` subcommand is a near-term follow-up).
 - **Token-aware summarizing compaction** via the configured provider.
 - Identity injected from `SOUL.md` into the system prompt.
+- Opt-in **local coding mode** for the CLI: read files, write files,
+  run allowlisted commands, and inspect git branch context with
+  per-call permission prompts for side effects.
 - All four shipped providers: `codex` (ChatGPT subscription),
   `gemini`, `openrouter`, `nvidia`. Codex is the default and uses
   your existing ChatGPT subscription via `codex login` — no per-token
@@ -214,10 +258,8 @@ external transports. The pattern is designed in
 Per tracker [#110](https://github.com/erain/glue/issues/110), in
 priority order:
 
-- **M2 — "she can code".** Permission-gated `tools/shell` and
-  `tools/fs.FileWrite`, the subagent primitive (`Agent`-as-`Tool`),
-  diff display in the TUI/Telegram, an `Executor` / `Permission` /
-  `Hook` interface trio in core glue.
+- **M2 — "she can code".** CLI coding tools are wired; next is
+  Telegram inline-keyboard permissions, then tighter product polish.
 - **M3 — multi-channel daemon.** `cmd/glue serve` so a single
   long-running Peggy serves a TUI, Telegram, and future clients
   concurrently. Per-channel permission tiers.

--- a/agents/peggy/cli_permission.go
+++ b/agents/peggy/cli_permission.go
@@ -1,0 +1,151 @@
+package peggy
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/erain/glue"
+)
+
+const permissionArgsPreviewBytes = 320
+
+// CLIPermissionOptions configures [NewCLIPermission].
+type CLIPermissionOptions struct {
+	// Stdin supplies prompt answers. Nil denies every request.
+	Stdin io.Reader
+
+	// Stderr receives prompts and diagnostics. Nil discards output.
+	Stderr io.Writer
+}
+
+// NewCLIPermission returns an interactive Permission implementation for
+// Peggy's single-prompt CLI. Decisions remembered for the session live only
+// in this object and are not persisted.
+func NewCLIPermission(opts CLIPermissionOptions) glue.Permission {
+	return &cliPermission{
+		in:             opts.Stdin,
+		out:            opts.Stderr,
+		sessionAllows:  map[string]struct{}{},
+		targetAllows:   map[string]struct{}{},
+		permissionScan: bufio.NewReader(opts.Stdin),
+	}
+}
+
+type cliPermission struct {
+	mu sync.Mutex
+
+	in  io.Reader
+	out io.Writer
+
+	permissionScan *bufio.Reader
+	sessionAllows  map[string]struct{}
+	targetAllows   map[string]struct{}
+}
+
+func (p *cliPermission) Decide(ctx context.Context, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	if p == nil {
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: no CLI permission handler"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return glue.PermissionDecision{}, err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := p.sessionAllows[permissionSessionKey(req)]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}, nil
+	}
+	if _, ok := p.targetAllows[permissionTargetKey(req)]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSessionTarget}, nil
+	}
+	if p.in == nil || p.permissionScan == nil {
+		p.print("peggy: permission denied for %s %q: stdin is not available\n", req.Action, req.Target)
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: stdin is not available"}, nil
+	}
+
+	p.printPermissionRequest(req)
+	answer, err := p.permissionScan.ReadString('\n')
+	if err != nil && len(answer) == 0 {
+		reason := "permission denied: no input"
+		if err != io.EOF {
+			reason = "permission denied: " + err.Error()
+		}
+		p.print("peggy: %s\n", reason)
+		return glue.PermissionDecision{Allow: false, Reason: reason}, nil
+	}
+
+	decision := parsePermissionAnswer(answer)
+	if !decision.Allow {
+		if decision.Reason == "" {
+			decision.Reason = "permission denied by user"
+		}
+		p.print("peggy: permission denied\n")
+		return decision, nil
+	}
+
+	switch decision.RememberFor {
+	case glue.RememberSession:
+		p.sessionAllows[permissionSessionKey(req)] = struct{}{}
+	case glue.RememberSessionTarget:
+		p.targetAllows[permissionTargetKey(req)] = struct{}{}
+	}
+	return decision, nil
+}
+
+func (p *cliPermission) printPermissionRequest(req glue.PermissionRequest) {
+	p.print("\npeggy: permission requested\n")
+	p.print("  tool:   %s\n", req.Tool)
+	p.print("  action: %s\n", req.Action)
+	if strings.TrimSpace(req.Target) != "" {
+		p.print("  target: %s\n", req.Target)
+	}
+	if preview := permissionArgsPreview(req.Args); preview != "" {
+		p.print("  args:   %s\n", preview)
+	}
+	p.print("Allow? [y] once, [s] session, [t] target, [n] deny: ")
+}
+
+func (p *cliPermission) print(format string, args ...any) {
+	if p.out == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(p.out, format, args...)
+}
+
+func parsePermissionAnswer(answer string) glue.PermissionDecision {
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes", "a", "allow", "o", "once":
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberNever}
+	case "s", "session", "yes-session", "yes for session":
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}
+	case "t", "target", "yes-target", "yes for target":
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSessionTarget}
+	default:
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied by user"}
+	}
+}
+
+func permissionSessionKey(req glue.PermissionRequest) string {
+	return req.Tool + "\x00" + req.Action
+}
+
+func permissionTargetKey(req glue.PermissionRequest) string {
+	return permissionSessionKey(req) + "\x00" + req.Target
+}
+
+func permissionArgsPreview(raw json.RawMessage) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" || text == "null" {
+		return ""
+	}
+	if len(text) <= permissionArgsPreviewBytes {
+		return text
+	}
+	return text[:permissionArgsPreviewBytes] + "...(truncated)"
+}

--- a/agents/peggy/cli_permission_test.go
+++ b/agents/peggy/cli_permission_test.go
@@ -1,0 +1,114 @@
+package peggy
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestCLIPermissionAllowOnceDoesNotRemember(t *testing.T) {
+	var stderr bytes.Buffer
+	perm := NewCLIPermission(CLIPermissionOptions{
+		Stdin:  strings.NewReader("y\nn\n"),
+		Stderr: &stderr,
+	})
+	req := glue.PermissionRequest{Tool: "shell_exec", Action: "exec", Target: "go test ./..."}
+
+	first, err := perm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first Decide: %v", err)
+	}
+	if !first.Allow || first.RememberFor != glue.RememberNever {
+		t.Fatalf("first decision = %+v, want allow once", first)
+	}
+	second, err := perm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second Decide: %v", err)
+	}
+	if second.Allow {
+		t.Fatalf("second decision = %+v, want deny after no cache", second)
+	}
+	if !strings.Contains(stderr.String(), "go test ./...") {
+		t.Fatalf("stderr = %q, want target preview", stderr.String())
+	}
+}
+
+func TestCLIPermissionRememberSession(t *testing.T) {
+	perm := NewCLIPermission(CLIPermissionOptions{Stdin: strings.NewReader("s\n")})
+	req := glue.PermissionRequest{Tool: "shell_exec", Action: "exec", Target: "go test ./..."}
+
+	first, err := perm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first Decide: %v", err)
+	}
+	if !first.Allow || first.RememberFor != glue.RememberSession {
+		t.Fatalf("first decision = %+v, want session allow", first)
+	}
+	second, err := perm.Decide(context.Background(), glue.PermissionRequest{
+		Tool:   "shell_exec",
+		Action: "exec",
+		Target: "go vet ./...",
+	})
+	if err != nil {
+		t.Fatalf("second Decide: %v", err)
+	}
+	if !second.Allow || second.RememberFor != glue.RememberSession {
+		t.Fatalf("second decision = %+v, want cached session allow", second)
+	}
+}
+
+func TestCLIPermissionRememberTarget(t *testing.T) {
+	perm := NewCLIPermission(CLIPermissionOptions{Stdin: strings.NewReader("t\nn\n")})
+	req := glue.PermissionRequest{Tool: "write_file", Action: "write_file", Target: "main.go"}
+
+	first, err := perm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first Decide: %v", err)
+	}
+	if !first.Allow || first.RememberFor != glue.RememberSessionTarget {
+		t.Fatalf("first decision = %+v, want target allow", first)
+	}
+	second, err := perm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second Decide: %v", err)
+	}
+	if !second.Allow {
+		t.Fatalf("second decision = %+v, want cached target allow", second)
+	}
+	third, err := perm.Decide(context.Background(), glue.PermissionRequest{
+		Tool:   "write_file",
+		Action: "write_file",
+		Target: "other.go",
+	})
+	if err != nil {
+		t.Fatalf("third Decide: %v", err)
+	}
+	if third.Allow {
+		t.Fatalf("third decision = %+v, want deny for different target", third)
+	}
+}
+
+func TestCLIPermissionEOFAndNilStdinDeny(t *testing.T) {
+	req := glue.PermissionRequest{Tool: "shell_exec", Action: "exec", Target: "go test ./..."}
+
+	eofPerm := NewCLIPermission(CLIPermissionOptions{Stdin: strings.NewReader("")})
+	eofDecision, err := eofPerm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("EOF Decide: %v", err)
+	}
+	if eofDecision.Allow || !strings.Contains(eofDecision.Reason, "no input") {
+		t.Fatalf("EOF decision = %+v, want no-input deny", eofDecision)
+	}
+
+	nilPerm := NewCLIPermission(CLIPermissionOptions{})
+	nilDecision, err := nilPerm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("nil Decide: %v", err)
+	}
+	if nilDecision.Allow || !strings.Contains(nilDecision.Reason, "stdin is not available") {
+		t.Fatalf("nil decision = %+v, want stdin deny", nilDecision)
+	}
+}

--- a/agents/peggy/coding.go
+++ b/agents/peggy/coding.go
@@ -1,0 +1,94 @@
+package peggy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/erain/glue"
+	toolsfs "github.com/erain/glue/tools/fs"
+	toolsgit "github.com/erain/glue/tools/git"
+	toolsshell "github.com/erain/glue/tools/shell"
+)
+
+// CodingTools builds Peggy's local coding tool set for the configured
+// workspace. It returns no tools when settings.Enabled is false.
+func CodingTools(settings CodingSettings) ([]glue.Tool, CodingSettings, error) {
+	if !settings.Enabled {
+		return nil, settings, nil
+	}
+
+	workDir := strings.TrimSpace(settings.WorkDir)
+	if workDir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, settings, fmt.Errorf("peggy: coding workdir: %w", err)
+		}
+		workDir = cwd
+	}
+	expanded, err := expandPath(workDir)
+	if err != nil {
+		return nil, settings, err
+	}
+	absWorkDir, err := filepath.Abs(expanded)
+	if err != nil {
+		return nil, settings, fmt.Errorf("peggy: coding workdir: %w", err)
+	}
+	info, err := os.Stat(absWorkDir)
+	if err != nil {
+		return nil, settings, fmt.Errorf("peggy: coding workdir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, settings, fmt.Errorf("peggy: coding workdir %q is not a directory", absWorkDir)
+	}
+
+	allowed := normalizedAllowedBinaries(settings.AllowedBinaries)
+	if len(allowed) == 0 {
+		allowed = append([]string(nil), DefaultCodingAllowedBinaries...)
+	}
+	settings.WorkDir = absWorkDir
+	settings.AllowedBinaries = allowed
+
+	blocklist := toolsfs.Default()
+	write, err := toolsfs.FileWrite(toolsfs.FileWriteOptions{
+		WorkDir:        absWorkDir,
+		AllowOverwrite: settings.AllowOverwrite,
+		Blocklist:      blocklist,
+	})
+	if err != nil {
+		return nil, settings, err
+	}
+	shell, err := toolsshell.Exec(toolsshell.ExecOptions{
+		WorkDir:         absWorkDir,
+		AllowedBinaries: allowed,
+	})
+	if err != nil {
+		return nil, settings, err
+	}
+
+	return []glue.Tool{
+		toolsfs.ReadFileTool(toolsfs.ReadFileOptions{WorkDir: absWorkDir, Blocklist: blocklist}),
+		write,
+		shell,
+		toolsgit.DiffBranchTool(toolsgit.DiffBranchOptions{WorkDir: absWorkDir}),
+		toolsgit.LogBranchTool(toolsgit.LogBranchOptions{WorkDir: absWorkDir}),
+	}, settings, nil
+}
+
+func normalizedAllowedBinaries(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, raw := range in {
+		bin := strings.TrimSpace(raw)
+		if bin == "" {
+			continue
+		}
+		if _, ok := seen[bin]; ok {
+			continue
+		}
+		seen[bin] = struct{}{}
+		out = append(out, bin)
+	}
+	return out
+}

--- a/agents/peggy/coding_test.go
+++ b/agents/peggy/coding_test.go
@@ -1,0 +1,190 @@
+package peggy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+	filestore "github.com/erain/glue/stores/file"
+)
+
+type scriptedProvider struct {
+	turns    [][]glue.ProviderEvent
+	calls    int
+	requests []glue.ProviderRequest
+}
+
+func (p *scriptedProvider) Stream(_ context.Context, req glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	if p.calls >= len(p.turns) {
+		return nil, errors.New("scriptedProvider: unexpected call")
+	}
+	p.requests = append(p.requests, req)
+	events := p.turns[p.calls]
+	p.calls++
+	ch := make(chan glue.ProviderEvent, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+type recordingPermission struct {
+	requests []glue.PermissionRequest
+	decision glue.PermissionDecision
+}
+
+func (p *recordingPermission) Decide(_ context.Context, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	p.requests = append(p.requests, req)
+	return p.decision, nil
+}
+
+func toolCallTurn(id, name, args string) []glue.ProviderEvent {
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventToolCall, ToolCall: &glue.ToolCall{ID: id, Name: name, Arguments: []byte(args)}},
+		{Type: glue.ProviderEventDone},
+	}
+}
+
+func peggyTextTurn(text string) []glue.ProviderEvent {
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: text},
+		{Type: glue.ProviderEventDone},
+	}
+}
+
+func newCodingTestPeggy(t *testing.T, provider glue.Provider, workDir string, perm glue.Permission) *Peggy {
+	t.Helper()
+	p, err := New(Options{
+		Settings: Settings{Coding: CodingSettings{
+			Enabled:         true,
+			WorkDir:         workDir,
+			AllowOverwrite:  true,
+			AllowedBinaries: []string{"go"},
+		}},
+		Provider:   provider,
+		Store:      filestore.New(filepath.Join(t.TempDir(), "sessions")),
+		Permission: perm,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func TestCodingToolsRegisteredWhenEnabled(t *testing.T) {
+	fp := &fakeProvider{text: "ok"}
+	p := newCodingTestPeggy(t, fp, t.TempDir(), glue.AllowAll{})
+
+	if _, err := p.Prompt(context.Background(), "s", "what can you do?", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(fp.requests) == 0 {
+		t.Fatal("provider not called")
+	}
+	var got []string
+	for _, tool := range fp.requests[0].Tools {
+		got = append(got, tool.Name)
+	}
+	sort.Strings(got)
+	for _, want := range []string{"git_diff_branch", "git_log_branch", "read_file", "shell_exec", "write_file"} {
+		if !containsString(got, want) {
+			t.Fatalf("tools = %v, missing %s", got, want)
+		}
+	}
+	if !filepath.IsAbs(p.Settings().Coding.WorkDir) {
+		t.Fatalf("coding workdir = %q, want absolute", p.Settings().Coding.WorkDir)
+	}
+}
+
+func TestPeggyCodingWriteFileAsksPermissionAndWrites(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "write_file", `{"path":"note.txt","content":"hello"}`),
+		peggyTextTurn("done"),
+	}}
+	perm := &recordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	p := newCodingTestPeggy(t, provider, workDir, perm)
+
+	if _, err := p.Prompt(context.Background(), "s", "write a note", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(perm.requests) != 1 {
+		t.Fatalf("permission requests = %d, want 1", len(perm.requests))
+	}
+	if got := perm.requests[0].Tool; got != "write_file" {
+		t.Fatalf("permission tool = %q, want write_file", got)
+	}
+	data, err := os.ReadFile(filepath.Join(workDir, "note.txt"))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("written content = %q, want hello", data)
+	}
+}
+
+func TestPeggyCodingReadOnlyToolDoesNotAskPermission(t *testing.T) {
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "note.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "read_file", `{"path":"note.txt"}`),
+		peggyTextTurn("done"),
+	}}
+	perm := &recordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	p := newCodingTestPeggy(t, provider, workDir, perm)
+
+	if _, err := p.Prompt(context.Background(), "s", "read a note", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(perm.requests) != 0 {
+		t.Fatalf("permission requests = %d, want 0", len(perm.requests))
+	}
+	toolResult := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if toolResult.Role != glue.MessageRoleTool || !strings.Contains(toolResult.Content[0].Text, "hello") {
+		t.Fatalf("tool result = %#v, want read_file content", toolResult)
+	}
+}
+
+func TestPeggyCodingShellDenyIsModelVisibleToolError(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "shell_exec", `{"argv":["go","version"]}`),
+		peggyTextTurn("done"),
+	}}
+	perm := &recordingPermission{decision: glue.PermissionDecision{Allow: false, Reason: "not now"}}
+	p := newCodingTestPeggy(t, provider, workDir, perm)
+
+	if _, err := p.Prompt(context.Background(), "s", "run go version", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(perm.requests) != 1 {
+		t.Fatalf("permission requests = %d, want 1", len(perm.requests))
+	}
+	if got := perm.requests[0].Tool; got != "shell_exec" {
+		t.Fatalf("permission tool = %q, want shell_exec", got)
+	}
+	toolResult := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if !toolResult.IsError || !strings.Contains(toolResult.Content[0].Text, "not now") {
+		t.Fatalf("tool result = %#v, want denial tool error", toolResult)
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -40,6 +40,12 @@ type Options struct {
 	// Settings.Store.
 	Store glue.Store
 
+	// Permission answers side-effecting tool requests. Nil means
+	// side-effecting tools are denied by the core loop. The CLI
+	// supplies an interactive implementation when coding tools are
+	// enabled.
+	Permission glue.Permission
+
 	// Stderr collects diagnostic warnings (missing SOUL.md etc).
 	// Defaults to os.Stderr.
 	Stderr io.Writer
@@ -137,6 +143,12 @@ func New(opts Options) (*Peggy, error) {
 			}
 		}
 	}
+	codingTools, codingSettings, err := CodingTools(settings.Coding)
+	if err != nil {
+		return nil, err
+	}
+	settings.Coding = codingSettings
+	tools = append(tools, codingTools...)
 	tools = append(tools, opts.ExtraTools...)
 
 	p.agent = glue.NewAgent(glue.AgentOptions{
@@ -145,6 +157,7 @@ func New(opts Options) (*Peggy, error) {
 		SystemPrompt:        finalSystem,
 		Tools:               tools,
 		Store:               store,
+		Permission:          opts.Permission,
 		Compactor:           compactor,
 		CompactionThreshold: settings.Compaction.Threshold,
 	})

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -6,7 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
+
+	"github.com/erain/glue"
 )
 
 // Version is the package version string surfaced by `peggy --version`.
@@ -21,13 +24,22 @@ const Version = "0.1.0"
 // captured stdout/stderr writers. For programmatic use prefer
 // constructing a Peggy via New.
 func Run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	return RunWithInput(ctx, args, os.Stdin, stdout, stderr)
+}
+
+// RunWithInput is like [Run] but lets tests and embedded callers provide the
+// stdin reader used by the CLI permission prompt.
+func RunWithInput(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("peggy", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
-		configPath  = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
-		soulPath    = fs.String("soul", "", "path to identity Markdown (overrides $PEGGY_SOUL / XDG / ~/.config/peggy/SOUL.md)")
-		sessionID   = fs.String("session", "default", "session id (file-backed transcripts key off this)")
-		showVersion = fs.Bool("version", false, "print version and exit")
+		configPath           = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		soulPath             = fs.String("soul", "", "path to identity Markdown (overrides $PEGGY_SOUL / XDG / ~/.config/peggy/SOUL.md)")
+		sessionID            = fs.String("session", "default", "session id (file-backed transcripts key off this)")
+		showVersion          = fs.Bool("version", false, "print version and exit")
+		enableCoding         = fs.Bool("coding", false, "enable local coding tools for this prompt")
+		codingWorkDir        = fs.String("workdir", "", "workspace root for --coding (default current directory)")
+		codingAllowOverwrite = fs.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
 	)
 	fs.Usage = func() {
 		fmt.Fprintf(stderr, `peggy — long-running personal-assistant agent built on glue.
@@ -39,6 +51,7 @@ Examples:
   peggy "hello"
   peggy --session work "remind me about the migration plan"
   peggy --config /tmp/peggy.json "what do you know about my Aussie?"
+  peggy --coding --workdir . "run the tests and fix the failure"
 
 Flags:
 `)
@@ -75,6 +88,15 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 	if settingsPath == "" {
 		fmt.Fprintln(stderr, "peggy: no settings.json found; using built-in defaults")
 	}
+	if *enableCoding || *codingWorkDir != "" || *codingAllowOverwrite {
+		settings.Coding.Enabled = true
+	}
+	if *codingWorkDir != "" {
+		settings.Coding.WorkDir = *codingWorkDir
+	}
+	if *codingAllowOverwrite {
+		settings.Coding.AllowOverwrite = true
+	}
 
 	soul, soulPathUsed, err := LoadSoul(*soulPath)
 	if err != nil {
@@ -87,10 +109,21 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 		fmt.Fprintf(stderr, "peggy: identity loaded from %s (%d bytes)\n", soulPathUsed, len(soul))
 	}
 
+	var permission glue.Permission
+	if settings.Coding.Enabled {
+		permission = NewCLIPermission(CLIPermissionOptions{Stdin: stdin, Stderr: stderr})
+		workDir := settings.Coding.WorkDir
+		if strings.TrimSpace(workDir) == "" {
+			workDir = "."
+		}
+		fmt.Fprintf(stderr, "peggy: coding tools enabled for %s\n", workDir)
+	}
+
 	p, err := New(Options{
-		Settings: settings,
-		Soul:     soul,
-		Stderr:   stderr,
+		Settings:   settings,
+		Soul:       soul,
+		Stderr:     stderr,
+		Permission: permission,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy: setup: %v\n", err)

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -122,3 +122,32 @@ func TestRun_PromptArgsJoined(t *testing.T) {
 		t.Fatalf("exit 2 indicates the prompt wasn't recognised; stderr=%q", errOut.String())
 	}
 }
+
+func TestRun_CodingFlagsParseAndUseInputAwareRunner(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "settings.json")
+	cfg := map[string]any{
+		"provider": "bogus-provider",
+		"store":    map[string]any{"type": "file", "path": filepath.Join(cfgDir, "s")},
+	}
+	raw, _ := json.MarshalIndent(cfg, "", "  ")
+	_ = os.WriteFile(cfgPath, raw, 0o600)
+
+	var out, errOut bytes.Buffer
+	code := RunWithInput(context.Background(), []string{
+		"--config", cfgPath,
+		"--coding",
+		"--workdir", t.TempDir(),
+		"help",
+	}, strings.NewReader("n\n"), &out, &errOut)
+	if code == 2 {
+		t.Fatalf("exit 2 indicates coding flags were not recognised; stderr=%q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "coding tools enabled") {
+		t.Fatalf("stderr = %q, want coding diagnostic", errOut.String())
+	}
+}

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -36,6 +36,10 @@ type Settings struct {
 	// back to the framework defaults (target 8000 / keep 8).
 	Compaction CompactionSettings `json:"compaction"`
 
+	// Coding configures Peggy's local coding tools. Disabled by
+	// default; enable only for trusted local workspaces.
+	Coding CodingSettings `json:"coding"`
+
 	// Channels carries per-channel configuration subtrees keyed by
 	// channel name (e.g. "telegram"). Each channel package decodes
 	// its own subtree via a DecodeConfig helper. Empty means "no
@@ -58,6 +62,26 @@ type CompactionSettings struct {
 	Threshold int `json:"threshold"`
 }
 
+// CodingSettings configures local code-reading, editing, and command
+// execution tools.
+type CodingSettings struct {
+	// Enabled registers local coding tools when true.
+	Enabled bool `json:"enabled"`
+
+	// WorkDir is the workspace root for all coding tools. Empty uses
+	// the current working directory when Enabled is true.
+	WorkDir string `json:"work_dir"`
+
+	// AllowedBinaries is the basename allowlist for shell_exec.
+	// Empty falls back to DefaultCodingAllowedBinaries.
+	AllowedBinaries []string `json:"allowed_binaries"`
+
+	// AllowOverwrite is the host-level file overwrite policy for
+	// write_file. The model must also pass overwrite=true and the
+	// Permission implementation must allow the call.
+	AllowOverwrite bool `json:"allow_overwrite"`
+}
+
 // Environment variables consulted when paths aren't given explicitly.
 const (
 	EnvConfigPath = "PEGGY_CONFIG"
@@ -68,6 +92,11 @@ const (
 // DefaultProvider is the registry-default provider Peggy uses when
 // no settings file is present.
 const DefaultProvider = "codex"
+
+// DefaultCodingAllowedBinaries is the conservative shell_exec allowlist
+// Peggy uses when coding tools are enabled and no explicit list is
+// configured.
+var DefaultCodingAllowedBinaries = []string{"go", "git", "make", "node", "npm", "python", "python3"}
 
 // LoadSettings reads and parses settings.json. When path is empty,
 // the loader walks the resolution chain $PEGGY_CONFIG →
@@ -106,6 +135,13 @@ func LoadSettings(path string) (Settings, string, error) {
 			return Settings{}, resolved, err
 		}
 		s.Store.Path = expanded
+	}
+	if s.Coding.WorkDir != "" {
+		expanded, err := expandPath(s.Coding.WorkDir)
+		if err != nil {
+			return Settings{}, resolved, err
+		}
+		s.Coding.WorkDir = expanded
 	}
 	return s, resolved, nil
 }
@@ -212,6 +248,9 @@ func fillDefaults(s Settings) Settings {
 	}
 	if s.Compaction.KeepRecent == 0 {
 		s.Compaction.KeepRecent = 8
+	}
+	if len(s.Coding.AllowedBinaries) == 0 {
+		s.Coding.AllowedBinaries = append([]string(nil), DefaultCodingAllowedBinaries...)
 	}
 	return s
 }

--- a/agents/peggy/settings_test.go
+++ b/agents/peggy/settings_test.go
@@ -155,6 +155,34 @@ func TestLoadSettings_InvalidJSONErrors(t *testing.T) {
 	}
 }
 
+func TestLoadSettings_CodingDefaultsAndWorkDirExpansion(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(XDGConfigEnv, "")
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeJSON(t, path, map[string]any{
+		"coding": map[string]any{
+			"enabled":  true,
+			"work_dir": "~",
+		},
+	})
+
+	s, _, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if !s.Coding.Enabled {
+		t.Fatal("coding.enabled = false, want true")
+	}
+	if s.Coding.WorkDir != home {
+		t.Fatalf("coding.work_dir = %q, want %q", s.Coding.WorkDir, home)
+	}
+	if len(s.Coding.AllowedBinaries) == 0 {
+		t.Fatal("coding.allowed_binaries default is empty")
+	}
+}
+
 func TestExpandPath_HomeAndTilde(t *testing.T) {
 	t.Setenv("HOME", "/tmp/peggy-home")
 	got, err := expandPath("~/.cache")


### PR DESCRIPTION
## Summary

- adds opt-in Peggy coding mode with workspace-rooted read/write/shell/git tools
- adds `peggy.Options.Permission` plus a CLI permission implementation with allow-once/session/target choices
- wires `--coding`, `--workdir`, and `--coding-allow-overwrite` through the single-prompt CLI
- documents the coding settings, CLI flags, tools, and permission prompt

## Verification

- `go test ./agents/peggy -run 'Test(Coding|PeggyCoding|CLIPermission|LoadSettings_Coding)' -count=1`
- `go test ./agents/peggy -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`
