### PR TITLE
agents/peggy/telegram: add daemon-client mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,13 @@ so `glue connect` works without explicit connection flags. Permission
 requests for Peggy coding tools are brokered over the daemon stream and
 answered by the connected client.
 
+Telegram can attach to that same daemon while preserving its chat
+allowlist and inline permission buttons:
+
+```sh
+go run ./agents/peggy/cmd/peggy-telegram --daemon
+```
+
 ### Standard flags for downstream agents
 
 Agents that ship their own CLI binary share the same six flags

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -177,6 +177,16 @@ Useful `serve` flags:
 Startup output prints the `base_url` and metadata path, never the
 bearer token. Stop the daemon with SIGINT/SIGTERM.
 
+Telegram can attach to the same daemon:
+
+```sh
+peggy-telegram --daemon
+```
+
+In daemon-client mode, Telegram keeps its chat allowlist and inline
+permission buttons, but Peggy, memory, coding tools, and remembered
+permission scopes live in the daemon process.
+
 ## Coding Tools
 
 Coding mode is opt-in. Enable it in `settings.json` with
@@ -314,7 +324,7 @@ external transports. The pattern is designed in
 - Each channel lives in its own package under
   `agents/peggy/channels/<name>`. Telegram is the first concrete
   channel — see [`channels/telegram/README.md`](channels/telegram/README.md)
-  for the bot setup and the `peggy-telegram` binary.
+  for the bot setup, standalone mode, and daemon-client mode.
 - Channels satisfy a small `peggy.Channel` interface and call into
   the existing `Peggy.Prompt` API. They never modify core `glue`.
 - Channels namespace their session ids (`telegram:12345` etc.) so a
@@ -332,8 +342,7 @@ priority order:
 
 - **M3 — multi-channel daemon.** `peggy serve` plus daemon clients so
   one long-running Peggy serves a terminal, Telegram, and future
-  clients concurrently. Next up: Telegram daemon-client mode and
-  per-channel permission tiers.
+  clients concurrently. Next up: per-channel permission tiers.
 - **M4 — ecosystem.** MCP client (stdio + HTTP), cost tracking,
   `providers/anthropic` when budget allows.
 

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -50,6 +50,39 @@ gated by a chat-id allowlist. Built on the pattern designed in
 
    SIGINT / SIGTERM stops cleanly.
 
+### Daemon-client mode
+
+Standalone mode builds Peggy inside the `peggy-telegram` process. To
+share one long-running Peggy process with terminal clients, start the
+daemon first and run Telegram as a daemon client:
+
+```sh
+peggy serve --coding --workdir /path/to/repo
+peggy-telegram --daemon
+```
+
+`--daemon` reads the same metadata file written by `peggy serve` and
+`glue serve`. Override discovery with `--daemon-base-url`,
+`--daemon-token`, or `--daemon-metadata`; the token also falls back to
+`GLUE_DAEMON_TOKEN`. Telegram still enforces `allow_chats` before any
+daemon request is sent.
+
+You can also put daemon settings under `channels.telegram.daemon`:
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "allow_chats": [123456789],
+      "daemon": {
+        "enabled": true,
+        "metadata": "~/.config/glue/daemon.json"
+      }
+    }
+  }
+}
+```
+
 ### Coding setup
 
 `peggy-telegram` uses the same `settings.json` as the CLI. To let
@@ -92,7 +125,13 @@ shows inline buttons for `Deny`, `Allow once`, `Allow session`, and
       "bot_token_env": "PEGGY_TELEGRAM_TOKEN",
       "allow_chats": [123456789],
       "long_poll_timeout_seconds": 30,
-      "api_base_url": ""
+      "api_base_url": "",
+      "daemon": {
+        "enabled": false,
+        "metadata": "~/.config/glue/daemon.json",
+        "base_url": "",
+        "token": ""
+      }
     }
   }
 }
@@ -104,6 +143,10 @@ shows inline buttons for `Deny`, `Allow once`, `Allow session`, and
 | `allow_chats` | `[]` (refuse-all) | Telegram chat ids permitted to reach the agent. |
 | `long_poll_timeout_seconds` | `30` | Seconds the server waits before returning an empty update set. Clamped to 60. |
 | `api_base_url` | `https://api.telegram.org` | Override for tests / private mirrors. |
