### PR TITLE
agents/peggy: polish v0.2 release

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to the `peggy` agent. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com); this project does
 not formally follow SemVer until v1.0.
 
+## v0.2.0 — 2026-05-23
+
+Peggy can now act as a permission-gated coding assistant in trusted
+local workspaces. The release completes M2 from tracker
+[#110](https://github.com/erain/glue/issues/110): she can read files,
+write files, run allowlisted commands, inspect git branch context, and
+ask before side effects from both CLI and Telegram.
+
+### Added
+
+- **Opt-in local coding mode.** `peggy --coding --workdir <repo>` and
+  the `coding` block in `settings.json` register five tools:
+  `read_file`, `write_file`, `shell_exec`, `git_diff_branch`, and
+  `git_log_branch`.
+- **Permission-gated side effects.** `write_file` and `shell_exec`
+  require a `glue.Permission` decision. Read-only file and git tools
+  do not prompt.
+- **CLI permission prompter.** The single-prompt CLI asks on stderr /
+  stdin with deny, allow-once, allow-for-session, and
+  allow-for-target choices. Remembered decisions are process-local.
+- **Telegram permission prompter.** `peggy-telegram` handles
+  `callback_query` updates and confirms side-effecting coding tools
+  with inline keyboard buttons in the same allowlisted chat that
+  triggered the request.
+- **Coding safety defaults.** `shell_exec` is argv-only, refuses
+  pathful binaries, and is constrained by a basename allowlist.
+  `write_file` is workspace-rooted, blocks sensitive path patterns,
+  refuses symlink escapes, writes atomically, and refuses overwrites
+  unless both host policy and model intent allow them.
+- **Framework primitives for future sandboxes and orchestration.**
+  `glue.Executor`, `glue.Permission`, `glue.Hook`, loop composition,
+  `tools/shell.Exec`, `tools/fs.FileWrite`, and `glue.SubagentTool`
+  landed behind Peggy's product surface.
+
+### Changed
+
+- `peggy.Version` is now `0.2.0`.
+- Peggy README and Telegram README now document coding-mode setup,
+  permission behavior, and the local-only trust boundary.
+- Release smoke coverage now drives read/write/shell/git coding tools
+  through Peggy with a fake provider and permission recorder.
+
+### Known limitations
+
+- Coding mode is a trusted-local workflow. v0.2 uses
+  `glue.LocalExecutor`; stronger sandboxing remains deferred behind
+  the `Executor` interface.
+- Remembered permission choices are process-local. Persistent
+  per-user / per-channel permission policy is a follow-up.
+- Peggy is still one channel process at a time. The M3 daemon will let
+  CLI, Telegram, and future clients share one long-running process.
+- No MCP client yet; that remains M4.
+
 ## v0.1.0 — 2026-05-16
 
 First public release. Peggy is a long-running personal-assistant
@@ -88,4 +141,4 @@ sessions and is reachable from the CLI or Telegram. Tracker:
   by hand at release time and pinned by a test.
 
 [Tracker #110](https://github.com/erain/glue/issues/110) is the
-canonical roadmap. M2 ("she can code") is the next milestone.
+canonical roadmap. M3 ("multi-channel daemon") is the next milestone.

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -4,7 +4,7 @@
 > remembers you across sessions, and curates facts on her own.
 
 A long-running personal-assistant agent built on the
-[glue](../..) framework. **v0.1** ships:
+[glue](../..) framework. **v0.2** ships:
 
 - a single-prompt **CLI** (`peggy`)
 - a **Telegram bot** binary (`peggy-telegram`) with a chat-id allowlist
@@ -14,11 +14,15 @@ A long-running personal-assistant agent built on the
   the context window
 - **FTS5 session search** under the hood, exposed via
   `Agent.SearchSessions`
+- opt-in local **coding tools** for reading files, writing files,
+  running allowlisted commands, and inspecting git branch context
+- per-call permission prompts for side-effecting coding tools in the
+  CLI and Telegram
 - four model backends: Codex (ChatGPT subscription), Gemini,
   OpenRouter, NVIDIA build
 
-Tracker: [#110](https://github.com/erain/glue/issues/110). M2 ("she
-can code") is the next milestone.
+Tracker: [#110](https://github.com/erain/glue/issues/110). M3
+("multi-channel daemon") is the next milestone.
 
 ## Quickstart
 
@@ -36,6 +40,10 @@ $EDITOR ~/.config/peggy/settings.json   # see "settings.json" below
 
 # 4. Talk to her.
 peggy "Hello — what should I be working on today?"
+
+# 5. Optional: let Peggy work in a trusted repo.
+cd /path/to/repo
+peggy --coding --workdir . "read the failing test and propose a fix"
 ```
 
 To reach her from your phone, set up Telegram next — see
@@ -142,6 +150,19 @@ CLI call with:
 peggy --coding --workdir . "run the tests and fix the failure"
 ```
 
+Persistent config for a single trusted workspace:
+
+```json
+{
+  "coding": {
+    "enabled": true,
+    "work_dir": "/path/to/repo",
+    "allowed_binaries": ["go", "git", "make"],
+    "allow_overwrite": false
+  }
+}
+```
+
 Peggy registers these model-callable tools:
 
 - `read_file` — read UTF-8 text inside the workspace. Read-only, no
@@ -163,6 +184,20 @@ Allow? [y] once, [s] session, [t] target, [n] deny:
 Remembered choices last only for the current `peggy` process. If stdin
 is unavailable or reaches EOF, Peggy denies the side effect and surfaces
 that denial to the model as a tool error.
+
+The permission choices are intentionally small:
+
+- `deny` — return a model-visible tool error.
+- `allow once` — run only this side-effecting call.
+- `allow session` — remember this tool/action for the current process
+  and session id.
+- `allow target` — remember this tool/action/target for the current
+  process and session id.
+
+Coding mode is a trusted-local workflow. The tool layer constrains
+paths, binaries, overwrites, output size, and permissions, but v0.2
+uses the host process via `glue.LocalExecutor`; it is not a container
+or VM sandbox.
 
 ### Config resolution
 
@@ -191,7 +226,7 @@ when to persist and when to look up across sessions:
 
 The model invokes these on its own as the conversation requires. The
 tools are registered by default; disable them via
-`Options.DisableMemoryTools` (library) — there's no CLI flag in v0.1.
+`Options.DisableMemoryTools` (library) — there's no CLI flag today.
 
 A short hint paragraph is appended to your `SOUL.md` content in the
 system prompt so the model knows the tools exist; override via
@@ -222,15 +257,15 @@ near-term follow-up.
   API (a `peggy recall` subcommand is a near-term follow-up).
 - **Token-aware summarizing compaction** via the configured provider.
 - Identity injected from `SOUL.md` into the system prompt.
-- Opt-in **local coding mode** for the CLI: read files, write files,
-  run allowlisted commands, and inspect git branch context with
+- Opt-in **local coding mode** for CLI and Telegram: read files, write
+  files, run allowlisted commands, and inspect git branch context with
   per-call permission prompts for side effects.
 - All four shipped providers: `codex` (ChatGPT subscription),
   `gemini`, `openrouter`, `nvidia`. Codex is the default and uses
   your existing ChatGPT subscription via `codex login` — no per-token
   bill.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.1 summary and
+See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.2 summary and
 known limitations.
 
 ## Channels
@@ -258,15 +293,13 @@ external transports. The pattern is designed in
 Per tracker [#110](https://github.com/erain/glue/issues/110), in
 priority order:
 
-- **M2 — "she can code".** CLI coding tools are wired; next is
-  Telegram inline-keyboard permissions, then tighter product polish.
 - **M3 — multi-channel daemon.** `cmd/glue serve` so a single
   long-running Peggy serves a TUI, Telegram, and future clients
   concurrently. Per-channel permission tiers.
 - **M4 — ecosystem.** MCP client (stdio + HTTP), cost tracking,
   `providers/anthropic` when budget allows.
 
-Near-term follow-ups that may slip into v0.1.x patches: a `peggy
+Near-term follow-ups that may slip into v0.2.x patches: a `peggy
 memories` subcommand (list / export / forget), edit-in-place
 Telegram streaming, FTS5 prefix-match on session ids for
 channel-scoped recall.

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -50,6 +50,39 @@ gated by a chat-id allowlist. Built on the pattern designed in
 
    SIGINT / SIGTERM stops cleanly.
 
+### Coding setup
+
+`peggy-telegram` uses the same `settings.json` as the CLI. To let
+Peggy work in a trusted local checkout from Telegram, enable coding
+tools and set the workspace root:
+
+```json
+{
+  "coding": {
+    "enabled": true,
+    "work_dir": "/path/to/repo",
+    "allowed_binaries": ["go", "git", "make"],
+    "allow_overwrite": false
+  },
+  "channels": {
+    "telegram": {
+      "allow_chats": [123456789]
+    }
+  }
+}
+```
+
+Then run the bot from the same host that has that checkout:
+
+```sh
+export PEGGY_TELEGRAM_TOKEN='123456:ABCDEF...'
+peggy-telegram
+```
+
+When the model asks to run `write_file` or `shell_exec`, Telegram
+shows inline buttons for `Deny`, `Allow once`, `Allow session`, and
+`Allow target`. Read-only coding tools do not prompt.
+
 ## Settings reference
 
 ```json

--- a/agents/peggy/channels/telegram/api.go
+++ b/agents/peggy/channels/telegram/api.go
@@ -21,7 +21,7 @@ type Update struct {
 }
 
 // Message is the text message variant we care about. Photo, voice,
-// document, etc. are out of scope for v0.1.
+// document, etc. are deferred follow-ups.
 type Message struct {
 	MessageID int64  `json:"message_id"`
 	From      *User  `json:"from,omitempty"`

--- a/agents/peggy/channels/telegram/doc.go
+++ b/agents/peggy/channels/telegram/doc.go
@@ -2,9 +2,10 @@
 // implements peggy.Channel against the Telegram Bot API using a
 // stdlib-only HTTP client (no third-party SDK).
 //
-// v0.1 supports text messages with long-polling and a chat-id
-// allowlist. Edit-in-place streaming, image / voice / file messages,
-// and webhook-mode are deferred follow-ups.
+// v0.2 supports text messages with long-polling, a chat-id allowlist,
+// and inline-keyboard permission prompts for Peggy coding tools.
+// Edit-in-place streaming, image / voice / file messages, and
+// webhook-mode are deferred follow-ups.
 //
 // Design: docs/adr/0008-channel-adapter.md.
 package telegram

--- a/agents/peggy/coding_test.go
+++ b/agents/peggy/coding_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -178,6 +179,88 @@ func TestPeggyCodingShellDenyIsModelVisibleToolError(t *testing.T) {
 	if !toolResult.IsError || !strings.Contains(toolResult.Content[0].Text, "not now") {
 		t.Fatalf("tool result = %#v, want denial tool error", toolResult)
 	}
+}
+
+func TestPeggyCodingReleaseSmoke(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	workDir := t.TempDir()
+	runGit(t, workDir, "init")
+	runGit(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, workDir, "add", "README.md")
+	runGit(t, workDir, "-c", "user.email=peggy@example.invalid", "-c", "user.name=Peggy Test", "commit", "-m", "base")
+	runGit(t, workDir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(workDir, "feature.txt"), []byte("feature\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, workDir, "add", "feature.txt")
+	runGit(t, workDir, "-c", "user.email=peggy@example.invalid", "-c", "user.name=Peggy Test", "commit", "-m", "feature")
+
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "read_file", `{"path":"README.md"}`),
+		toolCallTurn("c2", "write_file", `{"path":"note.txt","content":"hello from v0.2"}`),
+		toolCallTurn("c3", "shell_exec", `{"argv":["go","version"],"max_output_bytes":256}`),
+		toolCallTurn("c4", "git_diff_branch", `{"base":"main","max_bytes":4096}`),
+		toolCallTurn("c5", "git_log_branch", `{"base":"main","limit":2}`),
+		peggyTextTurn("release smoke done"),
+	}}
+	perm := &recordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	p := newCodingTestPeggy(t, provider, workDir, perm)
+
+	if _, err := p.Prompt(context.Background(), "release-smoke", "exercise coding tools", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if got, want := len(perm.requests), 2; got != want {
+		t.Fatalf("permission requests = %d, want %d", got, want)
+	}
+	if perm.requests[0].Tool != "write_file" || perm.requests[1].Tool != "shell_exec" {
+		t.Fatalf("permission tools = %s, %s; want write_file, shell_exec", perm.requests[0].Tool, perm.requests[1].Tool)
+	}
+	data, err := os.ReadFile(filepath.Join(workDir, "note.txt"))
+	if err != nil {
+		t.Fatalf("read note.txt: %v", err)
+	}
+	if string(data) != "hello from v0.2" {
+		t.Fatalf("note.txt = %q", data)
+	}
+	if !strings.Contains(lastToolText(t, provider.requests[1]), "base") {
+		t.Fatalf("read_file result missing content: %q", lastToolText(t, provider.requests[1]))
+	}
+	if !strings.Contains(lastToolText(t, provider.requests[3]), "go version") {
+		t.Fatalf("shell_exec result missing go version: %q", lastToolText(t, provider.requests[3]))
+	}
+	if !strings.Contains(lastToolText(t, provider.requests[4]), "feature.txt") {
+		t.Fatalf("git_diff_branch result missing feature file: %q", lastToolText(t, provider.requests[4]))
+	}
+	if !strings.Contains(lastToolText(t, provider.requests[5]), "feature") {
+		t.Fatalf("git_log_branch result missing feature commit: %q", lastToolText(t, provider.requests[5]))
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+func lastToolText(t *testing.T, req glue.ProviderRequest) string {
+	t.Helper()
+	if len(req.Messages) == 0 {
+		t.Fatal("provider request has no messages")
+	}
+	msg := req.Messages[len(req.Messages)-1]
+	if msg.Role != glue.MessageRoleTool || len(msg.Content) == 0 {
+		t.Fatalf("last message = %#v, want tool result", msg)
+	}
+	return msg.Content[0].Text
 }
 
 func containsString(haystack []string, needle string) bool {

--- a/agents/peggy/doc.go
+++ b/agents/peggy/doc.go
@@ -11,9 +11,10 @@
 //   - settings.json — JSON config (provider, model, store path,
 //     compaction knobs).
 //
-// v0.1 is single-prompt CLI ("peggy '<text>'"). REPL, Telegram
-// channel, coding skills, and the daemon mode arrive in later
-// milestones. Tracker: https://github.com/erain/glue/issues/110.
+// v0.2 ships the single-prompt CLI, Telegram channel, durable memory,
+// and opt-in local coding tools with per-call permission prompts. The
+// daemon mode arrives in a later milestone. Tracker:
+// https://github.com/erain/glue/issues/110.
 //
 // Design rule (per ADR-0005): every product concern lives in this
 // package and not in core glue. The framework supplies interfaces

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -14,7 +14,7 @@ import (
 
 // Version is the package version string surfaced by `peggy --version`.
 // Bumped by hand at release time.
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // Run is the top-level CLI entry point. It parses args, loads the
 // settings and identity files, constructs a Peggy, and dispatches a

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -25,8 +25,8 @@ func TestRun_Version(t *testing.T) {
 // whose --version still says "-dev". Bump the constant deliberately
 // at release time, and update this test to match.
 func TestVersionPinned(t *testing.T) {
-	if Version != "0.1.0" {
-		t.Fatalf("Version = %q, want %q", Version, "0.1.0")
+	if Version != "0.2.0" {
+		t.Fatalf("Version = %q, want %q", Version, "0.2.0")
 	}
 }
 


### PR DESCRIPTION
## Summary
- bump Peggy to `0.2.0` and add the v0.2.0 changelog entry
- update Peggy and Telegram docs for coding-mode setup, permission choices, and the trusted-local boundary
- add a deterministic release smoke test that drives read/write/shell/git coding tools through Peggy with a fake provider and permission recorder

Closes #157.

## Validation
- `go test ./agents/peggy -run 'Test(VersionPinned|Run_Version|PeggyCodingReleaseSmoke|PeggyCoding|CodingTools)' -count=1`
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./agents/peggy -run TestPeggyCodingReleaseSmoke -count=1`
- `go test ./agents/peggy -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`