### PR TITLE
agents/peggy: add daemon serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,19 @@ By default, `connect` reads the same metadata file written by `serve`.
 Use `--base-url`, `--token`, or `--metadata` when connecting to an
 explicit daemon endpoint.
 
+Peggy can serve the same daemon protocol with the personal-assistant
+agent, settings, memory store, and coding tools loaded once:
+
+```sh
+go run ./agents/peggy/cmd/peggy serve --coding --workdir .
+go run ./cmd/glue connect --prompt "Say hi to Peggy" --id cli:daily
+```
+
+`peggy serve` writes metadata to the same default path as `glue serve`,
+so `glue connect` works without explicit connection flags. Permission
+requests for Peggy coding tools are brokered over the daemon stream and
+answered by the connected client.
+
 ### Standard flags for downstream agents
 
 Agents that ship their own CLI binary share the same six flags

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -22,7 +22,7 @@ A long-running personal-assistant agent built on the
   OpenRouter, NVIDIA build
 
 Tracker: [#110](https://github.com/erain/glue/issues/110). M3
-("multi-channel daemon") is the next milestone.
+("multi-channel daemon") is active.
 
 ## Quickstart
 
@@ -44,6 +44,11 @@ peggy "Hello — what should I be working on today?"
 # 5. Optional: let Peggy work in a trusted repo.
 cd /path/to/repo
 peggy --coding --workdir . "read the failing test and propose a fix"
+
+# 6. Optional: keep one Peggy process running and connect to it.
+go install github.com/erain/glue/cmd/glue@latest  # if needed
+peggy serve --coding --workdir .
+glue connect --prompt "what should I do next?" --id cli:daily
 ```
 
 To reach her from your phone, set up Telegram next — see
@@ -121,6 +126,7 @@ defaults above and emits a stderr diagnostic.
 
 ```
 peggy [flags] "<prompt text>"
+peggy serve [flags]
 
   --config <path>    Override the settings.json path.
   --soul <path>      Override the SOUL.md path.
@@ -139,6 +145,37 @@ peggy [flags] "<prompt text>"
 
 The prompt is whatever non-flag args you pass — quoting is your
 shell's job. Multi-word prompts work without quoting too.
+
+## Daemon Mode
+
+`peggy serve` starts one local Peggy process behind the shared
+HTTP+SSE daemon protocol from
+[`ADR-0010`](../../docs/adr/0010-daemon-protocol.md). It loads the
+same `settings.json` and `SOUL.md` as the single-prompt CLI, keeps one
+provider/store in memory, and lets daemon clients share the same
+session history and memory store.
+
+```sh
+peggy serve --config ~/.config/peggy/settings.json
+glue connect --prompt "summarize today's plan" --id cli:daily
+```
+
+Useful `serve` flags:
+
+- `--listen` — local listen address (default `127.0.0.1:0`).
+- `--token` — bearer token. Defaults to `GLUE_DAEMON_TOKEN` or a
+  generated token.
+- `--metadata` — connection metadata path. Defaults to the same
+  `glue/daemon.json` user-config path that `glue connect` reads.
+  Pass an empty value only with `--token` or `GLUE_DAEMON_TOKEN`.
+- `--permission-timeout` — maximum time a side-effecting tool waits
+  for a client decision.
+- `--coding`, `--workdir`, `--coding-allow-overwrite` — same coding
+  tool controls as the prompt CLI, but permission prompts are emitted
+  over the daemon protocol for the connected client to answer.
+
+Startup output prints the `base_url` and metadata path, never the
+bearer token. Stop the daemon with SIGINT/SIGTERM.
 
 ## Coding Tools
 
@@ -293,9 +330,10 @@ external transports. The pattern is designed in
 Per tracker [#110](https://github.com/erain/glue/issues/110), in
 priority order:
 
-- **M3 — multi-channel daemon.** `cmd/glue serve` so a single
-  long-running Peggy serves a TUI, Telegram, and future clients
-  concurrently. Per-channel permission tiers.
+- **M3 — multi-channel daemon.** `peggy serve` plus daemon clients so
+  one long-running Peggy serves a terminal, Telegram, and future
+  clients concurrently. Next up: Telegram daemon-client mode and
+  per-channel permission tiers.
 - **M4 — ecosystem.** MCP client (stdio + HTTP), cost tracking,
   `providers/anthropic` when budget allows.
 

--- a/agents/peggy/cmd/peggy/main.go
+++ b/agents/peggy/cmd/peggy/main.go
@@ -5,10 +5,14 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/erain/glue/agents/peggy"
 )
 
 func main() {
-	os.Exit(peggy.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(peggy.Run(ctx, os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -1,0 +1,194 @@
+package peggy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
+	filestore "github.com/erain/glue/stores/file"
+)
+
+func TestPeggyDaemonCodingPermissionViaDaemon(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "write_file", `{"path":"note.txt","content":"hello from daemon"}`),
+		peggyTextTurn("done"),
+	}}
+	p, err := New(Options{
+		Settings: Settings{Coding: CodingSettings{
+			Enabled:        true,
+			WorkDir:        workDir,
+			AllowOverwrite: true,
+		}},
+		Provider: provider,
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	srv, err := daemon.New(daemon.Options{
+		Host:              p.Agent(),
+		Token:             "tok",
+		PermissionTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startPeggyDaemonRun(t, ts.URL)
+	events := collectPeggyDaemonEvents(t, ts.URL, start.RunID, start.EventsURL)
+	if !eventSeen(events, "permission_request") {
+		t.Fatalf("events = %v, want permission_request", eventTypes(events))
+	}
+	if got := readFileString(t, filepath.Join(workDir, "note.txt")); got != "hello from daemon" {
+		t.Fatalf("written file = %q", got)
+	}
+	if types := eventTypes(events); types[len(types)-1] != "run_done" {
+		t.Fatalf("events = %v, want terminal run_done", types)
+	}
+}
+
+type startRunResponse struct {
+	RunID     string `json:"run_id"`
+	EventsURL string `json:"events_url"`
+}
+
+func startPeggyDaemonRun(t *testing.T, baseURL string) startRunResponse {
+	t.Helper()
+	body := bytes.NewBufferString(`{"text":"write the note","client_id":"cli:test","max_turns":3}`)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/sessions/default/runs", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("start status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var start startRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&start); err != nil {
+		t.Fatal(err)
+	}
+	if start.RunID == "" || start.EventsURL == "" {
+		t.Fatalf("start response = %+v", start)
+	}
+	return start
+}
+
+func collectPeggyDaemonEvents(t *testing.T, baseURL, runID, eventsURL string) []daemon.EventEnvelope {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, baseURL+eventsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("events status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var events []daemon.EventEnvelope
+	scan := bufio.NewScanner(resp.Body)
+	for scan.Scan() {
+		line := scan.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event daemon.EventEnvelope
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, event)
+		if event.Type == "permission_request" {
+			postPeggyDaemonDecision(t, baseURL, runID, permissionID(t, event))
+		}
+		if event.Type == "run_done" || event.Type == "run_error" {
+			break
+		}
+	}
+	if err := scan.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return events
+}
+
+func postPeggyDaemonDecision(t *testing.T, baseURL, runID, permissionID string) {
+	t.Helper()
+	url := baseURL + "/v1/runs/" + runID + "/permissions/" + permissionID + "/decision"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(`{"allow":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("X-Glue-Client-ID", "cli:test")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("decision status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func permissionID(t *testing.T, event daemon.EventEnvelope) string {
+	t.Helper()
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload = %T, want object", event.Payload)
+	}
+	id, ok := payload["permission_id"].(string)
+	if !ok || id == "" {
+		t.Fatalf("payload = %#v, want permission_id", payload)
+	}
+	return id
+}
+
+func eventSeen(events []daemon.EventEnvelope, want string) bool {
+	for _, event := range events {
+		if event.Type == want {
+			return true
+		}
+	}
+	return false
+}
+
+func eventTypes(events []daemon.EventEnvelope) []string {
+	types := make([]string, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -6,15 +6,34 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
 )
 
 // Version is the package version string surfaced by `peggy --version`.
 // Bumped by hand at release time.
 const Version = "0.2.0"
+
+const (
+	defaultDaemonListenAddr      = "127.0.0.1:0"
+	defaultDaemonShutdownTimeout = 5 * time.Second
+)
+
+type serveFunc func(context.Context, serveConfig, http.Handler, io.Writer) error
+
+type serveConfig struct {
+	ListenAddr        string
+	Token             string
+	TokenSource       string
+	MetadataPath      string
+	PermissionTimeout time.Duration
+	ShutdownTimeout   time.Duration
+}
 
 // Run is the top-level CLI entry point. It parses args, loads the
 // settings and identity files, constructs a Peggy, and dispatches a
@@ -30,6 +49,14 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 // RunWithInput is like [Run] but lets tests and embedded callers provide the
 // stdin reader used by the CLI permission prompt.
 func RunWithInput(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	return runWithDeps(ctx, args, stdin, stdout, stderr, servePeggyDaemon)
+}
+
+func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, serve serveFunc) int {
+	if len(args) > 0 && args[0] == "serve" {
+		return runServe(ctx, args[1:], stdout, stderr, serve)
+	}
+
 	fs := flag.NewFlagSet("peggy", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
@@ -46,12 +73,14 @@ func RunWithInput(ctx context.Context, args []string, stdin io.Reader, stdout, s
 
 Usage:
   peggy [flags] "<prompt text>"
+  peggy serve [flags]
 
 Examples:
   peggy "hello"
   peggy --session work "remind me about the migration plan"
   peggy --config /tmp/peggy.json "what do you know about my Aussie?"
   peggy --coding --workdir . "run the tests and fix the failure"
+  peggy serve --config ~/.config/peggy/settings.json
 
 Flags:
 `)
@@ -88,15 +117,7 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 	if settingsPath == "" {
 		fmt.Fprintln(stderr, "peggy: no settings.json found; using built-in defaults")
 	}
-	if *enableCoding || *codingWorkDir != "" || *codingAllowOverwrite {
-		settings.Coding.Enabled = true
-	}
-	if *codingWorkDir != "" {
-		settings.Coding.WorkDir = *codingWorkDir
-	}
-	if *codingAllowOverwrite {
-		settings.Coding.AllowOverwrite = true
-	}
+	applyCodingFlags(&settings, *enableCoding, *codingWorkDir, *codingAllowOverwrite)
 
 	soul, soulPathUsed, err := LoadSoul(*soulPath)
 	if err != nil {
@@ -137,4 +158,146 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 	}
 	fmt.Fprintln(stdout) // trailing newline so shell prompts don't run on
 	return 0
+}
+
+func runServe(ctx context.Context, args []string, stdout, stderr io.Writer, serve serveFunc) int {
+	fs := flag.NewFlagSet("peggy serve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath           = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		soulPath             = fs.String("soul", "", "path to identity Markdown (overrides $PEGGY_SOUL / XDG / ~/.config/peggy/SOUL.md)")
+		listenAddr           = fs.String("listen", defaultDaemonListenAddr, "local listen address")
+		tokenFlag            = fs.String("token", "", "bearer token; defaults to GLUE_DAEMON_TOKEN or a generated token")
+		metadataPath         = fs.String("metadata", daemon.DefaultMetadataPath(), "connection metadata JSON path; empty disables metadata file")
+		permissionTimeout    = fs.Duration("permission-timeout", 0, "permission decision timeout; 0 uses daemon default")
+		showVersion          = fs.Bool("version", false, "print version and exit")
+		enableCoding         = fs.Bool("coding", false, "enable local coding tools for this daemon")
+		codingWorkDir        = fs.String("workdir", "", "workspace root for --coding (default current directory)")
+		codingAllowOverwrite = fs.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy serve — run Peggy as a local HTTP+SSE daemon.
+
+Usage:
+  peggy serve [flags]
+
+Then connect from another terminal:
+  glue connect --prompt "hello"
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if *showVersion {
+		fmt.Fprintln(stdout, Version)
+		return 0
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy serve: positional args not supported")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy serve: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy serve: no settings.json found; using built-in defaults")
+	}
+	applyCodingFlags(&settings, *enableCoding, *codingWorkDir, *codingAllowOverwrite)
+
+	soul, soulPathUsed, err := LoadSoul(*soulPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy serve: %v\n", err)
+		return 1
+	}
+	if soul == "" {
+		fmt.Fprintln(stderr, "peggy serve: no SOUL.md found; running without identity context")
+	} else {
+		fmt.Fprintf(stderr, "peggy serve: identity loaded from %s (%d bytes)\n", soulPathUsed, len(soul))
+	}
+	if settings.Coding.Enabled {
+		workDir := settings.Coding.WorkDir
+		if strings.TrimSpace(workDir) == "" {
+			workDir = "."
+		}
+		fmt.Fprintf(stderr, "peggy serve: coding tools enabled for %s\n", workDir)
+	}
+
+	token, tokenSource, err := daemon.ResolveToken(*tokenFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy serve: %v\n", err)
+		return 1
+	}
+	if strings.TrimSpace(*metadataPath) == "" && tokenSource == "generated" {
+		fmt.Fprintln(stderr, "peggy serve: metadata disabled requires --token or GLUE_DAEMON_TOKEN")
+		return 1
+	}
+
+	p, err := New(Options{
+		Settings: settings,
+		Soul:     soul,
+		Stderr:   stderr,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy serve: setup: %v\n", err)
+		return 1
+	}
+	defer p.Close()
+
+	handler, err := daemon.New(daemon.Options{
+		Host:              p.Agent(),
+		Token:             token,
+		PermissionTimeout: *permissionTimeout,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy serve: setup: %v\n", err)
+		return 1
+	}
+
+	if err := serve(ctx, serveConfig{
+		ListenAddr:        *listenAddr,
+		Token:             token,
+		TokenSource:       tokenSource,
+		MetadataPath:      *metadataPath,
+		PermissionTimeout: *permissionTimeout,
+		ShutdownTimeout:   defaultDaemonShutdownTimeout,
+	}, handler, stdout); err != nil {
+		fmt.Fprintf(stderr, "peggy serve: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func applyCodingFlags(settings *Settings, enable bool, workDir string, allowOverwrite bool) {
+	if settings == nil {
+		return
+	}
+	if enable || workDir != "" || allowOverwrite {
+		settings.Coding.Enabled = true
+	}
+	if workDir != "" {
+		settings.Coding.WorkDir = workDir
+	}
+	if allowOverwrite {
+		settings.Coding.AllowOverwrite = true
+	}
+}
+
+func servePeggyDaemon(ctx context.Context, cfg serveConfig, handler http.Handler, stdout io.Writer) error {
+	return daemon.ServeLocal(ctx, daemon.LocalConfig{
+		Name:            "peggy daemon",
+		ListenAddr:      cfg.ListenAddr,
+		Token:           cfg.Token,
+		TokenSource:     cfg.TokenSource,
+		MetadataPath:    cfg.MetadataPath,
+		ShutdownTimeout: cfg.ShutdownTimeout,
+	}, handler, stdout)
 }

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRun_Version(t *testing.T) {
@@ -150,4 +153,95 @@ func TestRun_CodingFlagsParseAndUseInputAwareRunner(t *testing.T) {
 	if !strings.Contains(errOut.String(), "coding tools enabled") {
 		t.Fatalf("stderr = %q, want coding diagnostic", errOut.String())
 	}
+}
+
+func TestRunServeMetadataDisabledRequiresExplicitToken(t *testing.T) {
+	t.Setenv("GLUE_DAEMON_TOKEN", "")
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	var out, errOut bytes.Buffer
+	code := runWithDeps(context.Background(), []string{
+		"serve",
+		"--metadata", "",
+	}, strings.NewReader(""), &out, &errOut, func(context.Context, serveConfig, http.Handler, io.Writer) error {
+		t.Fatal("serve should not be called")
+		return nil
+	})
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero")
+	}
+	if !strings.Contains(errOut.String(), "metadata disabled requires") {
+		t.Fatalf("stderr = %q, want metadata error", errOut.String())
+	}
+}
+
+func TestRunServeBuildsPeggyDaemonConfig(t *testing.T) {
+	t.Setenv("GLUE_DAEMON_TOKEN", "")
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "openrouter",
+		"store": map[string]any{
+			"type": "file",
+			"path": filepath.Join(t.TempDir(), "sessions"),
+		},
+	})
+	soulPath := filepath.Join(t.TempDir(), "SOUL.md")
+	if err := os.WriteFile(soulPath, []byte("You are Peggy."), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workDir := t.TempDir()
+
+	var captured serveConfig
+	var gotHandler bool
+	var out, errOut bytes.Buffer
+	code := runWithDeps(context.Background(), []string{
+		"serve",
+		"--config", cfgPath,
+		"--soul", soulPath,
+		"--listen", "127.0.0.1:12345",
+		"--token", "tok",
+		"--metadata", "",
+		"--permission-timeout", "2s",
+		"--coding",
+		"--workdir", workDir,
+	}, strings.NewReader(""), &out, &errOut, func(_ context.Context, cfg serveConfig, handler http.Handler, _ io.Writer) error {
+		captured = cfg
+		gotHandler = handler != nil
+		return nil
+	})
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, errOut.String())
+	}
+	if !gotHandler {
+		t.Fatal("handler was nil")
+	}
+	if captured.ListenAddr != "127.0.0.1:12345" || captured.Token != "tok" || captured.TokenSource != "flag" || captured.MetadataPath != "" {
+		t.Fatalf("serve config = %+v", captured)
+	}
+	if captured.PermissionTimeout != 2*time.Second {
+		t.Fatalf("permission timeout = %s", captured.PermissionTimeout)
+	}
+	if !strings.Contains(errOut.String(), "coding tools enabled for "+workDir) {
+		t.Fatalf("stderr = %q, want coding diagnostic", errOut.String())
+	}
+}
+
+func writeRunnerConfig(t *testing.T, cfg map[string]any) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath
 }

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -12,19 +12,15 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -67,12 +63,7 @@ type serveConfig struct {
 	ShutdownTimeout   time.Duration
 }
 
-type daemonMetadata struct {
-	Version int    `json:"version"`
-	BaseURL string `json:"base_url"`
-	Token   string `json:"token"`
-	PID     int    `json:"pid"`
-}
+type daemonMetadata = daemon.Metadata
 
 type httpDoer interface {
 	Do(*http.Request) (*http.Response, error)
@@ -593,87 +584,22 @@ func normalizeModel(model string) string {
 }
 
 func serveDaemon(ctx context.Context, cfg serveConfig, handler http.Handler, stdout io.Writer) error {
-	if cfg.ShutdownTimeout <= 0 {
-		cfg.ShutdownTimeout = defaultShutdownTimeout
-	}
-	ln, err := net.Listen("tcp", cfg.ListenAddr)
-	if err != nil {
-		return err
-	}
-	baseURL := "http://" + ln.Addr().String()
-	if cfg.MetadataPath != "" {
-		if err := writeDaemonMetadata(cfg.MetadataPath, daemonMetadata{
-			Version: 1,
-			BaseURL: baseURL,
-			Token:   cfg.Token,
-			PID:     os.Getpid(),
-		}); err != nil {
-			_ = ln.Close()
-			return err
-		}
-	}
-
-	fmt.Fprintln(stdout, "glue daemon listening")
-	fmt.Fprintf(stdout, "base_url: %s\n", baseURL)
-	if cfg.MetadataPath != "" {
-		fmt.Fprintf(stdout, "metadata: %s\n", cfg.MetadataPath)
-		fmt.Fprintf(stdout, "token: written to metadata file (%s)\n", cfg.TokenSource)
-	} else {
-		fmt.Fprintf(stdout, "token: configured (%s); metadata file disabled\n", cfg.TokenSource)
-	}
-
-	server := &http.Server{Handler: handler}
-	errCh := make(chan error, 1)
-	go func() {
-		err := server.Serve(ln)
-		if errors.Is(err, http.ErrServerClosed) {
-			err = nil
-		}
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
-		return err
-	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
-		defer cancel()
-		if err := server.Shutdown(shutdownCtx); err != nil {
-			_ = server.Close()
-			return err
-		}
-		return <-errCh
-	}
+	return daemon.ServeLocal(ctx, daemon.LocalConfig{
+		Name:            "glue daemon",
+		ListenAddr:      cfg.ListenAddr,
+		Token:           cfg.Token,
+		TokenSource:     cfg.TokenSource,
+		MetadataPath:    cfg.MetadataPath,
+		ShutdownTimeout: cfg.ShutdownTimeout,
+	}, handler, stdout)
 }
 
 func resolveDaemonToken(flagValue string) (token, source string, err error) {
-	if token := strings.TrimSpace(flagValue); token != "" {
-		return token, "flag", nil
-	}
-	if token := strings.TrimSpace(os.Getenv("GLUE_DAEMON_TOKEN")); token != "" {
-		return token, "GLUE_DAEMON_TOKEN", nil
-	}
-	token, err = randomToken()
-	if err != nil {
-		return "", "", err
-	}
-	return token, "generated", nil
-}
-
-func randomToken() (string, error) {
-	var b [32]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b[:]), nil
+	return daemon.ResolveToken(flagValue)
 }
 
 func defaultMetadataPath() string {
-	dir, err := os.UserConfigDir()
-	if err != nil || strings.TrimSpace(dir) == "" {
-		return filepath.Join(".glue", "daemon.json")
-	}
-	return filepath.Join(dir, "glue", "daemon.json")
+	return daemon.DefaultMetadataPath()
 }
 
 func defaultClientID() string {
@@ -681,38 +607,11 @@ func defaultClientID() string {
 }
 
 func readDaemonMetadata(path string) (daemonMetadata, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return daemonMetadata{}, err
-	}
-	var meta daemonMetadata
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return daemonMetadata{}, err
-	}
-	if meta.Version != 1 {
-		return daemonMetadata{}, fmt.Errorf("metadata %s: unsupported version %d", path, meta.Version)
-	}
-	return meta, nil
+	return daemon.ReadMetadata(path)
 }
 
 func writeDaemonMetadata(path string, meta daemonMetadata) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(meta, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return os.Chmod(path, 0o600)
+	return daemon.WriteMetadata(path, meta)
 }
 
 func decodePayload[T any](payload any) (T, error) {

--- a/daemon/local.go
+++ b/daemon/local.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const defaultLocalShutdownTimeout = 5 * time.Second
+
+// Metadata is the local connection file shape written by local daemon
+// launchers and consumed by daemon clients.
+type Metadata struct {
+	Version int    `json:"version"`
+	BaseURL string `json:"base_url"`
+	Token   string `json:"token"`
+	PID     int    `json:"pid"`
+}
+
+// LocalConfig configures ServeLocal.
+type LocalConfig struct {
+	Name            string
+	ListenAddr      string
+	Token           string
+	TokenSource     string
+	MetadataPath    string
+	ShutdownTimeout time.Duration
+}
+
+// ServeLocal starts handler on a local TCP listener, writes optional
+// connection metadata, and shuts down gracefully when ctx is canceled.
+func ServeLocal(ctx context.Context, cfg LocalConfig, handler http.Handler, stdout io.Writer) error {
+	if cfg.ListenAddr == "" {
+		cfg.ListenAddr = "127.0.0.1:0"
+	}
+	if cfg.ShutdownTimeout <= 0 {
+		cfg.ShutdownTimeout = defaultLocalShutdownTimeout
+	}
+	name := strings.TrimSpace(cfg.Name)
+	if name == "" {
+		name = "glue daemon"
+	}
+
+	ln, err := net.Listen("tcp", cfg.ListenAddr)
+	if err != nil {
+		return err
+	}
+	baseURL := "http://" + ln.Addr().String()
+	if cfg.MetadataPath != "" {
+		if err := WriteMetadata(cfg.MetadataPath, Metadata{
+			Version: 1,
+			BaseURL: baseURL,
+			Token:   cfg.Token,
+			PID:     os.Getpid(),
+		}); err != nil {
+			_ = ln.Close()
+			return err
+		}
+	}
+
+	if stdout != nil {
+		fmt.Fprintf(stdout, "%s listening\n", name)
+		fmt.Fprintf(stdout, "base_url: %s\n", baseURL)
+		if cfg.MetadataPath != "" {
+			fmt.Fprintf(stdout, "metadata: %s\n", cfg.MetadataPath)
+			fmt.Fprintf(stdout, "token: written to metadata file (%s)\n", cfg.TokenSource)
+		} else {
+			fmt.Fprintf(stdout, "token: configured (%s); metadata file disabled\n", cfg.TokenSource)
+		}
+	}
+
+	server := &http.Server{Handler: handler}
+	errCh := make(chan error, 1)
+	go func() {
+		err := server.Serve(ln)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			_ = server.Close()
+			return err
+		}
+		return <-errCh
+	}
+}
+
+// ResolveToken returns an explicit token, $GLUE_DAEMON_TOKEN, or a new
+// random token, along with a human-readable source string.
+func ResolveToken(flagValue string) (token, source string, err error) {
+	if token := strings.TrimSpace(flagValue); token != "" {
+		return token, "flag", nil
+	}
+	if token := strings.TrimSpace(os.Getenv("GLUE_DAEMON_TOKEN")); token != "" {
+		return token, "GLUE_DAEMON_TOKEN", nil
+	}
+	token, err = RandomToken()
+	if err != nil {
+		return "", "", err
+	}
+	return token, "generated", nil
+}
+
+// RandomToken returns a 256-bit random bearer token encoded as hex.
+func RandomToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// DefaultMetadataPath returns the shared local daemon metadata path.
+func DefaultMetadataPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil || strings.TrimSpace(dir) == "" {
+		return filepath.Join(".glue", "daemon.json")
+	}
+	return filepath.Join(dir, "glue", "daemon.json")
+}
+
+// ReadMetadata reads and validates local daemon connection metadata.
+func ReadMetadata(path string) (Metadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Metadata{}, err
+	}
+	var meta Metadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return Metadata{}, err
+	}
+	if meta.Version != 1 {
+		return Metadata{}, fmt.Errorf("metadata %s: unsupported version %d", path, meta.Version)
+	}
+	return meta, nil
+}
+
+// WriteMetadata writes local daemon connection metadata with owner-only
+// permissions.
+func WriteMetadata(path string, meta Metadata) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}


### PR DESCRIPTION
## Summary

- add reusable local daemon metadata/token/listen helpers in the daemon package and switch cmd/glue serve/connect metadata plumbing to them
- add `peggy serve` so one Peggy process can expose the daemon protocol with shared settings, SOUL, store, coding tools, and daemon-brokered permissions
- document the Peggy daemon + `glue connect` workflow and cover serve config plus coding-tool permission flow with tests

## Verification

- go test ./daemon ./cmd/glue ./agents/peggy -count=1
- go test ./agents/peggy/... -count=1
- go test ./cmd/glue ./daemon -race -count=1
- go build ./...
- go vet ./...
- git diff --check -- . ':!.gitignore'
- env -u NVIDIA_API_KEY go test ./...
