### PR TITLE
daemon: broker permission decisions

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -150,6 +150,45 @@ func TestSessionPromptPassesPermissionHooksAndSessionID(t *testing.T) {
 	}
 }
 
+func TestSessionPromptPermissionOverride(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingProvider{turns: [][]ProviderEvent{
+		{
+			{Type: ProviderEventStart},
+			{Type: ProviderEventToolCall, ToolCall: &ToolCall{ID: "c1", Name: "side", Arguments: []byte(`{}`)}},
+			{Type: ProviderEventDone},
+		},
+		textTurn("done"),
+	}}
+	defaultPerm := &recordingGluePermission{decision: PermissionDecision{Allow: false, Reason: "default deny"}}
+	overridePerm := &recordingGluePermission{decision: PermissionDecision{Allow: true}}
+	agent := NewAgent(AgentOptions{
+		Provider: provider,
+		Tools: []Tool{{
+			ToolSpec: ToolSpec{Name: "side", RequiresPermission: true},
+			Execute: func(context.Context, ToolCall) (ToolResult, error) {
+				return TextResult("ok"), nil
+			},
+		}},
+		Permission: defaultPerm,
+	})
+	session, err := agent.Session(context.Background(), "s")
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if _, err := session.Prompt(context.Background(), "go", WithPermission(overridePerm)); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(defaultPerm.requests) != 0 {
+		t.Fatalf("default permission requests = %d, want 0", len(defaultPerm.requests))
+	}
+	if len(overridePerm.requests) != 1 {
+		t.Fatalf("override permission requests = %d, want 1", len(overridePerm.requests))
+	}
+}
+
 func TestSessionPromptContinuation(t *testing.T) {
 	t.Parallel()
 

--- a/daemon/run.go
+++ b/daemon/run.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"sync"
 	"time"
+
+	"github.com/erain/glue"
 )
 
 type run struct {
@@ -18,6 +20,13 @@ type run struct {
 	events []EventEnvelope
 	done   bool
 	notify chan struct{}
+
+	pending map[string]*pendingPermission
+}
+
+type pendingPermission struct {
+	id   string
+	done chan glue.PermissionDecision
 }
 
 func (r *run) emit(typ string, payload any) {
@@ -58,6 +67,40 @@ func (r *run) eventsFrom(index int) ([]EventEnvelope, bool, <-chan struct{}) {
 	}
 	events := append([]EventEnvelope(nil), r.events[index:]...)
 	return events, r.done, r.notify
+}
+
+func (r *run) addPermission(p *pendingPermission) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.pending[p.id]; exists {
+		return false
+	}
+	r.pending[p.id] = p
+	return true
+}
+
+func (r *run) resolvePermission(id string, decision glue.PermissionDecision) bool {
+	r.mu.Lock()
+	pending := r.pending[id]
+	if pending != nil {
+		delete(r.pending, id)
+	}
+	r.mu.Unlock()
+	if pending == nil {
+		return false
+	}
+	pending.done <- decision
+	return true
+}
+
+func (r *run) expirePermission(id string, pending *pendingPermission) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.pending[id] != pending {
+		return false
+	}
+	delete(r.pending, id)
+	return true
 }
 
 func (r *run) signalLocked() {

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -21,6 +21,8 @@ import (
 
 const protocolVersion = 1
 
+const defaultPermissionTimeout = 10 * time.Minute
+
 // Host supplies sessions to a daemon Server.
 type Host interface {
 	Session(ctx context.Context, id string, options ...glue.SessionOption) (*glue.Session, error)
@@ -39,17 +41,27 @@ type Options struct {
 
 	// NewID returns ids for runs and events. Nil uses crypto/rand.
 	NewID func(prefix string) string
+
+	// PermissionTimeout caps how long a side-effecting tool waits for an
+	// HTTP decision. Zero uses a conservative default.
+	PermissionTimeout time.Duration
 }
 
 // Server is an http.Handler for the local daemon protocol.
 type Server struct {
-	host  Host
-	token string
-	now   func() time.Time
-	newID func(prefix string) string
+	host              Host
+	token             string
+	now               func() time.Time
+	newID             func(prefix string) string
+	permissionTimeout time.Duration
 
 	mu   sync.Mutex
 	runs map[string]*run
+
+	permMu        sync.Mutex
+	sessionAllows map[string]struct{}
+	targetAllows  map[string]struct{}
+	foreverAllows map[string]struct{}
 }
 
 // EventEnvelope is the JSON payload sent in each SSE data frame.
@@ -89,6 +101,23 @@ type startRunResponse struct {
 	EventsURL string `json:"events_url"`
 }
 
+type permissionRequestPayload struct {
+	PermissionID string                 `json:"permission_id"`
+	Request      glue.PermissionRequest `json:"request"`
+	ExpiresAt    time.Time              `json:"expires_at"`
+}
+
+type permissionDecisionRequest struct {
+	Allow       bool   `json:"allow"`
+	Reason      string `json:"reason,omitempty"`
+	RememberFor string `json:"remember_for,omitempty"`
+}
+
+type permissionDecisionResponse struct {
+	PermissionID string `json:"permission_id"`
+	Accepted     bool   `json:"accepted"`
+}
+
 // New constructs a daemon Server.
 func New(opts Options) (*Server, error) {
 	if opts.Host == nil {
@@ -106,12 +135,20 @@ func New(opts Options) (*Server, error) {
 	if newID == nil {
 		newID = randomID
 	}
+	permissionTimeout := opts.PermissionTimeout
+	if permissionTimeout <= 0 {
+		permissionTimeout = defaultPermissionTimeout
+	}
 	return &Server{
-		host:  opts.Host,
-		token: token,
-		now:   now,
-		newID: newID,
-		runs:  map[string]*run{},
+		host:              opts.Host,
+		token:             token,
+		now:               now,
+		newID:             newID,
+		permissionTimeout: permissionTimeout,
+		runs:              map[string]*run{},
+		sessionAllows:     map[string]struct{}{},
+		targetAllows:      map[string]struct{}{},
+		foreverAllows:     map[string]struct{}{},
 	}, nil
 }
 
@@ -145,6 +182,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleRunEvents(w, r, runID)
+		return
+	}
+
+	if runID, permissionID, ok := parsePermissionDecisionPath(r.URL.Path); ok {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handlePermissionDecision(w, r, runID, permissionID)
 		return
 	}
 
@@ -196,6 +242,7 @@ func (s *Server) handleStartRun(w http.ResponseWriter, r *http.Request, sessionI
 func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, req startRunRequest) {
 	r.emit("run_start", map[string]any{"client_id": req.ClientID})
 	options := []glue.PromptOption{
+		glue.WithPermission(runPermission{server: s, run: r}),
 		glue.WithEvents(func(event glue.Event) {
 			r.emit(string(event.Type), event)
 		}),
@@ -276,6 +323,41 @@ func (s *Server) handleCancelRun(w http.ResponseWriter, _ *http.Request, runID s
 	writeJSON(w, http.StatusAccepted, map[string]any{"run_id": runID, "canceled": true})
 }
 
+func (s *Server) handlePermissionDecision(w http.ResponseWriter, r *http.Request, runID, permissionID string) {
+	run := s.getRun(runID)
+	if run == nil {
+		writeError(w, http.StatusNotFound, "not_found", "run not found", false)
+		return
+	}
+	if clientID := r.Header.Get("X-Glue-Client-ID"); clientID != "" && run.clientID != "" && clientID != run.clientID {
+		writeError(w, http.StatusForbidden, "forbidden", "permission decision belongs to another client", false)
+		return
+	}
+	var req permissionDecisionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body", false)
+		return
+	}
+	scope, ok := parseRememberScope(req.RememberFor)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid remember_for", false)
+		return
+	}
+	decision := glue.PermissionDecision{
+		Allow:       req.Allow,
+		Reason:      req.Reason,
+		RememberFor: scope,
+	}
+	if !decision.Allow && strings.TrimSpace(decision.Reason) == "" {
+		decision.Reason = "permission denied by daemon client"
+	}
+	if !run.resolvePermission(permissionID, decision) {
+		writeError(w, http.StatusNotFound, "not_found", "permission request not found", false)
+		return
+	}
+	writeJSON(w, http.StatusOK, permissionDecisionResponse{PermissionID: permissionID, Accepted: true})
+}
+
 func (s *Server) newRun(sessionID, clientID string, cancel context.CancelFunc) *run {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -292,6 +374,7 @@ func (s *Server) newRun(sessionID, clientID string, cancel context.CancelFunc) *
 			now:       s.now,
 			newID:     s.newID,
 			notify:    make(chan struct{}),
+			pending:   map[string]*pendingPermission{},
 		}
 		s.runs[id] = r
 		return r
@@ -330,6 +413,29 @@ func parseRunEventsPath(path string) (string, bool) {
 	}
 	id, err := url.PathUnescape(raw)
 	return id, err == nil && id != ""
+}
+
+func parsePermissionDecisionPath(path string) (runID, permissionID string, ok bool) {
+	const prefix = "/v1/runs/"
+	const middle = "/permissions/"
+	const suffix = "/decision"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", "", false
+	}
+	rest := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	rawRunID, rawPermissionID, found := strings.Cut(rest, middle)
+	if !found || rawRunID == "" || rawPermissionID == "" || strings.Contains(rawRunID, "/") || strings.Contains(rawPermissionID, "/") {
+		return "", "", false
+	}
+	runID, err := url.PathUnescape(rawRunID)
+	if err != nil || runID == "" {
+		return "", "", false
+	}
+	permissionID, err = url.PathUnescape(rawPermissionID)
+	if err != nil || permissionID == "" {
+		return "", "", false
+	}
+	return runID, permissionID, true
 }
 
 func parseRunPath(path string) (string, bool) {
@@ -378,6 +484,124 @@ func errorFor(err error) protocolError {
 		code = "canceled"
 	}
 	return protocolError{Code: code, Message: err.Error(), Retryable: false}
+}
+
+type runPermission struct {
+	server *Server
+	run    *run
+}
+
+func (p runPermission) Decide(ctx context.Context, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	return p.server.decidePermission(ctx, p.run, req)
+}
+
+func (s *Server) decidePermission(ctx context.Context, run *run, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	if decision, ok := s.cachedPermission(req); ok {
+		return decision, nil
+	}
+
+	var permissionID string
+	var pending *pendingPermission
+	for {
+		permissionID = s.newID("perm")
+		pending = &pendingPermission{
+			id:   permissionID,
+			done: make(chan glue.PermissionDecision, 1),
+		}
+		if run.addPermission(pending) {
+			break
+		}
+	}
+
+	expiresAt := s.now().UTC().Add(s.permissionTimeout)
+	run.emit("permission_request", permissionRequestPayload{
+		PermissionID: permissionID,
+		Request:      req,
+		ExpiresAt:    expiresAt,
+	})
+
+	timer := time.NewTimer(s.permissionTimeout)
+	defer timer.Stop()
+	select {
+	case decision := <-pending.done:
+		s.rememberPermission(req, decision)
+		return decision, nil
+	case <-timer.C:
+		if !run.expirePermission(permissionID, pending) {
+			decision := <-pending.done
+			s.rememberPermission(req, decision)
+			return decision, nil
+		}
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: daemon permission request timed out"}, nil
+	case <-ctx.Done():
+		if !run.expirePermission(permissionID, pending) {
+			decision := <-pending.done
+			s.rememberPermission(req, decision)
+			return decision, nil
+		}
+		return glue.PermissionDecision{}, ctx.Err()
+	}
+}
+
+func (s *Server) cachedPermission(req glue.PermissionRequest) (glue.PermissionDecision, bool) {
+	sessionKey := permissionSessionKey(req)
+	targetKey := permissionTargetKey(req)
+	foreverKey := permissionForeverKey(req)
+	s.permMu.Lock()
+	defer s.permMu.Unlock()
+	if _, ok := s.foreverAllows[foreverKey]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberForever}, true
+	}
+	if _, ok := s.sessionAllows[sessionKey]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}, true
+	}
+	if _, ok := s.targetAllows[targetKey]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSessionTarget}, true
+	}
+	return glue.PermissionDecision{}, false
+}
+
+func (s *Server) rememberPermission(req glue.PermissionRequest, decision glue.PermissionDecision) {
+	if !decision.Allow {
+		return
+	}
+	s.permMu.Lock()
+	defer s.permMu.Unlock()
+	switch decision.RememberFor {
+	case glue.RememberSession:
+		s.sessionAllows[permissionSessionKey(req)] = struct{}{}
+	case glue.RememberSessionTarget:
+		s.targetAllows[permissionTargetKey(req)] = struct{}{}
+	case glue.RememberForever:
+		s.foreverAllows[permissionForeverKey(req)] = struct{}{}
+	}
+}
+
+func permissionSessionKey(req glue.PermissionRequest) string {
+	return req.SessionID + "\x00" + req.Tool + "\x00" + req.Action
+}
+
+func permissionTargetKey(req glue.PermissionRequest) string {
+	return permissionSessionKey(req) + "\x00" + req.Target
+}
+
+func permissionForeverKey(req glue.PermissionRequest) string {
+	return req.Tool + "\x00" + req.Action + "\x00" + req.Target
+}
+
+func parseRememberScope(raw string) (glue.RememberScope, bool) {
+	switch strings.TrimSpace(raw) {
+	case "", "never":
+		return glue.RememberNever, true
+	case "session":
+		return glue.RememberSession, true
+	case "session_target":
+		return glue.RememberSessionTarget, true
+	case "forever":
+		return glue.RememberForever, true
+	default:
+		return glue.RememberNever, false
+	}
 }
 
 func randomID(prefix string) string {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -5,11 +5,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,6 +26,27 @@ type scriptedProvider struct {
 func (p scriptedProvider) Stream(context.Context, glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
 	ch := make(chan glue.ProviderEvent, len(p.events))
 	for _, event := range p.events {
+		ch <- event
+	}
+	close(ch)
+	return ch, nil
+}
+
+type turnProvider struct {
+	mu    sync.Mutex
+	turns [][]glue.ProviderEvent
+}
+
+func (p *turnProvider) Stream(context.Context, glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.turns) == 0 {
+		return nil, errors.New("turnProvider: unexpected stream")
+	}
+	events := p.turns[0]
+	p.turns = p.turns[1:]
+	ch := make(chan glue.ProviderEvent, len(events))
+	for _, event := range events {
 		ch <- event
 	}
 	close(ch)
@@ -165,14 +189,249 @@ func TestServerCancelRun(t *testing.T) {
 	}
 }
 
+func TestServerPermissionAllowOnce(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{toolCallTurn(), textTurn("done")}},
+		Tools:    []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRun(t, ts.URL, "default")
+	events, err := collectSSE(t, ts.URL+start.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, start.RunID, permissionID(t, event), "token", `{"allow":true}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executed.Load() != 1 {
+		t.Fatalf("tool executions = %d, want 1", executed.Load())
+	}
+	types := eventTypes(events)
+	if !contains(types, "permission_request") || types[len(types)-1] != "run_done" {
+		t.Fatalf("events = %v, want permission_request and terminal run_done", types)
+	}
+}
+
+func TestServerPermissionDenyIsModelVisibleToolError(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{toolCallTurn(), textTurn("done")}},
+		Tools:    []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRun(t, ts.URL, "default")
+	events, err := collectSSE(t, ts.URL+start.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, start.RunID, permissionID(t, event), "token", `{"allow":false,"reason":"not now"}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executed.Load() != 0 {
+		t.Fatalf("tool executions = %d, want 0", executed.Load())
+	}
+	if text := toolEndText(t, events); !strings.Contains(text, "not now") {
+		t.Fatalf("tool_end text = %q, want denial reason", text)
+	}
+}
+
+func TestServerPermissionDecisionRejectsInvalidRequests(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{toolCallTurn(), textTurn("done")}},
+		Tools:    []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRun(t, ts.URL, "default")
+	events, err := collectSSE(t, ts.URL+start.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type != "permission_request" {
+			return
+		}
+		id := permissionID(t, event)
+		postDecisionStatus(t, ts.URL, start.RunID, id, "token", "cli:other", `{"allow":true}`, http.StatusForbidden)
+		postDecisionStatus(t, ts.URL, start.RunID, id, "token", "", `{"allow":true,"remember_for":"workspace"}`, http.StatusBadRequest)
+		postDecisionStatus(t, ts.URL, start.RunID, "perm_missing", "token", "", `{"allow":true}`, http.StatusNotFound)
+		postDecisionStatus(t, ts.URL, start.RunID, id, "token", "cli:test", `{"allow":true}`, http.StatusOK)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executed.Load() != 1 {
+		t.Fatalf("tool executions = %d, want 1", executed.Load())
+	}
+	if types := eventTypes(events); types[len(types)-1] != "run_done" {
+		t.Fatalf("events = %v, want terminal run_done", types)
+	}
+}
+
+func TestServerPermissionTimeoutDenies(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{toolCallTurn(), textTurn("done")}},
+		Tools:    []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithTimeout(t, agent, 10*time.Millisecond)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRun(t, ts.URL, "default")
+	events := getSSE(t, ts.URL+start.EventsURL, "token")
+	if executed.Load() != 0 {
+		t.Fatalf("tool executions = %d, want 0", executed.Load())
+	}
+	types := eventTypes(events)
+	if !contains(types, "permission_request") || types[len(types)-1] != "run_done" {
+		t.Fatalf("events = %v, want timed-out permission and run_done", types)
+	}
+	if text := toolEndText(t, events); !strings.Contains(text, "timed out") {
+		t.Fatalf("tool_end text = %q, want timeout reason", text)
+	}
+	var timedOutPermissionID string
+	for _, event := range events {
+		if event.Type == "permission_request" {
+			timedOutPermissionID = permissionID(t, event)
+			break
+		}
+	}
+	if timedOutPermissionID == "" {
+		t.Fatal("timed-out run did not emit permission_request")
+	}
+	postDecisionStatus(t, ts.URL, start.RunID, timedOutPermissionID, "token", "", `{"allow":true}`, http.StatusNotFound)
+}
+
+func TestServerPermissionRememberSession(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurnValue("first-target"), textTurn("first done"),
+			toolCallTurnValue("second-target"), textTurn("second done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithTimeout(t, agent, 50*time.Millisecond)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	first := startRun(t, ts.URL, "default")
+	firstEvents, err := collectSSE(t, ts.URL+first.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, first.RunID, permissionID(t, event), "token", `{"allow":true,"remember_for":"session"}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(eventTypes(firstEvents), "permission_request") {
+		t.Fatal("first run did not ask permission")
+	}
+
+	second := startRun(t, ts.URL, "default")
+	secondEvents := getSSE(t, ts.URL+second.EventsURL, "token")
+	if executed.Load() != 2 {
+		t.Fatalf("tool executions = %d, want 2", executed.Load())
+	}
+	if contains(eventTypes(secondEvents), "permission_request") {
+		t.Fatalf("second run events = %v, want cached session allow", eventTypes(secondEvents))
+	}
+}
+
+func TestServerPermissionRememberTarget(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("first done"),
+			toolCallTurn(), textTurn("second done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithTimeout(t, agent, 50*time.Millisecond)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	first := startRun(t, ts.URL, "default")
+	firstEvents, err := collectSSE(t, ts.URL+first.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, first.RunID, permissionID(t, event), "token", `{"allow":true,"remember_for":"session_target"}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(eventTypes(firstEvents), "permission_request") {
+		t.Fatal("first run did not ask permission")
+	}
+
+	second := startRun(t, ts.URL, "default")
+	secondEvents := getSSE(t, ts.URL+second.EventsURL, "token")
+	if executed.Load() != 2 {
+		t.Fatalf("tool executions = %d, want 2", executed.Load())
+	}
+	if contains(eventTypes(secondEvents), "permission_request") {
+		t.Fatalf("second run events = %v, want cached target allow", eventTypes(secondEvents))
+	}
+}
+
+func TestServerPermissionRememberForeverAcrossSessions(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("first done"),
+			toolCallTurn(), textTurn("second done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithTimeout(t, agent, 50*time.Millisecond)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	first := startRun(t, ts.URL, "default")
+	firstEvents, err := collectSSE(t, ts.URL+first.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, first.RunID, permissionID(t, event), "token", `{"allow":true,"remember_for":"forever"}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(eventTypes(firstEvents), "permission_request") {
+		t.Fatal("first run did not ask permission")
+	}
+
+	second := startRun(t, ts.URL, "other-session")
+	secondEvents := getSSE(t, ts.URL+second.EventsURL, "token")
+	if executed.Load() != 2 {
+		t.Fatalf("tool executions = %d, want 2", executed.Load())
+	}
+	if contains(eventTypes(secondEvents), "permission_request") {
+		t.Fatalf("second run events = %v, want cached forever allow", eventTypes(secondEvents))
+	}
+}
+
 func newTestServer(t *testing.T, host Host) *Server {
+	return newTestServerWithTimeout(t, host, time.Second)
+}
+
+func newTestServerWithTimeout(t *testing.T, host Host, timeout time.Duration) *Server {
 	t.Helper()
 	now := time.Date(2026, 5, 23, 20, 46, 0, 0, time.UTC)
 	srv, err := New(Options{
-		Host:  host,
-		Token: "token",
-		Now:   func() time.Time { return now },
-		NewID: sequenceIDs(),
+		Host:              host,
+		Token:             "token",
+		Now:               func() time.Time { return now },
+		NewID:             sequenceIDs(),
+		PermissionTimeout: timeout,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -208,20 +467,43 @@ func postJSON(t *testing.T, url, token, body string) *http.Response {
 	return resp
 }
 
+func startRun(t *testing.T, baseURL, sessionID string) startRunResponse {
+	t.Helper()
+	resp := postJSON(t, baseURL+"/v1/sessions/"+sessionID+"/runs", "token", `{"text":"go","client_id":"cli:test"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("start status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var start startRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&start); err != nil {
+		t.Fatal(err)
+	}
+	return start
+}
+
 func getSSE(t *testing.T, url, token string) []EventEnvelope {
+	t.Helper()
+	events, err := collectSSE(t, url, token, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return events
+}
+
+func collectSSE(t *testing.T, url, token string, onEvent func(EventEnvelope)) ([]EventEnvelope, error) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("SSE status = %d, want %d", resp.StatusCode, http.StatusOK)
+		return nil, fmt.Errorf("SSE status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
 	var events []EventEnvelope
@@ -235,17 +517,20 @@ func getSSE(t *testing.T, url, token string) []EventEnvelope {
 		dec := json.NewDecoder(bytes.NewBufferString(strings.TrimPrefix(line, "data: ")))
 		dec.UseNumber()
 		if err := dec.Decode(&event); err != nil {
-			t.Fatal(err)
+			return nil, err
 		}
 		events = append(events, event)
+		if onEvent != nil {
+			onEvent(event)
+		}
 	}
 	if err := scanner.Err(); err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 	if len(events) == 0 {
-		t.Fatal("no SSE events")
+		return nil, errors.New("no SSE events")
 	}
-	return events
+	return events, nil
 }
 
 func eventTypes(events []EventEnvelope) []string {
@@ -263,4 +548,117 @@ func contains(in []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func toolCallTurn() []glue.ProviderEvent {
+	return toolCallTurnValue("x")
+}
+
+func toolCallTurnValue(value string) []glue.ProviderEvent {
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventToolCall, ToolCall: &glue.ToolCall{ID: "c1", Name: "side_effect", Arguments: []byte(`{"value":` + strconv.Quote(value) + `}`)}},
+		{Type: glue.ProviderEventDone},
+	}
+}
+
+func textTurn(text string) []glue.ProviderEvent {
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: text},
+		{Type: glue.ProviderEventDone},
+	}
+}
+
+func permissionTool(counter *atomic.Int32) glue.Tool {
+	return glue.NewTool[struct {
+		Value string `json:"value"`
+	}](glue.ToolSpec{
+		Name:               "side_effect",
+		RequiresPermission: true,
+		PermissionAction:   "touch",
+		PermissionTarget: func(call glue.ToolCall) string {
+			var args struct {
+				Value string `json:"value"`
+			}
+			_ = json.Unmarshal(call.Arguments, &args)
+			return args.Value
+		},
+	}, func(context.Context, struct {
+		Value string `json:"value"`
+	}) (glue.ToolResult, error) {
+		counter.Add(1)
+		return glue.TextResult("touched"), nil
+	})
+}
+
+func permissionID(t *testing.T, event EventEnvelope) string {
+	t.Helper()
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("permission payload = %#v", event.Payload)
+	}
+	id, ok := payload["permission_id"].(string)
+	if !ok || id == "" {
+		t.Fatalf("permission payload missing id: %#v", payload)
+	}
+	return id
+}
+
+func postDecision(t *testing.T, baseURL, runID, permissionID, token, body string) {
+	t.Helper()
+	postDecisionStatus(t, baseURL, runID, permissionID, token, "", body, http.StatusOK)
+}
+
+func postDecisionStatus(t *testing.T, baseURL, runID, permissionID, token, clientID, body string, want int) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/runs/"+runID+"/permissions/"+permissionID+"/decision", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	if clientID != "" {
+		req.Header.Set("X-Glue-Client-ID", clientID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != want {
+		t.Fatalf("decision status = %d, want %d", resp.StatusCode, want)
+	}
+}
+
+func toolEndText(t *testing.T, events []EventEnvelope) string {
+	t.Helper()
+	for _, event := range events {
+		if event.Type != "tool_end" {
+			continue
+		}
+		payload, ok := event.Payload.(map[string]any)
+		if !ok {
+			t.Fatalf("tool_end payload = %#v", event.Payload)
+		}
+		result, ok := payload["tool_result"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool_end missing result: %#v", payload)
+		}
+		if isError, _ := result["is_error"].(bool); !isError {
+			t.Fatalf("tool_end result = %#v, want is_error", result)
+		}
+		content, ok := result["content"].([]any)
+		if !ok || len(content) == 0 {
+			t.Fatalf("tool_end result missing content: %#v", result)
+		}
+		part, ok := content[0].(map[string]any)
+		if !ok {
+			t.Fatalf("tool_end content = %#v", content[0])
+		}
+		text, _ := part["text"].(string)
+		return text
+	}
+	t.Fatal("missing tool_end event")
+	return ""
 }

--- a/session.go
+++ b/session.go
@@ -88,16 +88,18 @@ type PromptResult struct {
 type PromptOption func(*promptConfig)
 
 type promptConfig struct {
-	model        string
-	systemPrompt string
-	tools        []Tool
-	options      map[string]any
-	maxTurns     int
-	emit         func(Event)
-	auxEmits     []func(Event)
-	jsonSchema   any
-	role         string
-	modelSet     bool
+	model         string
+	systemPrompt  string
+	tools         []Tool
+	options       map[string]any
+	maxTurns      int
+	emit          func(Event)
+	auxEmits      []func(Event)
+	jsonSchema    any
+	role          string
+	modelSet      bool
+	permission    Permission
+	permissionSet bool
 }
 
 // WithModel overrides the model for one prompt. When set, this beats
@@ -134,6 +136,16 @@ func WithProviderOptions(options map[string]any) PromptOption {
 // WithMaxTurns overrides the loop max-turn guard for one prompt.
 func WithMaxTurns(maxTurns int) PromptOption {
 	return func(c *promptConfig) { c.maxTurns = maxTurns }
+}
+
+// WithPermission overrides the agent's Permission implementation for one
+// prompt. Passing nil explicitly disables permission handling for that
+// prompt, so side-effecting tools are denied by the loop.
+func WithPermission(permission Permission) PromptOption {
+	return func(c *promptConfig) {
+		c.permission = permission
+		c.permissionSet = true
+	}
 }
 
 // WithEvents registers a per-prompt event handler. It receives every loop
@@ -193,6 +205,11 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 	}
 	runMessages := append(base, userMessage)
 
+	permission := s.agent.permission
+	if config.permissionSet {
+		permission = config.permission
+	}
+
 	result, runErr := loop.Run(ctx, loop.RunRequest{
 		Provider:     s.agent.provider,
 		Model:        config.model,
@@ -202,7 +219,7 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 		Options:      config.options,
 		MaxTurns:     config.maxTurns,
 		SessionID:    s.id,
-		Permission:   s.agent.permission,
+		Permission:   permission,
 		Hooks:        cloneHooks(s.agent.hooks),
 		Emit: func(event Event) {
 			if config.emit != nil {


### PR DESCRIPTION
## Summary

- add daemon-backed permission brokering for side-effecting tool calls with `permission_request` SSE events
- add the HTTP decision endpoint with owner checks, invalid-request handling, timeout expiry, and in-memory remember scopes
- add per-prompt `glue.WithPermission` so daemon runs can override the agent permission handler without changing the agent

## Validation

- `go test ./daemon -count=1`
- `go test -race ./daemon -count=1`
- `go test . -run TestSessionPromptPermissionOverride -count=1`
- `go test . -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #163