### PR TITLE
cmd/glue: add daemon serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ A thin local CLI is built on the same library API:
 go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
 ```
 
-Flags:
+`run` flags:
 
 - `--id` — session id (default `"default"`).
 - `--prompt` — prompt text (required).
@@ -614,6 +614,20 @@ The CLI streams text deltas to stdout, persists sessions through
 `stores/file`, and uses `WorkDir="."` so `AGENTS.md`, `.agents/skills`, and
 `roles/` discovery work from the invocation directory. Errors return a
 non-zero exit code; missing `GEMINI_API_KEY` produces a clear message.
+
+The same binary can also start the local HTTP+SSE daemon described in
+[ADR-0010](docs/adr/0010-daemon-protocol.md):
+
+```sh
+go run ./cmd/glue serve --store .glue/sessions
+```
+
+`serve` binds to `127.0.0.1:0` by default, generates a bearer token when
+`--token` / `GLUE_DAEMON_TOKEN` are not set, and writes connection metadata
+to `glue/daemon.json` under the user config directory with mode `0600`.
+Startup output prints the effective `base_url` and metadata path but not the
+bearer token. Use `--listen`, `--metadata`, `--work`, and
+`--permission-timeout` to override daemon behavior.
 
 ### Standard flags for downstream agents
 

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -11,19 +11,31 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
 	"github.com/erain/glue/providers/gemini"
 	filestore "github.com/erain/glue/stores/file"
 )
 
 const defaultModel = "gemini-2.5-flash"
+const defaultListenAddr = "127.0.0.1:0"
+const defaultShutdownTimeout = 5 * time.Second
 
 // providerFactory returns a [glue.Provider] or an error. The error is the
 // hook the default factory uses to surface "GEMINI_API_KEY missing"
@@ -39,8 +51,31 @@ func (e *envFiles) Set(value string) error {
 	return nil
 }
 
+type serveFunc func(context.Context, serveConfig, http.Handler, io.Writer) error
+
+type serveConfig struct {
+	ListenAddr        string
+	Token             string
+	TokenSource       string
+	MetadataPath      string
+	Model             string
+	StoreDir          string
+	WorkDir           string
+	PermissionTimeout time.Duration
+	ShutdownTimeout   time.Duration
+}
+
+type daemonMetadata struct {
+	Version int    `json:"version"`
+	BaseURL string `json:"base_url"`
+	Token   string `json:"token"`
+	PID     int    `json:"pid"`
+}
+
 func main() {
-	os.Exit(runCLI(context.Background(), os.Args[1:], os.Stdout, os.Stderr, defaultGeminiFactory))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(runCLI(ctx, os.Args[1:], os.Stdout, os.Stderr, defaultGeminiFactory))
 }
 
 func defaultGeminiFactory() (glue.Provider, error) {
@@ -51,6 +86,10 @@ func defaultGeminiFactory() (glue.Provider, error) {
 }
 
 func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory) int {
+	return runCLIWithServe(ctx, args, stdout, stderr, newProvider, serveDaemon)
+}
+
+func runCLIWithServe(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory, serve serveFunc) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printUsage(stdout)
 		return 0
@@ -59,6 +98,12 @@ func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writ
 	switch args[0] {
 	case "run":
 		if err := runCommand(ctx, args[1:], stdout, stderr, newProvider); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	case "serve":
+		if err := serveCommand(ctx, args[1:], stdout, stderr, newProvider, serve); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
@@ -99,17 +144,10 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 		return err
 	}
 
-	provider, err := newProvider()
+	agent, err := newAgent(newProvider, *model, *storeDir, ".")
 	if err != nil {
 		return err
 	}
-
-	agent := glue.NewAgent(glue.AgentOptions{
-		Provider: provider,
-		Model:    normalizeModel(*model),
-		Store:    filestore.New(*storeDir),
-		WorkDir:  ".",
-	})
 	session, err := agent.Session(ctx, *id)
 	if err != nil {
 		return err
@@ -138,22 +176,205 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 	return nil
 }
 
+func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory, serve serveFunc) error {
+	flags := flag.NewFlagSet("glue serve", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	model := flags.String("model", defaultModel, "model id or gemini/<model>")
+	storeDir := flags.String("store", ".glue/sessions", "session store directory")
+	workDir := flags.String("work", ".", "working directory for AGENTS.md, skills, and roles")
+	listenAddr := flags.String("listen", defaultListenAddr, "local listen address")
+	tokenFlag := flags.String("token", "", "bearer token; defaults to GLUE_DAEMON_TOKEN or a generated token")
+	metadataPath := flags.String("metadata", defaultMetadataPath(), "connection metadata JSON path; empty disables metadata file")
+	permissionTimeout := flags.Duration("permission-timeout", 0, "permission decision timeout; 0 uses daemon default")
+	var envs envFiles
+	flags.Var(&envs, "env", "env file path; repeatable")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	agentName := "default"
+	if flags.NArg() > 0 {
+		agentName = flags.Arg(0)
+	}
+	if agentName != "default" && agentName != "gemini" {
+		return fmt.Errorf("unknown agent %q; only 'default' is available in this runner", agentName)
+	}
+	if err := loadEnvFiles(envs); err != nil {
+		return err
+	}
+	token, tokenSource, err := resolveDaemonToken(*tokenFlag)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(*metadataPath) == "" && tokenSource == "generated" {
+		return errors.New("metadata disabled requires --token or GLUE_DAEMON_TOKEN")
+	}
+	agent, err := newAgent(newProvider, *model, *storeDir, *workDir)
+	if err != nil {
+		return err
+	}
+	handler, err := daemon.New(daemon.Options{
+		Host:              agent,
+		Token:             token,
+		PermissionTimeout: *permissionTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	return serve(ctx, serveConfig{
+		ListenAddr:        *listenAddr,
+		Token:             token,
+		TokenSource:       tokenSource,
+		MetadataPath:      *metadataPath,
+		Model:             normalizeModel(*model),
+		StoreDir:          *storeDir,
+		WorkDir:           *workDir,
+		PermissionTimeout: *permissionTimeout,
+		ShutdownTimeout:   defaultShutdownTimeout,
+	}, handler, stdout)
+}
+
+func newAgent(newProvider providerFactory, model, storeDir, workDir string) (*glue.Agent, error) {
+	provider, err := newProvider()
+	if err != nil {
+		return nil, err
+	}
+	return glue.NewAgent(glue.AgentOptions{
+		Provider: provider,
+		Model:    normalizeModel(model),
+		Store:    filestore.New(storeDir),
+		WorkDir:  workDir,
+	}), nil
+}
+
 func normalizeModel(model string) string {
 	return strings.TrimPrefix(model, "gemini/")
+}
+
+func serveDaemon(ctx context.Context, cfg serveConfig, handler http.Handler, stdout io.Writer) error {
+	if cfg.ShutdownTimeout <= 0 {
+		cfg.ShutdownTimeout = defaultShutdownTimeout
+	}
+	ln, err := net.Listen("tcp", cfg.ListenAddr)
+	if err != nil {
+		return err
+	}
+	baseURL := "http://" + ln.Addr().String()
+	if cfg.MetadataPath != "" {
+		if err := writeDaemonMetadata(cfg.MetadataPath, daemonMetadata{
+			Version: 1,
+			BaseURL: baseURL,
+			Token:   cfg.Token,
+			PID:     os.Getpid(),
+		}); err != nil {
+			_ = ln.Close()
+			return err
+		}
+	}
+
+	fmt.Fprintln(stdout, "glue daemon listening")
+	fmt.Fprintf(stdout, "base_url: %s\n", baseURL)
+	if cfg.MetadataPath != "" {
+		fmt.Fprintf(stdout, "metadata: %s\n", cfg.MetadataPath)
+		fmt.Fprintf(stdout, "token: written to metadata file (%s)\n", cfg.TokenSource)
+	} else {
+		fmt.Fprintf(stdout, "token: configured (%s); metadata file disabled\n", cfg.TokenSource)
+	}
+
+	server := &http.Server{Handler: handler}
+	errCh := make(chan error, 1)
+	go func() {
+		err := server.Serve(ln)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			_ = server.Close()
+			return err
+		}
+		return <-errCh
+	}
+}
+
+func resolveDaemonToken(flagValue string) (token, source string, err error) {
+	if token := strings.TrimSpace(flagValue); token != "" {
+		return token, "flag", nil
+	}
+	if token := strings.TrimSpace(os.Getenv("GLUE_DAEMON_TOKEN")); token != "" {
+		return token, "GLUE_DAEMON_TOKEN", nil
+	}
+	token, err = randomToken()
+	if err != nil {
+		return "", "", err
+	}
+	return token, "generated", nil
+}
+
+func randomToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func defaultMetadataPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil || strings.TrimSpace(dir) == "" {
+		return filepath.Join(".glue", "daemon.json")
+	}
+	return filepath.Join(dir, "glue", "daemon.json")
+}
+
+func writeDaemonMetadata(path string, meta daemonMetadata) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Chmod(path, 0o600)
 }
 
 func printUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
   glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--env <path>]
+  glue serve [default|gemini] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--env <path>]
 
 Commands:
   run    Run the local Gemini-backed agent.
+  serve  Start a local HTTP+SSE daemon for Glue sessions.
 
 Flags:
   --id       Session id. Defaults to "default".
   --prompt   Prompt text. Required.
   --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
   --store    File session store directory. Defaults to .glue/sessions.
+  --work     Working directory for serve mode. Defaults to ".".
+  --listen   Serve listen address. Defaults to 127.0.0.1:0.
+  --token    Serve bearer token. Defaults to GLUE_DAEMON_TOKEN or a generated token.
+  --metadata Serve connection metadata JSON. Defaults to the user config directory.
   --env      Load env vars from a .env file. Repeatable; shell env wins.
 `)
 }

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -3,12 +3,16 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/erain/glue"
 )
