### PR TITLE
daemon: add local run server skeleton

### DIFF
--- a/daemon/run.go
+++ b/daemon/run.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+)
+
+type run struct {
+	id        string
+	sessionID string
+	clientID  string
+	cancel    func()
+	now       func() time.Time
+	newID     func(prefix string) string
+
+	mu     sync.Mutex
+	seq    int64
+	events []EventEnvelope
+	done   bool
+	notify chan struct{}
+}
+
+func (r *run) emit(typ string, payload any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq++
+	r.events = append(r.events, EventEnvelope{
+		Version:   protocolVersion,
+		ID:        r.newID("evt"),
+		Seq:       r.seq,
+		RunID:     r.id,
+		SessionID: r.sessionID,
+		Time:      r.now().UTC(),
+		Type:      typ,
+		Payload:   payload,
+	})
+	r.signalLocked()
+}
+
+func (r *run) finish() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.done {
+		return
+	}
+	r.done = true
+	r.signalLocked()
+}
+
+func (r *run) eventsFrom(index int) ([]EventEnvelope, bool, <-chan struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if index < 0 {
+		index = 0
+	}
+	if index > len(r.events) {
+		index = len(r.events)
+	}
+	events := append([]EventEnvelope(nil), r.events[index:]...)
+	return events, r.done, r.notify
+}
+
+func (r *run) signalLocked() {
+	close(r.notify)
+	r.notify = make(chan struct{})
+}

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -1,0 +1,389 @@
+// Package daemon serves local Glue sessions over the ADR-0010 HTTP+SSE
+// protocol.
+package daemon
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+const protocolVersion = 1
+
+// Host supplies sessions to a daemon Server.
+type Host interface {
+	Session(ctx context.Context, id string, options ...glue.SessionOption) (*glue.Session, error)
+}
+
+// Options configures [New].
+type Options struct {
+	// Host is required. A *glue.Agent satisfies this interface.
+	Host Host
+
+	// Token is required for every route except /v1/health.
+	Token string
+
+	// Now supplies event timestamps. Nil uses time.Now.
+	Now func() time.Time
+
+	// NewID returns ids for runs and events. Nil uses crypto/rand.
+	NewID func(prefix string) string
+}
+
+// Server is an http.Handler for the local daemon protocol.
+type Server struct {
+	host  Host
+	token string
+	now   func() time.Time
+	newID func(prefix string) string
+
+	mu   sync.Mutex
+	runs map[string]*run
+}
+
+// EventEnvelope is the JSON payload sent in each SSE data frame.
+type EventEnvelope struct {
+	Version   int       `json:"version"`
+	ID        string    `json:"id"`
+	Seq       int64     `json:"seq"`
+	RunID     string    `json:"run_id"`
+	SessionID string    `json:"session_id"`
+	Time      time.Time `json:"time"`
+	Type      string    `json:"type"`
+	Payload   any       `json:"payload,omitempty"`
+}
+
+type protocolError struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
+type errorResponse struct {
+	Error protocolError `json:"error"`
+}
+
+type startRunRequest struct {
+	Text     string         `json:"text"`
+	ClientID string         `json:"client_id,omitempty"`
+	Role     string         `json:"role,omitempty"`
+	Model    string         `json:"model,omitempty"`
+	MaxTurns int            `json:"max_turns,omitempty"`
+	Options  map[string]any `json:"options,omitempty"`
+}
+
+type startRunResponse struct {
+	RunID     string `json:"run_id"`
+	SessionID string `json:"session_id"`
+	EventsURL string `json:"events_url"`
+}
+
+// New constructs a daemon Server.
+func New(opts Options) (*Server, error) {
+	if opts.Host == nil {
+		return nil, errors.New("daemon: Host is required")
+	}
+	token := strings.TrimSpace(opts.Token)
+	if token == "" {
+		return nil, errors.New("daemon: Token is required")
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	newID := opts.NewID
+	if newID == nil {
+		newID = randomID
+	}
+	return &Server{
+		host:  opts.Host,
+		token: token,
+		now:   now,
+		newID: newID,
+		runs:  map[string]*run{},
+	}, nil
+}
+
+// ServeHTTP implements http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/v1/health" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "version": protocolVersion})
+		return
+	}
+	if !s.authorized(r) {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "missing or invalid bearer token", false)
+		return
+	}
+
+	if sessionID, ok := parseStartRunPath(r.URL.Path); ok {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleStartRun(w, r, sessionID)
+		return
+	}
+
+	if runID, ok := parseRunEventsPath(r.URL.Path); ok {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleRunEvents(w, r, runID)
+		return
+	}
+
+	if runID, ok := parseRunPath(r.URL.Path); ok {
+		if r.Method != http.MethodDelete {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleCancelRun(w, r, runID)
+		return
+	}
+
+	writeError(w, http.StatusNotFound, "not_found", "route not found", false)
+}
+
+func (s *Server) authorized(r *http.Request) bool {
+	want := "Bearer " + s.token
+	got := r.Header.Get("Authorization")
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+func (s *Server) handleStartRun(w http.ResponseWriter, r *http.Request, sessionID string) {
+	var req startRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body", false)
+		return
+	}
+	if strings.TrimSpace(req.Text) == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "text is required", false)
+		return
+	}
+	session, err := s.host.Session(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	run := s.newRun(sessionID, req.ClientID, cancel)
+	go s.executeRun(ctx, run, session, req)
+
+	writeJSON(w, http.StatusCreated, startRunResponse{
+		RunID:     run.id,
+		SessionID: sessionID,
+		EventsURL: "/v1/runs/" + url.PathEscape(run.id) + "/events",
+	})
+}
+
+func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, req startRunRequest) {
+	r.emit("run_start", map[string]any{"client_id": req.ClientID})
+	options := []glue.PromptOption{
+		glue.WithEvents(func(event glue.Event) {
+			r.emit(string(event.Type), event)
+		}),
+	}
+	if strings.TrimSpace(req.Role) != "" {
+		options = append(options, glue.WithRole(req.Role))
+	}
+	if strings.TrimSpace(req.Model) != "" {
+		options = append(options, glue.WithModel(req.Model))
+	}
+	if req.MaxTurns > 0 {
+		options = append(options, glue.WithMaxTurns(req.MaxTurns))
+	}
+	if len(req.Options) > 0 {
+		options = append(options, glue.WithProviderOptions(req.Options))
+	}
+
+	result, err := session.Prompt(ctx, req.Text, options...)
+	if err != nil {
+		r.emit("run_error", map[string]any{"error": errorFor(err)})
+		r.finish()
+		return
+	}
+	r.emit("run_done", map[string]any{
+		"text":         result.Text,
+		"message":      result.Message,
+		"new_messages": result.NewMessages,
+	})
+	r.finish()
+}
+
+func (s *Server) handleRunEvents(w http.ResponseWriter, r *http.Request, runID string) {
+	run := s.getRun(runID)
+	if run == nil {
+		writeError(w, http.StatusNotFound, "not_found", "run not found", false)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "internal", "streaming unsupported", false)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	next := 0
+	for {
+		events, done, notify := run.eventsFrom(next)
+		for _, event := range events {
+			if err := writeSSE(w, event); err != nil {
+				run.cancel()
+				return
+			}
+			next++
+			flusher.Flush()
+		}
+		if done {
+			return
+		}
+		select {
+		case <-notify:
+		case <-r.Context().Done():
+			run.cancel()
+			return
+		}
+	}
+}
+
+func (s *Server) handleCancelRun(w http.ResponseWriter, _ *http.Request, runID string) {
+	run := s.getRun(runID)
+	if run == nil {
+		writeError(w, http.StatusNotFound, "not_found", "run not found", false)
+		return
+	}
+	run.cancel()
+	writeJSON(w, http.StatusAccepted, map[string]any{"run_id": runID, "canceled": true})
+}
+
+func (s *Server) newRun(sessionID, clientID string, cancel context.CancelFunc) *run {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for {
+		id := s.newID("run")
+		if _, exists := s.runs[id]; exists {
+			continue
+		}
+		r := &run{
+			id:        id,
+			sessionID: sessionID,
+			clientID:  clientID,
+			cancel:    cancel,
+			now:       s.now,
+			newID:     s.newID,
+			notify:    make(chan struct{}),
+		}
+		s.runs[id] = r
+		return r
+	}
+}
+
+func (s *Server) getRun(id string) *run {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.runs[id]
+}
+
+func parseStartRunPath(path string) (string, bool) {
+	const prefix = "/v1/sessions/"
+	const suffix = "/runs"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", false
+	}
+	raw := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	if raw == "" || strings.Contains(raw, "/") {
+		return "", false
+	}
+	id, err := url.PathUnescape(raw)
+	return id, err == nil && id != ""
+}
+
+func parseRunEventsPath(path string) (string, bool) {
+	const prefix = "/v1/runs/"
+	const suffix = "/events"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", false
+	}
+	raw := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	if raw == "" || strings.Contains(raw, "/") {
+		return "", false
+	}
+	id, err := url.PathUnescape(raw)
+	return id, err == nil && id != ""
+}
+
+func parseRunPath(path string) (string, bool) {
+	const prefix = "/v1/runs/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	raw := strings.TrimPrefix(path, prefix)
+	if raw == "" || strings.Contains(raw, "/") {
+		return "", false
+	}
+	id, err := url.PathUnescape(raw)
+	return id, err == nil && id != ""
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string, retryable bool) {
+	writeJSON(w, status, errorResponse{Error: protocolError{Code: code, Message: message, Retryable: retryable}})
+}
+
+func writeSSE(w http.ResponseWriter, event EventEnvelope) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "id: %s\n", event.ID); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\n", event.Type); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func errorFor(err error) protocolError {
+	code := "internal"
+	if errors.Is(err, context.Canceled) {
+		code = "canceled"
+	}
+	return protocolError{Code: code, Message: err.Error(), Retryable: false}
+}
+
+func randomID(prefix string) string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	}
+	return prefix + "_" + hex.EncodeToString(b[:])
+}

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -1,0 +1,266 @@
+package daemon
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+type scriptedProvider struct {
+	events []glue.ProviderEvent
+}
+
+func (p scriptedProvider) Stream(context.Context, glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	ch := make(chan glue.ProviderEvent, len(p.events))
+	for _, event := range p.events {
+		ch <- event
+	}
+	close(ch)
+	return ch, nil
+}
+
+type blockingProvider struct {
+	started  chan struct{}
+	canceled chan struct{}
+	once     sync.Once
+}
+
+func (p *blockingProvider) Stream(ctx context.Context, _ glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	ch := make(chan glue.ProviderEvent, 1)
+	ch <- glue.ProviderEvent{Type: glue.ProviderEventStart}
+	p.once.Do(func() { close(p.started) })
+	go func() {
+		<-ctx.Done()
+		close(p.canceled)
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func TestServerAuthAndHealth(t *testing.T) {
+	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("health status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/sessions/default/runs", "", `{"text":"hi"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/sessions/default/runs", "wrong", `{"text":"hi"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("bad token status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestServerStartsRunAndStreamsEvents(t *testing.T) {
+	agent := glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{events: []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: "hello"},
+		{Type: glue.ProviderEventDone},
+	}}})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/sessions/default/runs", "token", `{"text":"say hi","client_id":"cli:test"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("start status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var start startRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&start); err != nil {
+		t.Fatal(err)
+	}
+	if start.RunID == "" || start.SessionID != "default" || !strings.HasSuffix(start.EventsURL, "/events") {
+		t.Fatalf("start response = %+v", start)
+	}
+
+	events := getSSE(t, ts.URL+start.EventsURL, "token")
+	types := eventTypes(events)
+	for _, want := range []string{"run_start", "loop_start", "turn_start", "message_start", "text_delta", "message_end", "turn_end", "loop_end", "run_done"} {
+		if !contains(types, want) {
+			t.Fatalf("events = %v, missing %s", types, want)
+		}
+	}
+	if types[0] != "run_start" || types[len(types)-1] != "run_done" {
+		t.Fatalf("events = %v, want run_start ... run_done", types)
+	}
+	for i, event := range events {
+		if event.Seq != int64(i+1) {
+			t.Fatalf("event %d seq = %d, want %d", i, event.Seq, i+1)
+		}
+		if event.RunID != start.RunID || event.SessionID != "default" {
+			t.Fatalf("event = %+v, want run/session ids", event)
+		}
+	}
+}
+
+func TestServerCancelRun(t *testing.T) {
+	provider := &blockingProvider{started: make(chan struct{}), canceled: make(chan struct{})}
+	agent := glue.NewAgent(glue.AgentOptions{Provider: provider})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/sessions/default/runs", "token", `{"text":"wait"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("start status = %d", resp.StatusCode)
+	}
+	var start startRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&start); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("provider did not start")
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/runs/"+start.RunID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	cancelResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("cancel status = %d, want %d", cancelResp.StatusCode, http.StatusAccepted)
+	}
+	select {
+	case <-provider.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("provider was not canceled")
+	}
+
+	events := getSSE(t, ts.URL+start.EventsURL, "token")
+	types := eventTypes(events)
+	if types[len(types)-1] != "run_error" {
+		t.Fatalf("events = %v, want terminal run_error", types)
+	}
+}
+
+func newTestServer(t *testing.T, host Host) *Server {
+	t.Helper()
+	now := time.Date(2026, 5, 23, 20, 46, 0, 0, time.UTC)
+	srv, err := New(Options{
+		Host:  host,
+		Token: "token",
+		Now:   func() time.Time { return now },
+		NewID: sequenceIDs(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func sequenceIDs() func(prefix string) string {
+	var mu sync.Mutex
+	var n int
+	return func(prefix string) string {
+		mu.Lock()
+		defer mu.Unlock()
+		n++
+		return fmt.Sprintf("%s_%02d", prefix, n)
+	}
+}
+
+func postJSON(t *testing.T, url, token, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func getSSE(t *testing.T, url, token string) []EventEnvelope {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("SSE status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var events []EventEnvelope
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event EventEnvelope
+		dec := json.NewDecoder(bytes.NewBufferString(strings.TrimPrefix(line, "data: ")))
+		dec.UseNumber()
+		if err := dec.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatal("no SSE events")
+	}
+	return events
+}
+
+func eventTypes(events []EventEnvelope) []string {
+	out := make([]string, 0, len(events))
+	for _, event := range events {
+		out = append(out, event.Type)
+	}
+	return out
+}
+
+func contains(in []string, want string) bool {
+	for _, got := range in {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add a neutral `daemon` HTTP handler package for the ADR-0010 local protocol
- implement health, bearer-token auth, run start, SSE event streaming, run cancellation, and protocol error envelopes
- cover auth, start response shape, SSE event order/envelopes, cancellation, and race safety with fake providers over real `glue.Agent` sessions

Closes #161.

## Validation
- `go test ./daemon -count=1`
- `go test -race ./daemon -count=1`
- `git diff --check -- . ':!.gitignore'`
- `go build ./...`
- `go vet ./...`
- `env -u NVIDIA_API_KEY go test ./...`