+| `daemon.enabled` | `false` | When true, Telegram connects to a running Peggy daemon instead of constructing Peggy in-process. |
+| `daemon.metadata` | glue daemon metadata path | Connection metadata written by `peggy serve` / `glue serve`. |
+| `daemon.base_url` | metadata | Explicit daemon base URL override. |
+| `daemon.token` | metadata or `GLUE_DAEMON_TOKEN` | Explicit bearer token override. Prefer metadata/env over committing tokens. |
 
 ## Session-id namespacing
 
@@ -141,8 +184,8 @@ Read-only tools such as `read_file`, `git_diff_branch`, and
 - Text-message-only inbound and outbound. Photos / voice / documents /
   stickers are dropped.
 - Long-polling. Webhook-mode is a follow-up.
-- One Telegram bot per process. Multi-bot in one process is an M3
-  concern.
+- One Telegram bot per process. It can run standalone or as a daemon
+  client for one shared Peggy process.
 - Replies are sent as one message per turn, after the model finishes.
   Edit-in-place streaming and "thinking…" placeholders are a
   follow-up (Telegram rate-limits message edits and the trade-offs

--- a/agents/peggy/channels/telegram/channel.go
+++ b/agents/peggy/channels/telegram/channel.go
@@ -19,10 +19,16 @@ import (
 const ChannelName = "telegram"
 
 // Options configures a Channel. Most fields are optional with sensible
-// defaults; the only required pieces are Peggy and a populated Config.
+// defaults. Standalone mode requires Peggy; daemon-client mode requires
+// Daemon.
 type Options struct {
 	// Peggy is the agent that handles inbound messages. Required.
+	// Ignored when Daemon is non-nil.
 	Peggy *peggy.Peggy
+
+	// Daemon handles inbound messages by talking to a running Peggy
+	// daemon. When set, Peggy may be nil.
+	Daemon *DaemonClient
 
 	// Config is the decoded settings.channels.telegram block.
 	Config Config
@@ -48,6 +54,7 @@ type Options struct {
 // Channel is the peggy.Channel implementation for Telegram.
 type Channel struct {
 	peggy   *peggy.Peggy
+	daemon  *DaemonClient
 	cfg     Config
 	api     *API
 	allowed map[int64]struct{}
@@ -59,8 +66,8 @@ type Channel struct {
 // missing — the bot token in particular surfaces early rather than
 // failing silently inside the poll loop.
 func New(opts Options) (*Channel, error) {
-	if opts.Peggy == nil {
-		return nil, errors.New("telegram: Peggy is required")
+	if opts.Peggy == nil && opts.Daemon == nil {
+		return nil, errors.New("telegram: Peggy or Daemon is required")
 	}
 	cfg, err := DecodeConfig(nil) // re-apply defaults defensively
 	if err != nil {
@@ -101,6 +108,7 @@ func New(opts Options) (*Channel, error) {
 
 	ch := &Channel{
 		peggy:   opts.Peggy,
+		daemon:  opts.Daemon,
 		cfg:     cfg,
 		api:     NewAPI(cfg.APIBaseURL, token, opts.HTTPClient),
 		allowed: allowed,
@@ -183,6 +191,9 @@ func (c *Channel) handleCallback(ctx context.Context, cb CallbackQuery) {
 	if c.perm != nil && c.perm.handleCallback(ctx, cb) {
 		return
 	}
+	if c.daemon != nil && c.daemon.HandleCallback(ctx, cb, c.api) {
+		return
+	}
 }
 
 func (c *Channel) sleep(ctx context.Context, d time.Duration) bool {
@@ -211,7 +222,13 @@ func (c *Channel) handleUpdate(ctx context.Context, u Update) {
 
 	sessionID := peggy.ChannelSessionID(ChannelName, strconv.FormatInt(chatID, 10))
 	var buf bytes.Buffer
-	text, err := c.peggy.Prompt(ctx, sessionID, u.Message.Text, &buf)
+	var text string
+	var err error
+	if c.daemon != nil {
+		text, err = c.daemon.Prompt(ctx, sessionID, u.Message.Text, c.api, chatID)
+	} else {
+		text, err = c.peggy.Prompt(ctx, sessionID, u.Message.Text, &buf)
+	}
 	if err != nil {
 		fmt.Fprintf(c.stderr, "telegram: prompt failed for chat %d: %v\n", chatID, err)
 		// Reply with a short error rather than going silent — the user

--- a/agents/peggy/channels/telegram/config.go
+++ b/agents/peggy/channels/telegram/config.go
@@ -3,6 +3,8 @@ package telegram
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/erain/glue/daemon"
 )
 
 // Config is the decoded form of settings.json's
@@ -27,6 +29,18 @@ type Config struct {
 	// https://api.telegram.org. Used by tests to point at an
 	// httptest.NewServer.
 	APIBaseURL string `json:"api_base_url"`
+
+	// Daemon configures optional daemon-client mode. Standalone mode
+	// remains the default when Enabled is false.
+	Daemon DaemonClientConfig `json:"daemon,omitempty"`
+}
+
+// DaemonClientConfig configures Telegram's optional daemon-client mode.
+type DaemonClientConfig struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	BaseURL      string `json:"base_url,omitempty"`
+	Token        string `json:"token,omitempty"`
+	MetadataPath string `json:"metadata,omitempty"`
 }
 
 const (
@@ -57,6 +71,9 @@ func DecodeConfig(raw json.RawMessage) (Config, error) {
 	}
 	if c.APIBaseURL == "" {
 		c.APIBaseURL = defaultAPIBaseURL
+	}
+	if c.Daemon.MetadataPath == "" {
+		c.Daemon.MetadataPath = daemon.DefaultMetadataPath()
 	}
 	return c, nil
 }

--- a/agents/peggy/channels/telegram/daemon_client.go
+++ b/agents/peggy/channels/telegram/daemon_client.go
@@ -1,0 +1,384 @@
+package telegram
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
+)
+
+// DaemonClient talks to a Peggy daemon on behalf of the Telegram channel.
+type DaemonClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+	stderr  io.Writer
+
+	nextNonce atomic.Uint64
+	mu        sync.Mutex
+	pending   map[string]daemonPendingPermission
+}
+
+type daemonPendingPermission struct {
+	chatID       int64
+	runID        string
+	permissionID string
+	clientID     string
+}
+
+type daemonStartRunPayload struct {
+	Text     string `json:"text"`
+	ClientID string `json:"client_id,omitempty"`
+}
+
+type daemonStartRunResponse struct {
+	RunID     string `json:"run_id"`
+	EventsURL string `json:"events_url"`
+}
+
+type daemonPermissionPayload struct {
+	PermissionID string                 `json:"permission_id"`
+	Request      glue.PermissionRequest `json:"request"`
+	ExpiresAt    time.Time              `json:"expires_at"`
+}
+
+type daemonPermissionDecision struct {
+	Allow       bool   `json:"allow"`
+	Reason      string `json:"reason,omitempty"`
+	RememberFor string `json:"remember_for,omitempty"`
+}
+
+// ResolveDaemonClientConfig applies metadata and environment fallback rules.
+func ResolveDaemonClientConfig(cfg DaemonClientConfig) (DaemonClientConfig, error) {
+	if strings.TrimSpace(cfg.MetadataPath) == "" {
+		cfg.MetadataPath = daemon.DefaultMetadataPath()
+	}
+	var meta daemon.Metadata
+	var metadataErr error
+	if strings.TrimSpace(cfg.MetadataPath) != "" {
+		loaded, err := daemon.ReadMetadata(cfg.MetadataPath)
+		if err != nil {
+			metadataErr = err
+		} else {
+			meta = loaded
+		}
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" && meta.BaseURL != "" {
+		cfg.BaseURL = meta.BaseURL
+	}
+	if strings.TrimSpace(cfg.Token) == "" && meta.Token != "" {
+		cfg.Token = meta.Token
+	}
+	if strings.TrimSpace(cfg.Token) == "" {
+		cfg.Token = strings.TrimSpace(os.Getenv("GLUE_DAEMON_TOKEN"))
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		if metadataErr != nil {
+			return cfg, fmt.Errorf("telegram daemon: base URL not configured and metadata unavailable: %w", metadataErr)
+		}
+		return cfg, errors.New("telegram daemon: base URL is required")
+	}
+	if strings.TrimSpace(cfg.Token) == "" {
+		if metadataErr != nil {
+			return cfg, fmt.Errorf("telegram daemon: token not configured and metadata unavailable: %w", metadataErr)
+		}
+		return cfg, errors.New("telegram daemon: token is required")
+	}
+	cfg.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	cfg.Token = strings.TrimSpace(cfg.Token)
+	return cfg, nil
+}
+
+// NewDaemonClient constructs a daemon client from resolved config.
+func NewDaemonClient(cfg DaemonClientConfig, client *http.Client, stderr io.Writer) (*DaemonClient, error) {
+	resolved, err := ResolveDaemonClientConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &DaemonClient{
+		baseURL: resolved.BaseURL,
+		token:   resolved.Token,
+		client:  client,
+		stderr:  stderr,
+		pending: map[string]daemonPendingPermission{},
+	}, nil
+}
+
+func (d *DaemonClient) Prompt(ctx context.Context, sessionID, text string, api *API, chatID int64) (string, error) {
+	if d == nil {
+		return "", errors.New("telegram daemon: client is not configured")
+	}
+	clientID := daemonTelegramClientID(chatID)
+	start, err := d.startRun(ctx, sessionID, text, clientID)
+	if err != nil {
+		return "", err
+	}
+	return d.streamRun(ctx, start, api, chatID, clientID)
+}
+
+func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api *API) bool {
+	if d == nil || !strings.HasPrefix(cb.Data, permissionCallbackPrefix) {
+		return false
+	}
+	nonce, action, ok := parsePermissionCallback(cb.Data)
+	if !ok {
+		answerDaemonCallback(ctx, api, cb.ID, "Invalid permission response.")
+		return true
+	}
+	chatID, ok := callbackChatID(cb)
+	if !ok {
+		answerDaemonCallback(ctx, api, cb.ID, "Permission response has no chat.")
+		return true
+	}
+
+	d.mu.Lock()
+	pending, ok := d.pending[nonce]
+	if ok && pending.chatID == chatID {
+		delete(d.pending, nonce)
+	}
+	d.mu.Unlock()
+	if !ok || pending.chatID != chatID {
+		answerDaemonCallback(ctx, api, cb.ID, "Permission request expired.")
+		return true
+	}
+
+	decision := glueDecisionToDaemon(permissionDecisionForAction(action))
+	if err := d.postDecision(ctx, pending, decision); err != nil {
+		d.print("telegram daemon: permission decision: %v\n", err)
+		answerDaemonCallback(ctx, api, cb.ID, "Permission response failed.")
+		return true
+	}
+	if decision.Allow {
+		answerDaemonCallback(ctx, api, cb.ID, "Allowed.")
+	} else {
+		answerDaemonCallback(ctx, api, cb.ID, "Denied.")
+	}
+	return true
+}
+
+func (d *DaemonClient) startRun(ctx context.Context, sessionID, text, clientID string) (daemonStartRunResponse, error) {
+	payload, _ := json.Marshal(daemonStartRunPayload{Text: text, ClientID: clientID})
+	endpoint := d.baseURL + "/v1/sessions/" + url.PathEscape(sessionID) + "/runs"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return daemonStartRunResponse{}, err
+	}
+	d.authorize(req)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemonStartRunResponse{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return daemonStartRunResponse{}, fmt.Errorf("telegram daemon: start run: %s", httpStatusText(resp))
+	}
+	var out daemonStartRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemonStartRunResponse{}, err
+	}
+	if out.RunID == "" || out.EventsURL == "" {
+		return daemonStartRunResponse{}, errors.New("telegram daemon: start run response missing run id or events url")
+	}
+	return out, nil
+}
+
+func (d *DaemonClient) streamRun(ctx context.Context, start daemonStartRunResponse, api *API, chatID int64, clientID string) (string, error) {
+	endpoint := d.baseURL + start.EventsURL
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	d.authorize(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return "", redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("telegram daemon: stream run: %s", httpStatusText(resp))
+	}
+
+	var text strings.Builder
+	scan := bufio.NewScanner(resp.Body)
+	scan.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scan.Scan() {
+		line := scan.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event daemon.EventEnvelope
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+			return "", err
+		}
+		switch event.Type {
+		case "text_delta":
+			text.WriteString(payloadString(event.Payload, "delta"))
+		case "permission_request":
+			if err := d.handlePermissionRequest(ctx, api, chatID, start.RunID, clientID, event.Payload); err != nil {
+				return "", err
+			}
+		case "run_error":
+			if msg := payloadString(event.Payload, "error"); msg != "" {
+				return "", errors.New(msg)
+			}
+			return "", errors.New("telegram daemon: run failed")
+		case "run_done":
+			if text.Len() == 0 {
+				text.WriteString(payloadString(event.Payload, "text"))
+			}
+			return text.String(), nil
+		}
+	}
+	if err := scan.Err(); err != nil {
+		return "", err
+	}
+	return text.String(), nil
+}
+
+func (d *DaemonClient) handlePermissionRequest(ctx context.Context, api *API, chatID int64, runID, clientID string, payload any) error {
+	var perm daemonPermissionPayload
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &perm); err != nil {
+		return err
+	}
+	if perm.PermissionID == "" {
+		return errors.New("telegram daemon: permission request missing id")
+	}
+	nonce := strconv.FormatUint(d.nextNonce.Add(1), 36)
+	d.mu.Lock()
+	d.pending[nonce] = daemonPendingPermission{
+		chatID:       chatID,
+		runID:        runID,
+		permissionID: perm.PermissionID,
+		clientID:     clientID,
+	}
+	d.mu.Unlock()
+	if err := api.SendMessageWithReplyMarkup(ctx, chatID, permissionMessage(perm.Request), permissionKeyboard(nonce)); err != nil {
+		d.deletePending(nonce)
+		_ = d.postDecision(ctx, daemonPendingPermission{runID: runID, permissionID: perm.PermissionID, clientID: clientID}, daemonPermissionDecision{
+			Allow:  false,
+			Reason: "permission denied: failed to send Telegram permission prompt",
+		})
+		return err
+	}
+	return nil
+}
+
+func (d *DaemonClient) postDecision(ctx context.Context, pending daemonPendingPermission, decision daemonPermissionDecision) error {
+	path := "/v1/runs/" + url.PathEscape(pending.runID) + "/permissions/" + url.PathEscape(pending.permissionID) + "/decision"
+	body, _ := json.Marshal(decision)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	d.authorize(req)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Glue-Client-ID", pending.clientID)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("telegram daemon: permission decision: %s", httpStatusText(resp))
+	}
+	return nil
+}
+
+func (d *DaemonClient) deletePending(nonce string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.pending, nonce)
+}
+
+func (d *DaemonClient) authorize(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+d.token)
+}
+
+func (d *DaemonClient) print(format string, args ...any) {
+	if d.stderr != nil {
+		_, _ = fmt.Fprintf(d.stderr, format, args...)
+	}
+}
+
+func daemonTelegramClientID(chatID int64) string {
+	return "telegram:" + strconv.FormatInt(chatID, 10)
+}
+
+func glueDecisionToDaemon(decision glue.PermissionDecision) daemonPermissionDecision {
+	return daemonPermissionDecision{
+		Allow:       decision.Allow,
+		Reason:      decision.Reason,
+		RememberFor: daemonRememberScope(decision.RememberFor),
+	}
+}
+
+func daemonRememberScope(scope glue.RememberScope) string {
+	switch scope {
+	case glue.RememberSession:
+		return "session"
+	case glue.RememberSessionTarget:
+		return "session_target"
+	case glue.RememberForever:
+		return "forever"
+	default:
+		return ""
+	}
+}
+
+func payloadString(payload any, key string) string {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := m[key].(string)
+	return v
+}
+
+func httpStatusText(resp *http.Response) string {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		return resp.Status
+	}
+	return resp.Status + ": " + msg
+}
+
+func redactDaemonErr(err error, token string) error {
+	if err == nil || token == "" {
+		return err
+	}
+	msg := err.Error()
+	if strings.Contains(msg, token) {
+		return errors.New(strings.ReplaceAll(msg, token, "<redacted>"))
+	}
+	return err
+}
+
+func answerDaemonCallback(ctx context.Context, api *API, callbackID, text string) {
+	if api == nil || callbackID == "" {
+		return
+	}
+	_ = api.AnswerCallbackQuery(ctx, callbackID, text)
+}

--- a/agents/peggy/channels/telegram/daemon_client_test.go
+++ b/agents/peggy/channels/telegram/daemon_client_test.go
@@ -1,0 +1,270 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/agents/peggy"
+	"github.com/erain/glue/daemon"
+)
+
+func TestResolveDaemonClientConfigUsesMetadataAndOverrides(t *testing.T) {
+	metadataPath := filepath.Join(t.TempDir(), "daemon.json")
+	if err := daemon.WriteMetadata(metadataPath, daemon.Metadata{
+		Version: 1,
+		BaseURL: "http://metadata",
+		Token:   "meta-token",
+		PID:     123,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := ResolveDaemonClientConfig(DaemonClientConfig{MetadataPath: metadataPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BaseURL != "http://metadata" || cfg.Token != "meta-token" {
+		t.Fatalf("metadata config = %+v", cfg)
+	}
+
+	cfg, err = ResolveDaemonClientConfig(DaemonClientConfig{
+		MetadataPath: metadataPath,
+		BaseURL:      "http://override/",
+		Token:        "override-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BaseURL != "http://override" || cfg.Token != "override-token" {
+		t.Fatalf("override config = %+v", cfg)
+	}
+
+	t.Setenv("GLUE_DAEMON_TOKEN", "env-token")
+	cfg, err = ResolveDaemonClientConfig(DaemonClientConfig{
+		MetadataPath: filepath.Join(t.TempDir(), "missing.json"),
+		BaseURL:      "http://explicit",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BaseURL != "http://explicit" || cfg.Token != "env-token" {
+		t.Fatalf("env fallback config = %+v", cfg)
+	}
+}
+
+func TestDaemonClientMessageStartsRunAndSendsText(t *testing.T) {
+	var start daemonStartRunPayload
+	var startPath string
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/telegram:123/runs":
+			startPath = r.URL.Path
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("auth = %q", auth)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&start); err != nil {
+				t.Fatal(err)
+			}
+			writeJSON(t, w, http.StatusCreated, daemonStartRunResponse{RunID: "run_1", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			writeSSE(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "hello from daemon"}})
+			writeSSE(t, w, daemon.EventEnvelope{Type: "run_done"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "hello"))
+	if startPath != "/v1/sessions/telegram:123/runs" {
+		t.Fatalf("start path = %q", startPath)
+	}
+	if start.Text != "hello" || start.ClientID != "telegram:123" {
+		t.Fatalf("start payload = %+v", start)
+	}
+	if got := tg.lastSendText(); got != "hello from daemon" {
+		t.Fatalf("telegram reply = %q", got)
+	}
+}
+
+func TestDaemonClientAllowlistBeforeDaemonRequest(t *testing.T) {
+	var starts int
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		starts++
+	}))
+	defer daemonServer.Close()
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{999}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "hello"))
+	if starts != 0 {
+		t.Fatalf("daemon starts = %d, want 0", starts)
+	}
+	if tg.sendCount() != 0 {
+		t.Fatalf("telegram sends = %d, want 0", tg.sendCount())
+	}
+}
+
+func TestDaemonClientPermissionCallbackPostsDecision(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		decisionBody   daemonPermissionDecision
+		decisionClient string
+		decisionCh     = make(chan struct{})
+	)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/telegram:123/runs":
+			writeJSON(t, w, http.StatusCreated, daemonStartRunResponse{RunID: "run_1", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			writeSSE(t, w, daemon.EventEnvelope{
+				Type: "permission_request",
+				Payload: daemonPermissionPayload{
+					PermissionID: "perm_1",
+					Request: glue.PermissionRequest{
+						SessionID: peggy.ChannelSessionID(ChannelName, "123"),
+						Tool:      "write_file",
+						Action:    "write_file",
+						Target:    "note.txt",
+					},
+				},
+			})
+			select {
+			case <-decisionCh:
+			case <-time.After(time.Second):
+				t.Error("timed out waiting for decision")
+			}
+			writeSSE(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "done"}})
+			writeSSE(t, w, daemon.EventEnvelope{Type: "run_done"})
+		case "/v1/runs/run_1/permissions/perm_1/decision":
+			mu.Lock()
+			defer mu.Unlock()
+			decisionClient = r.Header.Get("X-Glue-Client-ID")
+			if err := json.NewDecoder(r.Body).Decode(&decisionBody); err != nil {
+				t.Fatal(err)
+			}
+			close(decisionCh)
+			writeJSON(t, w, http.StatusOK, map[string]any{"accepted": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ch.handleUpdate(context.Background(), messageUpdate(1, 123, "write file"))
+		close(done)
+	}()
+	waitForSendCount(t, tg, 1)
+	ch.handleCallback(context.Background(), CallbackQuery{
+		ID:      "cb_1",
+		Message: &Message{Chat: Chat{ID: 123, Type: "private"}},
+		Data:    permissionCallback("1", "session"),
+	})
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleUpdate did not finish")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if decisionClient != "telegram:123" {
+		t.Fatalf("decision client = %q", decisionClient)
+	}
+	if !decisionBody.Allow || decisionBody.RememberFor != "session" {
+		t.Fatalf("decision = %+v", decisionBody)
+	}
+	if got := tg.lastSendText(); got != "done" {
+		t.Fatalf("final reply = %q", got)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSSE(t *testing.T, w http.ResponseWriter, event daemon.EventEnvelope) {
+	t.Helper()
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func waitForSendCount(t *testing.T, tg *telegramFixture, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if tg.sendCount() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	var bodies []string
+	tg.mu.Lock()
+	for _, body := range tg.sendBodies {
+		bodies = append(bodies, string(body))
+	}
+	tg.mu.Unlock()
+	t.Fatalf("send count = %d, want %d; bodies=%s", tg.sendCount(), want, strings.Join(bodies, "\n"))
+}

--- a/agents/peggy/cmd/peggy-telegram/main.go
+++ b/agents/peggy/cmd/peggy-telegram/main.go
@@ -34,6 +34,10 @@ func run(parent context.Context, args []string, stdout, stderr io.Writer) int {
 		configPath  = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
 		soulPath    = fs.String("soul", "", "path to identity Markdown")
 		showVersion = fs.Bool("version", false, "print version and exit")
+		daemonMode  = fs.Bool("daemon", false, "connect to a running peggy serve daemon instead of constructing Peggy in-process")
+		daemonURL   = fs.String("daemon-base-url", "", "Peggy daemon base URL; defaults to metadata when --daemon is set")
+		daemonToken = fs.String("daemon-token", "", "Peggy daemon bearer token; defaults to metadata or GLUE_DAEMON_TOKEN")
+		daemonMeta  = fs.String("daemon-metadata", "", "Peggy daemon metadata JSON path; defaults to glue daemon metadata path")
 	)
 	fs.Usage = func() {
 		fmt.Fprintf(stderr, `peggy-telegram — Peggy reachable on Telegram.
@@ -80,6 +84,38 @@ Flags:
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
 		return 1
+	}
+	if *daemonURL != "" {
+		cfg.Daemon.BaseURL = *daemonURL
+	}
+	if *daemonToken != "" {
+		cfg.Daemon.Token = *daemonToken
+	}
+	if *daemonMeta != "" {
+		cfg.Daemon.MetadataPath = *daemonMeta
+	}
+	if *daemonMode || cfg.Daemon.Enabled {
+		cfg.Daemon.Enabled = true
+		daemonClient, err := telegram.NewDaemonClient(cfg.Daemon, nil, stderr)
+		if err != nil {
+			fmt.Fprintf(stderr, "peggy-telegram: daemon: %v\n", err)
+			return 1
+		}
+		ch, err := telegram.New(telegram.Options{Daemon: daemonClient, Config: cfg, Stderr: stderr})
+		if err != nil {
+			fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+			return 1
+		}
+		ctx, cancel := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+		defer cancel()
+
+		fmt.Fprintln(stderr, "peggy-telegram: listening for Telegram updates via daemon; SIGINT to stop.")
+		if err := ch.Run(ctx); err != nil {
+			fmt.Fprintf(stderr, "peggy-telegram: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stderr, "peggy-telegram: stopped.")
+		return 0
 	}
 	var permission *telegram.Permission
 	if settings.Coding.Enabled {


### PR DESCRIPTION
## Summary

- add optional Telegram daemon-client mode that starts Peggy daemon runs over HTTP+SSE while preserving standalone `peggy-telegram`
- resolve daemon connection metadata/base-url/token with `GLUE_DAEMON_TOKEN` fallback and keep Telegram allowlist gating before daemon requests
- broker daemon permission requests through the existing inline-keyboard UX and post decisions with the Telegram client id
- document standalone vs daemon-client deployment paths

## Verification

- go test ./agents/peggy/channels/telegram -count=1
- go test ./agents/peggy/... -count=1
- go test ./daemon ./cmd/glue -count=1
- go build ./...
- go vet ./...
- git diff --check -- . ':!.gitignore'
- env -u NVIDIA_API_KEY go test ./...