@@ -217,6 +221,219 @@ func TestRunCLIMissingPrompt(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "missing required --prompt") {
 		t.Fatalf("stderr = %q, want missing prompt", stderr.String())
+	}
+}
+
+func TestRunCLIServeBuildsDaemon(t *testing.T) {
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{textTurn("served")}}
+	storeDir := t.TempDir()
+	workDir := t.TempDir()
+	metadataPath := filepath.Join(t.TempDir(), "daemon.json")
+	var captured serveConfig
+	serve := func(ctx context.Context, cfg serveConfig, handler http.Handler, _ io.Writer) error {
+		captured = cfg
+
+		health := httptest.NewRecorder()
+		handler.ServeHTTP(health, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+		if health.Code != http.StatusOK {
+			t.Fatalf("health status = %d, want %d", health.Code, http.StatusOK)
+		}
+
+		ts := httptest.NewServer(handler)
+		defer ts.Close()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/v1/sessions/default/runs", strings.NewReader(`{"text":"go"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer test-token")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("start status = %d, want %d", resp.StatusCode, http.StatusCreated)
+		}
+		var start struct {
+			EventsURL string `json:"events_url"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&start); err != nil {
+			t.Fatal(err)
+		}
+
+		eventsReq, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+start.EventsURL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		eventsReq.Header.Set("Authorization", "Bearer test-token")
+		eventsResp, err := http.DefaultClient.Do(eventsReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer eventsResp.Body.Close()
+		if eventsResp.StatusCode != http.StatusOK {
+			t.Fatalf("events status = %d, want %d", eventsResp.StatusCode, http.StatusOK)
+		}
+		if _, err := io.Copy(io.Discard, eventsResp.Body); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithServe(context.Background(), []string{
+		"serve",
+		"--listen", "127.0.0.1:0",
+		"--token", "test-token",
+		"--metadata", metadataPath,
+		"--model", "gemini/custom",
+		"--store", storeDir,
+		"--work", workDir,
+	}, &stdout, &stderr, fakeFactory(provider), serve)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if captured.ListenAddr != "127.0.0.1:0" || captured.Token != "test-token" || captured.TokenSource != "flag" {
+		t.Fatalf("serve config auth/listen = %+v", captured)
+	}
+	if captured.Model != "custom" || captured.StoreDir != storeDir || captured.WorkDir != workDir || captured.MetadataPath != metadataPath {
+		t.Fatalf("serve config paths/model = %+v", captured)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider requests = %d, want 1", len(provider.requests))
+	}
+	if got := provider.requests[0].Model; got != "custom" {
+		t.Fatalf("provider model = %q, want custom", got)
+	}
+}
+
+func TestRunCLIServeGeneratesTokenWhenMetadataEnabled(t *testing.T) {
+	t.Setenv("GLUE_DAEMON_TOKEN", "")
+	var captured serveConfig
+	serve := func(_ context.Context, cfg serveConfig, _ http.Handler, _ io.Writer) error {
+		captured = cfg
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithServe(context.Background(), []string{
+		"serve",
+		"--metadata", filepath.Join(t.TempDir(), "daemon.json"),
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}), serve)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if captured.TokenSource != "generated" || len(captured.Token) != 64 {
+		t.Fatalf("generated token = source %q len %d", captured.TokenSource, len(captured.Token))
+	}
+}
+
+func TestRunCLIServeMetadataDisabledRequiresKnownToken(t *testing.T) {
+	t.Setenv("GLUE_DAEMON_TOKEN", "")
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithServe(context.Background(), []string{
+		"serve",
+		"--metadata", "",
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}), func(context.Context, serveConfig, http.Handler, io.Writer) error {
+		t.Fatal("serve should not be called")
+		return nil
+	})
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero")
+	}
+	if !strings.Contains(stderr.String(), "metadata disabled requires") {
+		t.Fatalf("stderr = %q, want metadata error", stderr.String())
+	}
+}
+
+func TestRunCLIServeMetadataDisabledAllowsEnvToken(t *testing.T) {
+	t.Setenv("GLUE_DAEMON_TOKEN", "env-token")
+	var captured serveConfig
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithServe(context.Background(), []string{
+		"serve",
+		"--metadata", "",
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}), func(_ context.Context, cfg serveConfig, _ http.Handler, _ io.Writer) error {
+		captured = cfg
+		return nil
+	})
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if captured.Token != "env-token" || captured.TokenSource != "GLUE_DAEMON_TOKEN" {
+		t.Fatalf("token config = %+v", captured)
+	}
+}
+
+func TestRunCLIServeLoadsEnvBeforeTokenResolution(t *testing.T) {
+	os.Unsetenv("GLUE_DAEMON_TOKEN")
+	t.Cleanup(func() { os.Unsetenv("GLUE_DAEMON_TOKEN") })
+	envPath := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envPath, []byte("GLUE_DAEMON_TOKEN=file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured serveConfig
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithServe(context.Background(), []string{
+		"serve",
+		"--metadata", "",
+		"--env", envPath,
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}), func(_ context.Context, cfg serveConfig, _ http.Handler, _ io.Writer) error {
+		captured = cfg
+		return nil
+	})
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if captured.Token != "file-token" || captured.TokenSource != "GLUE_DAEMON_TOKEN" {
+		t.Fatalf("token config = %+v", captured)
+	}
+}
+
+func TestServeDaemonWritesMetadataAndShutsDown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	metadataPath := filepath.Join(t.TempDir(), "glue", "daemon.json")
+	var stdout bytes.Buffer
+
+	err := serveDaemon(ctx, serveConfig{
+		ListenAddr:      "127.0.0.1:0",
+		Token:           "secret-token",
+		TokenSource:     "test",
+		MetadataPath:    metadataPath,
+		ShutdownTimeout: time.Second,
+	}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), &stdout)
+	if err != nil {
+		t.Fatalf("serveDaemon: %v", err)
+	}
+
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta daemonMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.Version != 1 || meta.Token != "secret-token" || !strings.HasPrefix(meta.BaseURL, "http://127.0.0.1:") || meta.PID == 0 {
+		t.Fatalf("metadata = %+v", meta)
+	}
+	info, err := os.Stat(metadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("metadata mode = %v, want 0600", info.Mode().Perm())
+	}
+	if strings.Contains(stdout.String(), "secret-token") {
+		t.Fatalf("stdout leaked token: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "metadata: "+metadataPath) {
+		t.Fatalf("stdout = %q, want metadata path", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `glue serve` to start the local HTTP+SSE daemon from `cmd/glue`
- add local-first daemon defaults: `127.0.0.1:0`, generated/explicit bearer token, metadata JSON with mode `0600`, and SIGINT/SIGTERM shutdown
- document the serve command and cover startup, token resolution, env-file handling, metadata permissions, and fake-provider daemon runs

## Validation

- `go test ./cmd/glue -count=1`
- `go test -race ./cmd/glue -count=1`
- `go test ./daemon ./cmd/glue -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #165