### PR TITLE
agents/peggy/telegram: add permission prompts

### DIFF
--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -82,7 +82,28 @@ sqlite store. `Agent.SearchSessions` can scope to one channel by
 filtering on the session id (FTS5 prefix search is a planned
 follow-up; exact-match works today).
 
-## What v0.1 supports
+## Permissions
+
+When Peggy coding tools are enabled in the shared `settings.json`,
+side-effecting tool calls (`write_file`, `shell_exec`) are confirmed in
+Telegram with inline keyboard buttons:
+
+- `Deny`
+- `Allow once`
+- `Allow session`
+- `Allow target`
+
+Permission requests are sent only to the same allowlisted chat whose
+message triggered the prompt. Decisions remembered for a session or
+target live only in the running `peggy-telegram` process. If the bot is
+stopped, the request times out, or the callback comes from a
+non-allowlisted chat, Peggy denies the side effect and surfaces that
+denial to the model as a tool result.
+
+Read-only tools such as `read_file`, `git_diff_branch`, and
+`git_log_branch` do not prompt.
+
+## What Peggy on Telegram supports today
 
 - Text-message-only inbound and outbound. Photos / voice / documents /
   stickers are dropped.
@@ -96,11 +117,13 @@ follow-up; exact-match works today).
 - Replies exceeding Telegram's 4096-character limit are truncated
   with a `… [truncated]` suffix; full responses are still in the
   session transcript / sqlite store.
+- Inline-keyboard permission prompts for side-effecting coding tools
+  in allowlisted chats.
 
 ## What's coming
 
 - Edit-in-place streaming for replies (delta → edited message).
-- Per-user permission policy (gated by the M2 `Permission` interface).
+- Persistent per-user permission policy.
 - Webhook-mode (push-based) for low-latency hosted setups.
 - `Agent.SearchSessions` channel-prefix filter so the user can scope
   recall to "things we talked about on Telegram."

--- a/agents/peggy/channels/telegram/api.go
+++ b/agents/peggy/channels/telegram/api.go
@@ -15,8 +15,9 @@ import (
 // Update is one entry from getUpdates. Only the fields glue needs are
 // modeled; everything else is ignored.
 type Update struct {
-	UpdateID int64    `json:"update_id"`
-	Message  *Message `json:"message,omitempty"`
+	UpdateID      int64          `json:"update_id"`
+	Message       *Message       `json:"message,omitempty"`
+	CallbackQuery *CallbackQuery `json:"callback_query,omitempty"`
 }
 
 // Message is the text message variant we care about. Photo, voice,
@@ -41,6 +42,26 @@ type Chat struct {
 	ID    int64  `json:"id"`
 	Type  string `json:"type"`
 	Title string `json:"title,omitempty"`
+}
+
+// CallbackQuery is the inline-keyboard callback variant used by
+// permission prompts.
+type CallbackQuery struct {
+	ID      string   `json:"id"`
+	From    *User    `json:"from,omitempty"`
+	Message *Message `json:"message,omitempty"`
+	Data    string   `json:"data,omitempty"`
+}
+
+// InlineKeyboardMarkup is Telegram's inline keyboard payload shape.
+type InlineKeyboardMarkup struct {
+	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
+}
+
+// InlineKeyboardButton is one inline keyboard button.
+type InlineKeyboardButton struct {
+	Text         string `json:"text"`
+	CallbackData string `json:"callback_data"`
 }
 
 // API is the minimal Telegram Bot API client used by the channel.
@@ -84,15 +105,38 @@ func (a *API) GetUpdates(ctx context.Context, offset int64, timeoutSeconds int) 
 // SendMessage sends a text message to chatID. text is truncated to
 // telegramMessageLimit bytes (Telegram's hard cap).
 func (a *API) SendMessage(ctx context.Context, chatID int64, text string) error {
+	return a.SendMessageWithReplyMarkup(ctx, chatID, text, nil)
+}
+
+// SendMessageWithReplyMarkup sends a text message with optional Telegram
+// reply_markup such as [InlineKeyboardMarkup].
+func (a *API) SendMessageWithReplyMarkup(ctx context.Context, chatID int64, text string, replyMarkup any) error {
 	if len(text) > telegramMessageLimit {
 		text = text[:telegramMessageLimit-len(truncationSuffix)] + truncationSuffix
 	}
-	body, _ := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"chat_id": chatID,
 		"text":    text,
-	})
+	}
+	if replyMarkup != nil {
+		payload["reply_markup"] = replyMarkup
+	}
+	body, _ := json.Marshal(payload)
 	_, err := a.do(ctx, "sendMessage", body, func(b []byte) ([]Update, error) {
 		// sendMessage's result is the sent Message; we don't need it.
+		return nil, nil
+	})
+	return err
+}
+
+// AnswerCallbackQuery acknowledges an inline-keyboard callback. text may be
+// empty.
+func (a *API) AnswerCallbackQuery(ctx context.Context, callbackQueryID, text string) error {
+	body, _ := json.Marshal(map[string]any{
+		"callback_query_id": callbackQueryID,
+		"text":              text,
+	})
+	_, err := a.do(ctx, "answerCallbackQuery", body, func(b []byte) ([]Update, error) {
 		return nil, nil
 	})
 	return err

--- a/agents/peggy/channels/telegram/api_test.go
+++ b/agents/peggy/channels/telegram/api_test.go
@@ -42,6 +42,31 @@ func TestGetUpdates_ParsesCannedResponse(t *testing.T) {
 	}
 }
 
+func TestGetUpdates_ParsesCallbackQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{
+            "ok": true,
+            "result": [
+                {"update_id": 3, "callback_query": {"id": "cb1", "from": {"id": 42}, "message": {"message_id": 200, "chat": {"id": 555, "type": "private"}, "date": 1700000000, "text": "permission"}, "data": "perm:abc:once"}}
+            ]
+        }`)
+	}))
+	defer srv.Close()
+
+	api := NewAPI(srv.URL, "secret-token", srv.Client())
+	updates, err := api.GetUpdates(context.Background(), 0, 30)
+	if err != nil {
+		t.Fatalf("GetUpdates: %v", err)
+	}
+	if len(updates) != 1 || updates[0].CallbackQuery == nil {
+		t.Fatalf("updates = %+v, want callback_query", updates)
+	}
+	cb := updates[0].CallbackQuery
+	if cb.ID != "cb1" || cb.Data != "perm:abc:once" || cb.Message.Chat.ID != 555 {
+		t.Fatalf("callback = %+v, want parsed id/data/chat", cb)
+	}
+}
+
 func TestSendMessage_PostsCorrectShape(t *testing.T) {
 	var capturedBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -66,6 +91,57 @@ func TestSendMessage_PostsCorrectShape(t *testing.T) {
 	}
 	if body["text"] != "hello" {
 		t.Errorf("text = %v", body["text"])
+	}
+}
+
+func TestSendMessageWithReplyMarkup_PostsInlineKeyboard(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/sendMessage") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"ok": true, "result": {}}`)
+	}))
+	defer srv.Close()
+
+	api := NewAPI(srv.URL, "tk", srv.Client())
+	keyboard := InlineKeyboardMarkup{InlineKeyboard: [][]InlineKeyboardButton{{
+		{Text: "Allow once", CallbackData: "perm:1:once"},
+	}}}
+	if err := api.SendMessageWithReplyMarkup(context.Background(), 555, "allow?", keyboard); err != nil {
+		t.Fatalf("SendMessageWithReplyMarkup: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(capturedBody, &body); err != nil {
+		t.Fatalf("body json: %v", err)
+	}
+	if body["reply_markup"] == nil {
+		t.Fatalf("body = %+v, missing reply_markup", body)
+	}
+}
+
+func TestAnswerCallbackQuery_PostsCorrectShape(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/answerCallbackQuery") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"ok": true, "result": {}}`)
+	}))
+	defer srv.Close()
+
+	api := NewAPI(srv.URL, "tk", srv.Client())
+	if err := api.AnswerCallbackQuery(context.Background(), "cb1", "Allowed."); err != nil {
+		t.Fatalf("AnswerCallbackQuery: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(capturedBody, &body); err != nil {
+		t.Fatalf("body json: %v", err)
+	}
+	if body["callback_query_id"] != "cb1" || body["text"] != "Allowed." {
+		t.Fatalf("body = %+v, want callback id/text", body)
 	}
 }
 

--- a/agents/peggy/channels/telegram/channel.go
+++ b/agents/peggy/channels/telegram/channel.go
@@ -38,6 +38,11 @@ type Options struct {
 	// errors, etc.). Defaults to os.Stderr. The channel never logs
 	// the bot token here.
 	Stderr io.Writer
+
+	// Permission, when non-nil, handles inline-keyboard responses for
+	// Peggy side-effect permission requests. The same value must be
+	// passed to peggy.New via peggy.Options.Permission.
+	Permission *Permission
 }
 
 // Channel is the peggy.Channel implementation for Telegram.
@@ -47,6 +52,7 @@ type Channel struct {
 	api     *API
 	allowed map[int64]struct{}
 	stderr  io.Writer
+	perm    *Permission
 }
 
 // New constructs a Channel. Returns an error when required fields are
@@ -93,13 +99,18 @@ func New(opts Options) (*Channel, error) {
 		allowed[id] = struct{}{}
 	}
 
-	return &Channel{
+	ch := &Channel{
 		peggy:   opts.Peggy,
 		cfg:     cfg,
 		api:     NewAPI(cfg.APIBaseURL, token, opts.HTTPClient),
 		allowed: allowed,
 		stderr:  stderr,
-	}, nil
+		perm:    opts.Permission,
+	}
+	if ch.perm != nil {
+		ch.perm.attach(ch.api, ch.allowed, stderr)
+	}
+	return ch, nil
 }
 
 // Name implements peggy.Channel.
@@ -115,8 +126,8 @@ func (c *Channel) Run(ctx context.Context) error {
 		fmt.Fprintln(c.stderr, "telegram: allow_chats is empty — refusing all inbound messages (set allow_chats in settings.json to enable)")
 	}
 	var (
-		offset    int64
-		backoff   = transientRetryInitial
+		offset     int64
+		backoff    = transientRetryInitial
 		maxBackoff = transientRetryMax
 	)
 	for {
@@ -145,8 +156,32 @@ func (c *Channel) Run(ctx context.Context) error {
 			if u.UpdateID >= offset {
 				offset = u.UpdateID + 1
 			}
-			c.handleUpdate(ctx, u)
+			if u.CallbackQuery != nil {
+				c.handleCallback(ctx, *u.CallbackQuery)
+				continue
+			}
+			go c.handleUpdate(ctx, u)
 		}
+	}
+}
+
+func (c *Channel) handleCallback(ctx context.Context, cb CallbackQuery) {
+	chatID, ok := callbackChatID(cb)
+	if !ok {
+		if c.perm != nil {
+			_ = c.perm.handleCallback(ctx, cb)
+		}
+		return
+	}
+	if _, ok := c.allowed[chatID]; !ok {
+		fmt.Fprintf(c.stderr, "telegram: dropping callback from non-allowlisted chat %d\n", chatID)
+		if c.perm != nil {
+			_ = c.perm.handleCallback(ctx, cb)
+		}
+		return
+	}
+	if c.perm != nil && c.perm.handleCallback(ctx, cb) {
+		return
 	}
 }
 

--- a/agents/peggy/channels/telegram/channel_test.go
+++ b/agents/peggy/channels/telegram/channel_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -43,6 +44,38 @@ func (p *fakeProvider) Stream(_ context.Context, req glue.ProviderRequest) (<-ch
 		Role:    glue.MessageRoleAssistant,
 		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
 	}}
+	close(ch)
+	return ch, nil
+}
+
+type toolProvider struct {
+	mu       sync.Mutex
+	requests []glue.ProviderRequest
+	calls    int
+}
+
+func (p *toolProvider) Stream(_ context.Context, req glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, req)
+	call := p.calls
+	p.calls++
+	p.mu.Unlock()
+	ch := make(chan glue.ProviderEvent, 4)
+	ch <- glue.ProviderEvent{Type: glue.ProviderEventStart}
+	if call == 0 {
+		ch <- glue.ProviderEvent{Type: glue.ProviderEventToolCall, ToolCall: &glue.ToolCall{
+			ID:        "c1",
+			Name:      "write_file",
+			Arguments: []byte(`{"path":"note.txt","content":"hello from telegram"}`),
+		}}
+		ch <- glue.ProviderEvent{Type: glue.ProviderEventDone}
+	} else {
+		ch <- glue.ProviderEvent{Type: glue.ProviderEventTextDelta, Delta: "done"}
+		ch <- glue.ProviderEvent{Type: glue.ProviderEventDone, Message: &glue.Message{
+			Role:    glue.MessageRoleAssistant,
+			Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "done"}},
+		}}
+	}
 	close(ch)
 	return ch, nil
 }
@@ -125,9 +158,32 @@ func (f *telegramFixture) lastSendText() string {
 	return ""
 }
 
+func (f *telegramFixture) sendBody(index int) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if index < 0 || index >= len(f.sendBodies) {
+		return nil
+	}
+	return append([]byte(nil), f.sendBodies[index]...)
+}
+
+func (f *telegramFixture) appendUpdates(updates []Update) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = append(f.updates, updates)
+}
+
 func messageUpdate(updateID int64, chatID int64, text string) Update {
 	return Update{UpdateID: updateID, Message: &Message{
 		MessageID: updateID, Chat: Chat{ID: chatID, Type: "private"}, Text: text, Date: time.Now().Unix(),
+	}}
+}
+
+func callbackUpdate(updateID int64, chatID int64, data string) Update {
+	return Update{UpdateID: updateID, CallbackQuery: &CallbackQuery{
+		ID:      fmt.Sprintf("cb-%d", updateID),
+		Message: &Message{MessageID: updateID, Chat: Chat{ID: chatID, Type: "private"}, Text: "permission", Date: time.Now().Unix()},
+		Data:    data,
 	}}
 }
 
@@ -188,6 +244,67 @@ func TestChannel_AllowedChatPromptsAndReplies(t *testing.T) {
 	}
 	if msgs := sess.Messages(); len(msgs) == 0 {
 		t.Errorf("namespaced session has no messages — session-id routing broken")
+	}
+}
+
+func TestChannel_TelegramPermissionCallbackUnblocksPrompt(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &toolProvider{}
+	store := filestore.New(filepath.Join(t.TempDir(), "sessions"))
+	perm := NewPermission(PermissionOptions{Timeout: 2 * time.Second})
+	p, err := peggy.New(peggy.Options{
+		Settings: peggy.Settings{Coding: peggy.CodingSettings{
+			Enabled:         true,
+			WorkDir:         workDir,
+			AllowOverwrite:  true,
+			AllowedBinaries: []string{"go"},
+		}},
+		Provider:           provider,
+		Store:              store,
+		DisableMemoryTools: true,
+		Permission:         perm,
+	})
+	if err != nil {
+		t.Fatalf("peggy.New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	fix := newTelegramFixture(t, [][]Update{{messageUpdate(1, 555, "write the file")}})
+	ch, err := New(Options{
+		Peggy:      p,
+		Token:      "secret",
+		Permission: perm,
+		Config: Config{
+			AllowChats:             []int64{555},
+			APIBaseURL:             fix.server.URL,
+			LongPollTimeoutSeconds: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- ch.Run(ctx) }()
+
+	waitFor(t, func() bool { return fix.sendCount() >= 1 })
+	callbackData := callbackDataForButton(t, fix.sendBody(0), "Allow once")
+	fix.appendUpdates([]Update{callbackUpdate(2, 555, callbackData)})
+	waitFor(t, func() bool { return fix.sendCount() >= 2 })
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(workDir, "note.txt"))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "hello from telegram" {
+		t.Fatalf("written content = %q", data)
+	}
+	if got := fix.lastSendText(); got != "done" {
+		t.Fatalf("final send text = %q, want done", got)
 	}
 }
 

--- a/agents/peggy/channels/telegram/permission.go
+++ b/agents/peggy/channels/telegram/permission.go
@@ -1,0 +1,340 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/agents/peggy"
+)
+
+const (
+	defaultPermissionTimeout = 10 * time.Minute
+	permissionCallbackPrefix = "perm:"
+	permissionArgsPreviewMax = 320
+)
+
+// PermissionOptions configures [NewPermission].
+type PermissionOptions struct {
+	// Timeout caps how long a side-effecting tool waits for a Telegram
+	// button response. Zero uses a conservative default.
+	Timeout time.Duration
+
+	// Stderr receives diagnostics. Nil discards output.
+	Stderr io.Writer
+}
+
+// Permission is a Telegram inline-keyboard implementation of
+// glue.Permission. It is configured by [Channel] and is safe for concurrent
+// use by prompt goroutines and the long-poll callback handler.
+type Permission struct {
+	mu sync.Mutex
+
+	api     *API
+	allowed map[int64]struct{}
+	stderr  io.Writer
+	timeout time.Duration
+
+	nextNonce     atomic.Uint64
+	pending       map[string]*pendingPermission
+	sessionAllows map[string]struct{}
+	targetAllows  map[string]struct{}
+}
+
+type pendingPermission struct {
+	chatID int64
+	req    glue.PermissionRequest
+	done   chan glue.PermissionDecision
+}
+
+// NewPermission constructs a Telegram permission adapter. The channel attaches
+// API and allowlist state during New.
+func NewPermission(opts PermissionOptions) *Permission {
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = defaultPermissionTimeout
+	}
+	return &Permission{
+		stderr:        opts.Stderr,
+		timeout:       timeout,
+		pending:       map[string]*pendingPermission{},
+		sessionAllows: map[string]struct{}{},
+		targetAllows:  map[string]struct{}{},
+	}
+}
+
+func (p *Permission) attach(api *API, allowed map[int64]struct{}, stderr io.Writer) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.api = api
+	p.allowed = cloneAllowedChats(allowed)
+	if p.stderr == nil {
+		p.stderr = stderr
+	}
+	if p.pending == nil {
+		p.pending = map[string]*pendingPermission{}
+	}
+	if p.sessionAllows == nil {
+		p.sessionAllows = map[string]struct{}{}
+	}
+	if p.targetAllows == nil {
+		p.targetAllows = map[string]struct{}{}
+	}
+}
+
+// Decide implements glue.Permission.
+func (p *Permission) Decide(ctx context.Context, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	if p == nil {
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: telegram permission handler is not configured"}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return glue.PermissionDecision{}, err
+	}
+
+	chatID, err := chatIDFromSession(req.SessionID)
+	if err != nil {
+		return glue.PermissionDecision{Allow: false, Reason: err.Error()}, nil
+	}
+
+	sessionKey := permissionSessionKey(req)
+	targetKey := permissionTargetKey(req)
+	nonce := strconv.FormatUint(p.nextNonce.Add(1), 36)
+	pending := &pendingPermission{chatID: chatID, req: req, done: make(chan glue.PermissionDecision, 1)}
+
+	p.mu.Lock()
+	if _, ok := p.sessionAllows[sessionKey]; ok {
+		p.mu.Unlock()
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}, nil
+	}
+	if _, ok := p.targetAllows[targetKey]; ok {
+		p.mu.Unlock()
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSessionTarget}, nil
+	}
+	api := p.api
+	_, allowed := p.allowed[chatID]
+	p.pending[nonce] = pending
+	p.mu.Unlock()
+
+	if !allowed {
+		p.deletePending(nonce)
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: chat is not allowlisted"}, nil
+	}
+	if api == nil {
+		p.deletePending(nonce)
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: telegram API is not configured"}, nil
+	}
+
+	if err := api.SendMessageWithReplyMarkup(ctx, chatID, permissionMessage(req), permissionKeyboard(nonce)); err != nil {
+		p.deletePending(nonce)
+		p.print("telegram: send permission prompt to chat %d: %v\n", chatID, err)
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: failed to send Telegram permission prompt"}, nil
+	}
+
+	timer := time.NewTimer(p.timeout)
+	defer timer.Stop()
+	select {
+	case decision := <-pending.done:
+		p.rememberDecision(req, decision)
+		return decision, nil
+	case <-timer.C:
+		p.deletePending(nonce)
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: Telegram permission prompt timed out"}, nil
+	case <-ctx.Done():
+		p.deletePending(nonce)
+		return glue.PermissionDecision{}, ctx.Err()
+	}
+}
+
+func (p *Permission) handleCallback(ctx context.Context, cb CallbackQuery) bool {
+	if p == nil || !strings.HasPrefix(cb.Data, permissionCallbackPrefix) {
+		return false
+	}
+	nonce, action, ok := parsePermissionCallback(cb.Data)
+	if !ok {
+		p.answerCallback(ctx, cb.ID, "Invalid permission response.")
+		return true
+	}
+	chatID, ok := callbackChatID(cb)
+	if !ok {
+		p.answerCallback(ctx, cb.ID, "Permission response has no chat.")
+		return true
+	}
+
+	p.mu.Lock()
+	_, allowed := p.allowed[chatID]
+	pending := p.pending[nonce]
+	if pending != nil && pending.chatID == chatID && allowed {
+		delete(p.pending, nonce)
+	}
+	p.mu.Unlock()
+
+	if !allowed {
+		p.answerCallback(ctx, cb.ID, "This chat is not allowed.")
+		return true
+	}
+	if pending == nil || pending.chatID != chatID {
+		p.answerCallback(ctx, cb.ID, "Permission request expired.")
+		return true
+	}
+
+	decision := permissionDecisionForAction(action)
+	pending.done <- decision
+	if decision.Allow {
+		p.answerCallback(ctx, cb.ID, "Allowed.")
+	} else {
+		p.answerCallback(ctx, cb.ID, "Denied.")
+	}
+	return true
+}
+
+func (p *Permission) rememberDecision(req glue.PermissionRequest, decision glue.PermissionDecision) {
+	if !decision.Allow {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	switch decision.RememberFor {
+	case glue.RememberSession:
+		p.sessionAllows[permissionSessionKey(req)] = struct{}{}
+	case glue.RememberSessionTarget:
+		p.targetAllows[permissionTargetKey(req)] = struct{}{}
+	}
+}
+
+func (p *Permission) deletePending(nonce string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.pending, nonce)
+}
+
+func (p *Permission) answerCallback(ctx context.Context, callbackID, text string) {
+	if p == nil || callbackID == "" {
+		return
+	}
+	p.mu.Lock()
+	api := p.api
+	p.mu.Unlock()
+	if api == nil {
+		return
+	}
+	if err := api.AnswerCallbackQuery(ctx, callbackID, text); err != nil {
+		p.print("telegram: answerCallbackQuery: %v\n", err)
+	}
+}
+
+func (p *Permission) print(format string, args ...any) {
+	if p.stderr == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(p.stderr, format, args...)
+}
+
+func permissionKeyboard(nonce string) InlineKeyboardMarkup {
+	return InlineKeyboardMarkup{InlineKeyboard: [][]InlineKeyboardButton{
+		{
+			{Text: "Deny", CallbackData: permissionCallback(nonce, "deny")},
+			{Text: "Allow once", CallbackData: permissionCallback(nonce, "once")},
+		},
+		{
+			{Text: "Allow session", CallbackData: permissionCallback(nonce, "session")},
+			{Text: "Allow target", CallbackData: permissionCallback(nonce, "target")},
+		},
+	}}
+}
+
+func permissionCallback(nonce, action string) string {
+	return permissionCallbackPrefix + nonce + ":" + action
+}
+
+func parsePermissionCallback(data string) (nonce string, action string, ok bool) {
+	rest := strings.TrimPrefix(data, permissionCallbackPrefix)
+	parts := strings.Split(rest, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func permissionDecisionForAction(action string) glue.PermissionDecision {
+	switch action {
+	case "once":
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberNever}
+	case "session":
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}
+	case "target":
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSessionTarget}
+	default:
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied by Telegram user"}
+	}
+}
+
+func permissionMessage(req glue.PermissionRequest) string {
+	var b strings.Builder
+	b.WriteString("Peggy wants permission to run a side-effecting tool.\n\n")
+	fmt.Fprintf(&b, "Tool: %s\n", req.Tool)
+	fmt.Fprintf(&b, "Action: %s\n", req.Action)
+	if strings.TrimSpace(req.Target) != "" {
+		fmt.Fprintf(&b, "Target: %s\n", req.Target)
+	}
+	if preview := permissionArgsPreview(req.Args); preview != "" {
+		fmt.Fprintf(&b, "Args: %s\n", preview)
+	}
+	return b.String()
+}
+
+func permissionArgsPreview(raw json.RawMessage) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" || text == "null" {
+		return ""
+	}
+	if len(text) <= permissionArgsPreviewMax {
+		return text
+	}
+	return text[:permissionArgsPreviewMax] + "...(truncated)"
+}
+
+func permissionSessionKey(req glue.PermissionRequest) string {
+	return req.SessionID + "\x00" + req.Tool + "\x00" + req.Action
+}
+
+func permissionTargetKey(req glue.PermissionRequest) string {
+	return permissionSessionKey(req) + "\x00" + req.Target
+}
+
+func chatIDFromSession(sessionID string) (int64, error) {
+	raw := strings.TrimPrefix(sessionID, peggy.ChannelSessionID(ChannelName, ""))
+	if raw == "" || raw == sessionID {
+		return 0, errors.New("permission denied: request is not from a Telegram session")
+	}
+	chatID, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, errors.New("permission denied: invalid Telegram session id")
+	}
+	return chatID, nil
+}
+
+func callbackChatID(cb CallbackQuery) (int64, bool) {
+	if cb.Message == nil {
+		return 0, false
+	}
+	return cb.Message.Chat.ID, cb.Message.Chat.ID != 0
+}
+
+func cloneAllowedChats(in map[int64]struct{}) map[int64]struct{} {
+	out := make(map[int64]struct{}, len(in))
+	for k := range in {
+		out[k] = struct{}{}
+	}
+	return out
+}

--- a/agents/peggy/channels/telegram/permission_test.go
+++ b/agents/peggy/channels/telegram/permission_test.go
@@ -1,0 +1,259 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/agents/peggy"
+)
+
+type permissionAPIFixture struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	bodies map[string][][]byte
+}
+
+func newPermissionAPIFixture(t *testing.T) *permissionAPIFixture {
+	t.Helper()
+	f := &permissionAPIFixture{bodies: map[string][][]byte{}}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.bodies[method] = append(f.bodies[method], body)
+		f.mu.Unlock()
+		_, _ = io.WriteString(w, `{"ok": true, "result": {}}`)
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *permissionAPIFixture) count(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.bodies[method])
+}
+
+func (f *permissionAPIFixture) lastBody(method string) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	bodies := f.bodies[method]
+	if len(bodies) == 0 {
+		return nil
+	}
+	return append([]byte(nil), bodies[len(bodies)-1]...)
+}
+
+func TestTelegramPermissionAllowOnceFromCallback(t *testing.T) {
+	fix := newPermissionAPIFixture(t)
+	api := NewAPI(fix.server.URL, "tk", fix.server.Client())
+	perm := NewPermission(PermissionOptions{Timeout: time.Second})
+	perm.attach(api, map[int64]struct{}{555: {}}, nil)
+	req := glue.PermissionRequest{
+		Tool:      "shell_exec",
+		Action:    "exec",
+		Target:    "go test ./...",
+		Args:      []byte(`{"argv":["go","test","./..."]}`),
+		SessionID: peggy.ChannelSessionID(ChannelName, "555"),
+	}
+
+	decisionCh := make(chan glue.PermissionDecision, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		decision, err := perm.Decide(context.Background(), req)
+		decisionCh <- decision
+		errCh <- err
+	}()
+
+	waitFor(t, func() bool { return fix.count("sendMessage") == 1 })
+	callbackData := callbackDataForButton(t, fix.lastBody("sendMessage"), "Allow once")
+	if !perm.handleCallback(context.Background(), CallbackQuery{
+		ID:      "cb1",
+		Message: &Message{Chat: Chat{ID: 555}},
+		Data:    callbackData,
+	}) {
+		t.Fatal("callback was not handled")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Decide error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Decide error")
+	}
+	select {
+	case decision := <-decisionCh:
+		if !decision.Allow || decision.RememberFor != glue.RememberNever {
+			t.Fatalf("decision = %+v, want allow once", decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for decision")
+	}
+	if fix.count("answerCallbackQuery") != 1 {
+		t.Fatalf("answerCallbackQuery count = %d, want 1", fix.count("answerCallbackQuery"))
+	}
+}
+
+func TestTelegramPermissionRememberTarget(t *testing.T) {
+	fix := newPermissionAPIFixture(t)
+	api := NewAPI(fix.server.URL, "tk", fix.server.Client())
+	perm := NewPermission(PermissionOptions{Timeout: time.Second})
+	perm.attach(api, map[int64]struct{}{555: {}}, nil)
+	req := glue.PermissionRequest{
+		Tool:      "write_file",
+		Action:    "write_file",
+		Target:    "main.go",
+		SessionID: peggy.ChannelSessionID(ChannelName, "555"),
+	}
+
+	decisionCh := make(chan glue.PermissionDecision, 1)
+	go func() {
+		decision, _ := perm.Decide(context.Background(), req)
+		decisionCh <- decision
+	}()
+	waitFor(t, func() bool { return fix.count("sendMessage") == 1 })
+	callbackData := callbackDataForButton(t, fix.lastBody("sendMessage"), "Allow target")
+	perm.handleCallback(context.Background(), CallbackQuery{
+		ID:      "cb1",
+		Message: &Message{Chat: Chat{ID: 555}},
+		Data:    callbackData,
+	})
+	if decision := <-decisionCh; !decision.Allow || decision.RememberFor != glue.RememberSessionTarget {
+		t.Fatalf("decision = %+v, want target allow", decision)
+	}
+
+	second, err := perm.Decide(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second Decide: %v", err)
+	}
+	if !second.Allow || second.RememberFor != glue.RememberSessionTarget {
+		t.Fatalf("second = %+v, want cached target allow", second)
+	}
+	if fix.count("sendMessage") != 1 {
+		t.Fatalf("sendMessage count = %d, want cached second decision", fix.count("sendMessage"))
+	}
+}
+
+func TestTelegramPermissionRejectsCallbackFromDifferentChat(t *testing.T) {
+	fix := newPermissionAPIFixture(t)
+	api := NewAPI(fix.server.URL, "tk", fix.server.Client())
+	perm := NewPermission(PermissionOptions{Timeout: time.Second})
+	perm.attach(api, map[int64]struct{}{555: {}}, nil)
+	req := glue.PermissionRequest{
+		Tool:      "write_file",
+		Action:    "write_file",
+		Target:    "main.go",
+		SessionID: peggy.ChannelSessionID(ChannelName, "555"),
+	}
+
+	decisionCh := make(chan glue.PermissionDecision, 1)
+	go func() {
+		decision, _ := perm.Decide(context.Background(), req)
+		decisionCh <- decision
+	}()
+	waitFor(t, func() bool { return fix.count("sendMessage") == 1 })
+	callbackData := callbackDataForButton(t, fix.lastBody("sendMessage"), "Allow once")
+	perm.handleCallback(context.Background(), CallbackQuery{
+		ID:      "cb-wrong",
+		Message: &Message{Chat: Chat{ID: 999}},
+		Data:    callbackData,
+	})
+	select {
+	case decision := <-decisionCh:
+		t.Fatalf("wrong chat resolved decision unexpectedly: %+v", decision)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	perm.handleCallback(context.Background(), CallbackQuery{
+		ID:      "cb-right",
+		Message: &Message{Chat: Chat{ID: 555}},
+		Data:    callbackData,
+	})
+	select {
+	case decision := <-decisionCh:
+		if !decision.Allow {
+			t.Fatalf("decision = %+v, want allow after right chat callback", decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for right-chat decision")
+	}
+}
+
+func TestTelegramPermissionTimeoutAndAllowlistDeny(t *testing.T) {
+	fix := newPermissionAPIFixture(t)
+	api := NewAPI(fix.server.URL, "tk", fix.server.Client())
+	perm := NewPermission(PermissionOptions{Timeout: time.Millisecond})
+	perm.attach(api, map[int64]struct{}{555: {}}, nil)
+
+	timeoutDecision, err := perm.Decide(context.Background(), glue.PermissionRequest{
+		Tool:      "shell_exec",
+		Action:    "exec",
+		Target:    "go test ./...",
+		SessionID: peggy.ChannelSessionID(ChannelName, "555"),
+	})
+	if err != nil {
+		t.Fatalf("timeout Decide: %v", err)
+	}
+	if timeoutDecision.Allow || !strings.Contains(timeoutDecision.Reason, "timed out") {
+		t.Fatalf("timeout decision = %+v, want timeout deny", timeoutDecision)
+	}
+
+	denied, err := perm.Decide(context.Background(), glue.PermissionRequest{
+		Tool:      "shell_exec",
+		Action:    "exec",
+		Target:    "go test ./...",
+		SessionID: peggy.ChannelSessionID(ChannelName, "999"),
+	})
+	if err != nil {
+		t.Fatalf("allowlist Decide: %v", err)
+	}
+	if denied.Allow || !strings.Contains(denied.Reason, "allowlisted") {
+		t.Fatalf("allowlist decision = %+v, want allowlist deny", denied)
+	}
+}
+
+func callbackDataForButton(t *testing.T, body []byte, text string) string {
+	t.Helper()
+	var payload struct {
+		ReplyMarkup InlineKeyboardMarkup `json:"reply_markup"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("sendMessage body: %v", err)
+	}
+	for _, row := range payload.ReplyMarkup.InlineKeyboard {
+		for _, button := range row {
+			if button.Text == text {
+				return button.CallbackData
+			}
+		}
+	}
+	t.Fatalf("button %q not found in %#v", text, payload.ReplyMarkup)
+	return ""
+}
+
+func waitFor(t *testing.T, ok func() bool) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if ok() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for condition")
+		case <-tick.C:
+		}
+	}
+}

--- a/agents/peggy/cmd/peggy-telegram/main.go
+++ b/agents/peggy/cmd/peggy-telegram/main.go
@@ -76,10 +76,21 @@ Flags:
 		return 1
 	}
 
+	cfg, err := telegram.DecodeConfig(settings.Channels[telegram.ChannelName])
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+		return 1
+	}
+	var permission *telegram.Permission
+	if settings.Coding.Enabled {
+		permission = telegram.NewPermission(telegram.PermissionOptions{Stderr: stderr})
+	}
+
 	p, err := peggy.New(peggy.Options{
-		Settings: settings,
-		Soul:     soul,
-		Stderr:   stderr,
+		Settings:   settings,
+		Soul:       soul,
+		Stderr:     stderr,
+		Permission: permission,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy-telegram: setup: %v\n", err)
@@ -87,12 +98,7 @@ Flags:
 	}
 	defer p.Close()
 
-	cfg, err := telegram.DecodeConfig(settings.Channels[telegram.ChannelName])
-	if err != nil {
-		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
-		return 1
-	}
-	ch, err := telegram.New(telegram.Options{Peggy: p, Config: cfg, Stderr: stderr})
+	ch, err := telegram.New(telegram.Options{Peggy: p, Config: cfg, Stderr: stderr, Permission: permission})
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
 		return 1


### PR DESCRIPTION
## Summary
- add a Telegram `Permission` adapter that prompts side-effecting coding tools with inline keyboard decisions
- parse callback queries, send reply markup, and acknowledge permission callbacks through the Telegram API client
- wire `peggy-telegram` so coding mode uses the same permission adapter in Peggy and the channel
- cover allow-once, target memory, wrong-chat callbacks, API payloads, and the end-to-end callback-unblocks-prompt flow

Closes #155.

## Validation
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./agents/peggy/cmd/peggy-telegram -count=1`
- `go test -race ./agents/peggy/channels/telegram -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`