### PR TITLE
agents/peggy: add channel permission tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,24 @@ allowlist and inline permission buttons:
 go run ./agents/peggy/cmd/peggy-telegram --daemon
 ```
 
+Peggy can assign permission tiers by daemon client/channel in
+`settings.json`. The default remains `prompt`; `read_only` denies
+side-effecting tools before any client prompt, and `trusted` allows
+side-effecting tools without prompting while preserving workspace,
+binary, overwrite, timeout, and output limits:
+
+```json
+{
+  "permissions": {
+    "default_tier": "prompt",
+    "channels": {
+      "cli": "trusted",
+      "telegram": "prompt"
+    }
+  }
+}
+```
+
 ### Standard flags for downstream agents
 
 Agents that ship their own CLI binary share the same six flags

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -101,6 +101,13 @@ and emits a stderr diagnostic.
     "threshold": 200,
     "target_tokens": 8000,
     "keep_recent": 8
+  },
+  "permissions": {
+    "default_tier": "prompt",
+    "channels": {
+      "cli": "trusted",
+      "telegram": "prompt"
+    }
   }
 }
 ```
@@ -118,6 +125,8 @@ and emits a stderr diagnostic.
 | `coding.work_dir` | current directory | Workspace root for `read_file`, `write_file`, `shell_exec`, and git helpers. `~` and `$HOME` expand. |
 | `coding.allowed_binaries` | `go`, `git`, `make`, `node`, `npm`, `python`, `python3` | Basename allowlist for `shell_exec`; model calls cannot run arbitrary paths. |
 | `coding.allow_overwrite` | `false` | Host policy for replacing existing files. The model must still pass `overwrite: true`, and the permission prompt must allow the call. |
+| `permissions.default_tier` | `prompt` | Permission tier for side-effecting tools when a channel has no override. One of `prompt`, `read_only`, or `trusted`. |
+| `permissions.channels.<name>` | inherited | Channel override keyed by `cli`, `telegram`, or a future daemon client prefix. |
 
 Missing `settings.json` is non-fatal — Peggy uses the built-in
 defaults above and emits a stderr diagnostic.
@@ -187,6 +196,11 @@ In daemon-client mode, Telegram keeps its chat allowlist and inline
 permission buttons, but Peggy, memory, coding tools, and remembered
 permission scopes live in the daemon process.
 
+Permission tiers apply in daemon mode by daemon `client_id`: `cli:*`
+uses the `cli` tier and `telegram:<chat_id>` uses the `telegram` tier.
+Use this to keep a trusted local terminal fast while making Telegram
+ask every time, or to make Telegram read-only.
+
 ## Coding Tools
 
 Coding mode is opt-in. Enable it in `settings.json` with
@@ -240,6 +254,34 @@ The permission choices are intentionally small:
   and session id.
 - `allow target` — remember this tool/action/target for the current
   process and session id.
+
+Peggy also supports product-level permission tiers:
+
+- `prompt` — current behavior. Ask the owning client and honor
+  remembered scopes.
+- `read_only` — deny side-effecting tools before any terminal prompt
+  or Telegram inline keyboard is shown.
+- `trusted` — allow side-effecting tools without prompting. Existing
+  tool controls still apply: workspace root, binary allowlist,
+  overwrite policy, timeouts, and output limits.
+
+Example:
+
+```json
+{
+  "permissions": {
+    "default_tier": "prompt",
+    "channels": {
+      "cli": "trusted",
+      "telegram": "read_only"
+    }
+  }
+}
+```
+
+Remembered daemon permission decisions are scoped to the daemon client
+that made them, so a Telegram allow does not silently authorize a
+terminal request.
 
 Coding mode is a trusted-local workflow. The tool layer constrains
 paths, binaries, overwrites, output size, and permissions, but v0.2

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -171,13 +171,37 @@ Telegram with inline keyboard buttons:
 
 Permission requests are sent only to the same allowlisted chat whose
 message triggered the prompt. Decisions remembered for a session or
-target live only in the running `peggy-telegram` process. If the bot is
-stopped, the request times out, or the callback comes from a
+target live only in the running `peggy-telegram` process in standalone
+mode, or in the running `peggy serve` process in daemon-client mode.
+Daemon remembered decisions are scoped to the daemon client id, so a
+Telegram allow does not silently authorize a terminal request. If the
+bot is stopped, the request times out, or the callback comes from a
 non-allowlisted chat, Peggy denies the side effect and surfaces that
 denial to the model as a tool result.
 
 Read-only tools such as `read_file`, `git_diff_branch`, and
 `git_log_branch` do not prompt.
+
+Peggy-level permission tiers can make Telegram stricter or looser than
+other clients:
+
+```json
+{
+  "permissions": {
+    "default_tier": "prompt",
+    "channels": {
+      "cli": "trusted",
+      "telegram": "read_only"
+    }
+  }
+}
+```
+
+`prompt` keeps the inline keyboard flow, `read_only` denies
+side-effecting tools before any Telegram prompt is sent, and `trusted`
+allows side-effecting tools without prompting. `trusted` still keeps the
+coding tool constraints from Peggy settings, including workspace root,
+binary allowlist, overwrite policy, timeouts, and output limits.
 
 ## What Peggy on Telegram supports today
 
@@ -195,11 +219,13 @@ Read-only tools such as `read_file`, `git_diff_branch`, and
   session transcript / sqlite store.
 - Inline-keyboard permission prompts for side-effecting coding tools
   in allowlisted chats.
+- Optional Peggy permission tiers for prompt/read-only/trusted channel
+  behavior.
 
 ## What's coming
 
 - Edit-in-place streaming for replies (delta → edited message).
-- Persistent per-user permission policy.
+- Persistent per-user permission policy across daemon restarts.
 - Webhook-mode (push-based) for low-latency hosted setups.
 - `Agent.SearchSessions` channel-prefix filter so the user can scope
   recall to "things we talked about on Telegram."

--- a/agents/peggy/cmd/peggy-telegram/main.go
+++ b/agents/peggy/cmd/peggy-telegram/main.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/erain/glue"
 	"github.com/erain/glue/agents/peggy"
 	"github.com/erain/glue/agents/peggy/channels/telegram"
 )
@@ -118,15 +119,21 @@ Flags:
 		return 0
 	}
 	var permission *telegram.Permission
+	var agentPermission glue.Permission
 	if settings.Coding.Enabled {
 		permission = telegram.NewPermission(telegram.PermissionOptions{Stderr: stderr})
+		agentPermission = peggy.NewTieredPermission(
+			permission,
+			peggy.PermissionTierForChannel(settings.Permissions, peggy.PermissionChannelTelegram),
+			peggy.PermissionChannelTelegram,
+		)
 	}
 
 	p, err := peggy.New(peggy.Options{
 		Settings:   settings,
 		Soul:       soul,
 		Stderr:     stderr,
-		Permission: permission,
+		Permission: agentPermission,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy-telegram: setup: %v\n", err)

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -84,6 +84,9 @@ type Peggy struct {
 // [fillDefaults] (the simplest way: Settings.WithDefaults()).
 func New(opts Options) (*Peggy, error) {
 	settings := fillDefaults(opts.Settings)
+	if err := validatePermissionSettings(settings.Permissions); err != nil {
+		return nil, err
+	}
 
 	stderr := opts.Stderr
 	if stderr == nil {

--- a/agents/peggy/permission_policy.go
+++ b/agents/peggy/permission_policy.go
@@ -1,0 +1,170 @@
+package peggy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
+)
+
+const (
+	PermissionChannelCLI      = "cli"
+	PermissionChannelTelegram = "telegram"
+)
+
+// PermissionTier names Peggy's product-level side-effect policy for a channel.
+type PermissionTier string
+
+const (
+	PermissionTierPrompt   PermissionTier = "prompt"
+	PermissionTierReadOnly PermissionTier = "read_only"
+	PermissionTierTrusted  PermissionTier = "trusted"
+)
+
+// PermissionTierForChannel returns the configured tier for a channel name.
+func PermissionTierForChannel(settings PermissionSettings, channel string) PermissionTier {
+	settings = normalizePermissionSettings(settings)
+	key := normalizePermissionChannel(channel)
+	if key != "" && settings.Channels != nil {
+		if raw := settings.Channels[key]; strings.TrimSpace(raw) != "" {
+			return PermissionTier(normalizePermissionTier(raw))
+		}
+	}
+	return PermissionTier(normalizePermissionTier(settings.DefaultTier))
+}
+
+// NewTieredPermission wraps a channel permission UI with Peggy's product-level
+// permission tier. Prompt delegates to inner; read_only and trusted answer
+// before any prompt UI is shown.
+func NewTieredPermission(inner glue.Permission, tier PermissionTier, channel string) glue.Permission {
+	return tieredPermission{
+		inner:   inner,
+		tier:    PermissionTier(normalizePermissionTier(string(tier))),
+		channel: normalizePermissionChannel(channel),
+	}
+}
+
+type tieredPermission struct {
+	inner   glue.Permission
+	tier    PermissionTier
+	channel string
+}
+
+func (p tieredPermission) Decide(ctx context.Context, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	switch p.tier {
+	case "", PermissionTierPrompt:
+		if p.inner == nil {
+			return glue.PermissionDecision{Allow: false, Reason: "permission denied: no permission handler configured"}, nil
+		}
+		return p.inner.Decide(ctx, req)
+	case PermissionTierReadOnly:
+		return glue.PermissionDecision{Allow: false, Reason: permissionReadOnlyReason(p.channel)}, nil
+	case PermissionTierTrusted:
+		return glue.PermissionDecision{Allow: true}, nil
+	default:
+		return glue.PermissionDecision{}, fmt.Errorf("peggy: invalid permission tier %q", p.tier)
+	}
+}
+
+// NewDaemonPermissionPolicy returns a daemon permission policy backed by Peggy
+// settings. The daemon remains neutral; Peggy owns tier names and channel
+// derivation.
+func NewDaemonPermissionPolicy(settings PermissionSettings) daemon.PermissionPolicy {
+	settings = normalizePermissionSettings(settings)
+	return daemon.PermissionPolicyFunc(func(_ context.Context, info daemon.PermissionContext, req glue.PermissionRequest) (daemon.PermissionPolicyDecision, error) {
+		channel := permissionChannelFromDaemon(info, req)
+		tier := PermissionTierForChannel(settings, channel)
+		switch tier {
+		case PermissionTierPrompt:
+			return daemon.PermissionPolicyDecision{Action: daemon.PermissionPolicyPrompt}, nil
+		case PermissionTierReadOnly:
+			return daemon.PermissionPolicyDecision{
+				Action: daemon.PermissionPolicyDeny,
+				Reason: permissionReadOnlyReason(channel),
+			}, nil
+		case PermissionTierTrusted:
+			return daemon.PermissionPolicyDecision{Action: daemon.PermissionPolicyAllow}, nil
+		default:
+			return daemon.PermissionPolicyDecision{}, fmt.Errorf("peggy: invalid permission tier %q", tier)
+		}
+	})
+}
+
+func permissionChannelFromDaemon(info daemon.PermissionContext, req glue.PermissionRequest) string {
+	if channel := channelPrefix(info.ClientID); channel != "" {
+		return channel
+	}
+	if channel := channelPrefix(info.SessionID); channel != "" {
+		return channel
+	}
+	return channelPrefix(req.SessionID)
+}
+
+func permissionReadOnlyReason(channel string) string {
+	channel = normalizePermissionChannel(channel)
+	if channel == "" {
+		return "permission denied: channel is read-only"
+	}
+	return "permission denied: " + channel + " channel is read-only"
+}
+
+func normalizePermissionSettings(settings PermissionSettings) PermissionSettings {
+	settings.DefaultTier = normalizePermissionTier(settings.DefaultTier)
+	if settings.DefaultTier == "" {
+		settings.DefaultTier = string(PermissionTierPrompt)
+	}
+	if len(settings.Channels) == 0 {
+		return settings
+	}
+	channels := make(map[string]string, len(settings.Channels))
+	for channel, tier := range settings.Channels {
+		key := normalizePermissionChannel(channel)
+		if key == "" {
+			key = strings.TrimSpace(channel)
+		}
+		channels[key] = normalizePermissionTier(tier)
+	}
+	settings.Channels = channels
+	return settings
+}
+
+func validatePermissionSettings(settings PermissionSettings) error {
+	settings = normalizePermissionSettings(settings)
+	if !validPermissionTier(settings.DefaultTier) {
+		return fmt.Errorf("peggy: invalid permissions.default_tier %q", settings.DefaultTier)
+	}
+	for channel, tier := range settings.Channels {
+		if !validPermissionTier(tier) {
+			return fmt.Errorf("peggy: invalid permissions.channels.%s tier %q", channel, tier)
+		}
+	}
+	return nil
+}
+
+func normalizePermissionTier(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func validPermissionTier(raw string) bool {
+	switch PermissionTier(normalizePermissionTier(raw)) {
+	case PermissionTierPrompt, PermissionTierReadOnly, PermissionTierTrusted:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizePermissionChannel(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func channelPrefix(raw string) string {
+	raw = strings.TrimSpace(raw)
+	prefix, _, ok := strings.Cut(raw, ":")
+	if !ok || prefix == "" {
+		return ""
+	}
+	return normalizePermissionChannel(prefix)
+}

--- a/agents/peggy/permission_policy_test.go
+++ b/agents/peggy/permission_policy_test.go
@@ -1,0 +1,117 @@
+package peggy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
+)
+
+type tierRecordingPermission struct {
+	called   int
+	decision glue.PermissionDecision
+}
+
+func (p *tierRecordingPermission) Decide(context.Context, glue.PermissionRequest) (glue.PermissionDecision, error) {
+	p.called++
+	return p.decision, nil
+}
+
+func TestTieredPermissionPromptDelegates(t *testing.T) {
+	inner := &tierRecordingPermission{decision: glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}}
+	perm := NewTieredPermission(inner, PermissionTierPrompt, PermissionChannelCLI)
+
+	decision, err := perm.Decide(context.Background(), glue.PermissionRequest{Tool: "shell_exec"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inner.called != 1 {
+		t.Fatalf("inner calls = %d, want 1", inner.called)
+	}
+	if !decision.Allow || decision.RememberFor != glue.RememberSession {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestTieredPermissionReadOnlySkipsInner(t *testing.T) {
+	inner := &tierRecordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	perm := NewTieredPermission(inner, PermissionTierReadOnly, PermissionChannelTelegram)
+
+	decision, err := perm.Decide(context.Background(), glue.PermissionRequest{Tool: "write_file"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inner.called != 0 {
+		t.Fatalf("inner calls = %d, want 0", inner.called)
+	}
+	if decision.Allow || !strings.Contains(decision.Reason, "telegram channel is read-only") {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestTieredPermissionTrustedSkipsInner(t *testing.T) {
+	inner := &tierRecordingPermission{decision: glue.PermissionDecision{Allow: false}}
+	perm := NewTieredPermission(inner, PermissionTierTrusted, PermissionChannelCLI)
+
+	decision, err := perm.Decide(context.Background(), glue.PermissionRequest{Tool: "shell_exec"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inner.called != 0 {
+		t.Fatalf("inner calls = %d, want 0", inner.called)
+	}
+	if !decision.Allow {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestDaemonPermissionPolicyDerivesChannelFromClientID(t *testing.T) {
+	policy := NewDaemonPermissionPolicy(PermissionSettings{
+		DefaultTier: string(PermissionTierPrompt),
+		Channels: map[string]string{
+			PermissionChannelTelegram: string(PermissionTierReadOnly),
+			PermissionChannelCLI:      string(PermissionTierTrusted),
+		},
+	})
+
+	telegramDecision, err := policy.DecidePermission(context.Background(), daemon.PermissionContext{
+		ClientID:  "telegram:123",
+		SessionID: "default",
+	}, glue.PermissionRequest{SessionID: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if telegramDecision.Action != daemon.PermissionPolicyDeny || !strings.Contains(telegramDecision.Reason, "telegram channel is read-only") {
+		t.Fatalf("telegram decision = %+v", telegramDecision)
+	}
+
+	cliDecision, err := policy.DecidePermission(context.Background(), daemon.PermissionContext{
+		ClientID:  "cli:123",
+		SessionID: "telegram:123",
+	}, glue.PermissionRequest{SessionID: "telegram:123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cliDecision.Action != daemon.PermissionPolicyAllow {
+		t.Fatalf("cli decision = %+v", cliDecision)
+	}
+}
+
+func TestDaemonPermissionPolicyFallsBackToSessionPrefix(t *testing.T) {
+	policy := NewDaemonPermissionPolicy(PermissionSettings{
+		DefaultTier: string(PermissionTierPrompt),
+		Channels:    map[string]string{PermissionChannelTelegram: string(PermissionTierReadOnly)},
+	})
+
+	decision, err := policy.DecidePermission(context.Background(), daemon.PermissionContext{
+		SessionID: "telegram:123",
+	}, glue.PermissionRequest{SessionID: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != daemon.PermissionPolicyDeny {
+		t.Fatalf("decision = %+v", decision)
+	}
+}

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -132,7 +132,11 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 
 	var permission glue.Permission
 	if settings.Coding.Enabled {
-		permission = NewCLIPermission(CLIPermissionOptions{Stdin: stdin, Stderr: stderr})
+		permission = NewTieredPermission(
+			NewCLIPermission(CLIPermissionOptions{Stdin: stdin, Stderr: stderr}),
+			PermissionTierForChannel(settings.Permissions, PermissionChannelCLI),
+			PermissionChannelCLI,
+		)
 		workDir := settings.Coding.WorkDir
 		if strings.TrimSpace(workDir) == "" {
 			workDir = "."
@@ -255,6 +259,7 @@ Flags:
 	handler, err := daemon.New(daemon.Options{
 		Host:              p.Agent(),
 		Token:             token,
+		PermissionPolicy:  NewDaemonPermissionPolicy(settings.Permissions),
 		PermissionTimeout: *permissionTimeout,
 	})
 	if err != nil {

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -40,6 +40,10 @@ type Settings struct {
 	// default; enable only for trusted local workspaces.
 	Coding CodingSettings `json:"coding"`
 
+	// Permissions configures Peggy's side-effect permission policy.
+	// Defaults to prompt for every channel.
+	Permissions PermissionSettings `json:"permissions"`
+
 	// Channels carries per-channel configuration subtrees keyed by
 	// channel name (e.g. "telegram"). Each channel package decodes
 	// its own subtree via a DecodeConfig helper. Empty means "no
@@ -80,6 +84,13 @@ type CodingSettings struct {
 	// write_file. The model must also pass overwrite=true and the
 	// Permission implementation must allow the call.
 	AllowOverwrite bool `json:"allow_overwrite"`
+}
+
+// PermissionSettings configures Peggy permission tiers. Channel keys are
+// lower-case names such as "cli" and "telegram".
+type PermissionSettings struct {
+	DefaultTier string            `json:"default_tier"`
+	Channels    map[string]string `json:"channels,omitempty"`
 }
 
 // Environment variables consulted when paths aren't given explicitly.
@@ -129,6 +140,9 @@ func LoadSettings(path string) (Settings, string, error) {
 		return Settings{}, resolved, fmt.Errorf("peggy: parse %s: %w", resolved, err)
 	}
 	s = fillDefaults(s)
+	if err := validatePermissionSettings(s.Permissions); err != nil {
+		return Settings{}, resolved, err
+	}
 	if s.Store.Path != "" {
 		expanded, err := expandPath(s.Store.Path)
 		if err != nil {
@@ -252,5 +266,6 @@ func fillDefaults(s Settings) Settings {
 	if len(s.Coding.AllowedBinaries) == 0 {
 		s.Coding.AllowedBinaries = append([]string(nil), DefaultCodingAllowedBinaries...)
 	}
+	s.Permissions = normalizePermissionSettings(s.Permissions)
 	return s
 }

--- a/agents/peggy/settings_test.go
+++ b/agents/peggy/settings_test.go
@@ -183,6 +183,54 @@ func TestLoadSettings_CodingDefaultsAndWorkDirExpansion(t *testing.T) {
 	}
 }
 
+func TestLoadSettings_PermissionDefaultsAndChannels(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(XDGConfigEnv, "")
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeJSON(t, path, map[string]any{
+		"permissions": map[string]any{
+			"default_tier": "read_only",
+			"channels": map[string]any{
+				"Telegram": "TRUSTED",
+				"cli":      " prompt ",
+			},
+		},
+	})
+
+	s, _, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if s.Permissions.DefaultTier != "read_only" {
+		t.Fatalf("default tier = %q", s.Permissions.DefaultTier)
+	}
+	if got := s.Permissions.Channels["telegram"]; got != "trusted" {
+		t.Fatalf("telegram tier = %q", got)
+	}
+	if got := PermissionTierForChannel(s.Permissions, PermissionChannelCLI); got != PermissionTierPrompt {
+		t.Fatalf("cli tier = %q", got)
+	}
+	if got := PermissionTierForChannel(s.Permissions, "unknown"); got != PermissionTierReadOnly {
+		t.Fatalf("unknown tier = %q", got)
+	}
+}
+
+func TestLoadSettings_InvalidPermissionTierErrors(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeJSON(t, path, map[string]any{
+		"permissions": map[string]any{
+			"channels": map[string]any{"telegram": "maybe"},
+		},
+	})
+
+	_, _, err := LoadSettings(path)
+	if err == nil || !strings.Contains(err.Error(), "permissions.channels.telegram") {
+		t.Fatalf("LoadSettings error = %v", err)
+	}
+}
+
 func TestExpandPath_HomeAndTilde(t *testing.T) {
 	t.Setenv("HOME", "/tmp/peggy-home")
 	got, err := expandPath("~/.cache")

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -36,6 +36,12 @@ type Options struct {
 	// Token is required for every route except /v1/health.
 	Token string
 
+	// PermissionPolicy, when non-nil, can allow, deny, or defer
+	// side-effecting tool permission requests before the daemon emits a
+	// permission_request event. The daemon package remains channel-blind:
+	// hosts that need channel/client policy decide from the supplied context.
+	PermissionPolicy PermissionPolicy
+
 	// Now supplies event timestamps. Nil uses time.Now.
 	Now func() time.Time
 
@@ -47,10 +53,56 @@ type Options struct {
 	PermissionTimeout time.Duration
 }
 
+// PermissionPolicy optionally decides side-effecting tool permission requests
+// before the daemon asks the run owner over HTTP.
+type PermissionPolicy interface {
+	DecidePermission(context.Context, PermissionContext, glue.PermissionRequest) (PermissionPolicyDecision, error)
+}
+
+// PermissionPolicyFunc adapts a function into a [PermissionPolicy].
+type PermissionPolicyFunc func(context.Context, PermissionContext, glue.PermissionRequest) (PermissionPolicyDecision, error)
+
+// DecidePermission implements [PermissionPolicy].
+func (f PermissionPolicyFunc) DecidePermission(ctx context.Context, info PermissionContext, req glue.PermissionRequest) (PermissionPolicyDecision, error) {
+	if f == nil {
+		return PermissionPolicyDecision{}, nil
+	}
+	return f(ctx, info, req)
+}
+
+// PermissionContext describes the daemon run that owns a permission request.
+type PermissionContext struct {
+	RunID     string
+	SessionID string
+	ClientID  string
+}
+
+// PermissionPolicyAction is the host policy outcome for one permission
+// request.
+type PermissionPolicyAction int
+
+const (
+	// PermissionPolicyPrompt keeps the existing daemon behavior: use cached
+	// remembered decisions or ask the owning client over HTTP.
+	PermissionPolicyPrompt PermissionPolicyAction = iota
+	// PermissionPolicyAllow allows the side effect without asking the client.
+	PermissionPolicyAllow
+	// PermissionPolicyDeny denies the side effect without asking the client.
+	PermissionPolicyDeny
+)
+
+// PermissionPolicyDecision is returned by [PermissionPolicy].
+type PermissionPolicyDecision struct {
+	Action      PermissionPolicyAction
+	Reason      string
+	RememberFor glue.RememberScope
+}
+
 // Server is an http.Handler for the local daemon protocol.
 type Server struct {
 	host              Host
 	token             string
+	permissionPolicy  PermissionPolicy
 	now               func() time.Time
 	newID             func(prefix string) string
 	permissionTimeout time.Duration
@@ -142,6 +194,7 @@ func New(opts Options) (*Server, error) {
 	return &Server{
 		host:              opts.Host,
 		token:             token,
+		permissionPolicy:  opts.PermissionPolicy,
 		now:               now,
 		newID:             newID,
 		permissionTimeout: permissionTimeout,
@@ -496,7 +549,10 @@ func (p runPermission) Decide(ctx context.Context, req glue.PermissionRequest) (
 }
 
 func (s *Server) decidePermission(ctx context.Context, run *run, req glue.PermissionRequest) (glue.PermissionDecision, error) {
-	if decision, ok := s.cachedPermission(req); ok {
+	if decision, handled, err := s.applyPermissionPolicy(ctx, run, req); err != nil || handled {
+		return decision, err
+	}
+	if decision, ok := s.cachedPermission(run, req); ok {
 		return decision, nil
 	}
 
@@ -524,29 +580,66 @@ func (s *Server) decidePermission(ctx context.Context, run *run, req glue.Permis
 	defer timer.Stop()
 	select {
 	case decision := <-pending.done:
-		s.rememberPermission(req, decision)
+		s.rememberPermission(run, req, decision)
 		return decision, nil
 	case <-timer.C:
 		if !run.expirePermission(permissionID, pending) {
 			decision := <-pending.done
-			s.rememberPermission(req, decision)
+			s.rememberPermission(run, req, decision)
 			return decision, nil
 		}
 		return glue.PermissionDecision{Allow: false, Reason: "permission denied: daemon permission request timed out"}, nil
 	case <-ctx.Done():
 		if !run.expirePermission(permissionID, pending) {
 			decision := <-pending.done
-			s.rememberPermission(req, decision)
+			s.rememberPermission(run, req, decision)
 			return decision, nil
 		}
 		return glue.PermissionDecision{}, ctx.Err()
 	}
 }
 
-func (s *Server) cachedPermission(req glue.PermissionRequest) (glue.PermissionDecision, bool) {
-	sessionKey := permissionSessionKey(req)
-	targetKey := permissionTargetKey(req)
-	foreverKey := permissionForeverKey(req)
+func (s *Server) applyPermissionPolicy(ctx context.Context, run *run, req glue.PermissionRequest) (glue.PermissionDecision, bool, error) {
+	if s.permissionPolicy == nil {
+		return glue.PermissionDecision{}, false, nil
+	}
+	info := PermissionContext{}
+	if run != nil {
+		info.RunID = run.id
+		info.SessionID = run.sessionID
+		info.ClientID = run.clientID
+	}
+	if info.SessionID == "" {
+		info.SessionID = req.SessionID
+	}
+	policyDecision, err := s.permissionPolicy.DecidePermission(ctx, info, req)
+	if err != nil {
+		return glue.PermissionDecision{}, true, err
+	}
+	switch policyDecision.Action {
+	case PermissionPolicyPrompt:
+		return glue.PermissionDecision{}, false, nil
+	case PermissionPolicyAllow:
+		return glue.PermissionDecision{
+			Allow:       true,
+			Reason:      policyDecision.Reason,
+			RememberFor: policyDecision.RememberFor,
+		}, true, nil
+	case PermissionPolicyDeny:
+		reason := strings.TrimSpace(policyDecision.Reason)
+		if reason == "" {
+			reason = "permission denied by daemon policy"
+		}
+		return glue.PermissionDecision{Allow: false, Reason: reason}, true, nil
+	default:
+		return glue.PermissionDecision{}, true, fmt.Errorf("daemon: invalid permission policy action %d", policyDecision.Action)
+	}
+}
+
+func (s *Server) cachedPermission(run *run, req glue.PermissionRequest) (glue.PermissionDecision, bool) {
+	sessionKey := permissionSessionKey(run, req)
+	targetKey := permissionTargetKey(run, req)
+	foreverKey := permissionForeverKey(run, req)
 	s.permMu.Lock()
 	defer s.permMu.Unlock()
 	if _, ok := s.foreverAllows[foreverKey]; ok {
@@ -561,7 +654,7 @@ func (s *Server) cachedPermission(req glue.PermissionRequest) (glue.PermissionDe
 	return glue.PermissionDecision{}, false
 }
 
-func (s *Server) rememberPermission(req glue.PermissionRequest, decision glue.PermissionDecision) {
+func (s *Server) rememberPermission(run *run, req glue.PermissionRequest, decision glue.PermissionDecision) {
 	if !decision.Allow {
 		return
 	}
@@ -569,24 +662,34 @@ func (s *Server) rememberPermission(req glue.PermissionRequest, decision glue.Pe
 	defer s.permMu.Unlock()
 	switch decision.RememberFor {
 	case glue.RememberSession:
-		s.sessionAllows[permissionSessionKey(req)] = struct{}{}
+		s.sessionAllows[permissionSessionKey(run, req)] = struct{}{}
 	case glue.RememberSessionTarget:
-		s.targetAllows[permissionTargetKey(req)] = struct{}{}
+		s.targetAllows[permissionTargetKey(run, req)] = struct{}{}
 	case glue.RememberForever:
-		s.foreverAllows[permissionForeverKey(req)] = struct{}{}
+		s.foreverAllows[permissionForeverKey(run, req)] = struct{}{}
 	}
 }
 
-func permissionSessionKey(req glue.PermissionRequest) string {
-	return req.SessionID + "\x00" + req.Tool + "\x00" + req.Action
+func permissionSessionKey(run *run, req glue.PermissionRequest) string {
+	return permissionOwnerKey(run, req) + "\x00" + req.SessionID + "\x00" + req.Tool + "\x00" + req.Action
 }
 
-func permissionTargetKey(req glue.PermissionRequest) string {
-	return permissionSessionKey(req) + "\x00" + req.Target
+func permissionTargetKey(run *run, req glue.PermissionRequest) string {
+	return permissionSessionKey(run, req) + "\x00" + req.Target
 }
 
-func permissionForeverKey(req glue.PermissionRequest) string {
-	return req.Tool + "\x00" + req.Action + "\x00" + req.Target
+func permissionForeverKey(run *run, req glue.PermissionRequest) string {
+	return permissionOwnerKey(run, req) + "\x00" + req.Tool + "\x00" + req.Action + "\x00" + req.Target
+}
+
+func permissionOwnerKey(run *run, req glue.PermissionRequest) string {
+	if run != nil && strings.TrimSpace(run.clientID) != "" {
+		return "client:" + strings.TrimSpace(run.clientID)
+	}
+	if run != nil && strings.TrimSpace(run.sessionID) != "" {
+		return "session:" + strings.TrimSpace(run.sessionID)
+	}
+	return "session:" + strings.TrimSpace(req.SessionID)
 }
 
 func parseRememberScope(raw string) (glue.RememberScope, bool) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -419,8 +419,158 @@ func TestServerPermissionRememberForeverAcrossSessions(t *testing.T) {
 	}
 }
 
+func TestServerPermissionPolicyAllowSkipsPrompt(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	var observed PermissionContext
+	srv := newTestServerWithPolicy(t, agent, PermissionPolicyFunc(func(_ context.Context, info PermissionContext, req glue.PermissionRequest) (PermissionPolicyDecision, error) {
+		observed = info
+		if req.Tool != "side_effect" || req.Action != "touch" || req.SessionID != "default" {
+			t.Fatalf("permission request = %+v", req)
+		}
+		return PermissionPolicyDecision{Action: PermissionPolicyAllow}, nil
+	}))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRunWithClient(t, ts.URL, "default", "cli:test")
+	events := getSSE(t, ts.URL+start.EventsURL, "token")
+	if observed.ClientID != "cli:test" || observed.SessionID != "default" || observed.RunID == "" {
+		t.Fatalf("permission context = %+v", observed)
+	}
+	if executed.Load() != 1 {
+		t.Fatalf("tool executions = %d, want 1", executed.Load())
+	}
+	if contains(eventTypes(events), "permission_request") {
+		t.Fatalf("events = %v, want no permission_request", eventTypes(events))
+	}
+}
+
+func TestServerPermissionPolicyDenySkipsPrompt(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithPolicy(t, agent, PermissionPolicyFunc(func(context.Context, PermissionContext, glue.PermissionRequest) (PermissionPolicyDecision, error) {
+		return PermissionPolicyDecision{Action: PermissionPolicyDeny, Reason: "permission denied: read-only channel"}, nil
+	}))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRunWithClient(t, ts.URL, "default", "telegram:123")
+	events := getSSE(t, ts.URL+start.EventsURL, "token")
+	if executed.Load() != 0 {
+		t.Fatalf("tool executions = %d, want 0", executed.Load())
+	}
+	if contains(eventTypes(events), "permission_request") {
+		t.Fatalf("events = %v, want no permission_request", eventTypes(events))
+	}
+	if got := toolEndText(t, events); !strings.Contains(got, "read-only channel") {
+		t.Fatalf("tool error = %q, want policy reason", got)
+	}
+}
+
+func TestServerPermissionPolicyPromptFallsThrough(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithPolicy(t, agent, PermissionPolicyFunc(func(context.Context, PermissionContext, glue.PermissionRequest) (PermissionPolicyDecision, error) {
+		return PermissionPolicyDecision{Action: PermissionPolicyPrompt}, nil
+	}))
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRunWithClient(t, ts.URL, "default", "cli:test")
+	events, err := collectSSE(t, ts.URL+start.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, start.RunID, permissionID(t, event), "token", `{"allow":true}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executed.Load() != 1 {
+		t.Fatalf("tool executions = %d, want 1", executed.Load())
+	}
+	if !contains(eventTypes(events), "permission_request") {
+		t.Fatalf("events = %v, want permission_request", eventTypes(events))
+	}
+}
+
+func TestServerPermissionRememberForeverIsClientScoped(t *testing.T) {
+	var executed atomic.Int32
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("first done"),
+			toolCallTurn(), textTurn("second done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&executed)},
+	})
+	srv := newTestServerWithTimeout(t, agent, 50*time.Millisecond)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	first := startRunWithClient(t, ts.URL, "telegram:123", "telegram:123")
+	firstEvents, err := collectSSE(t, ts.URL+first.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, first.RunID, permissionID(t, event), "token", `{"allow":true,"remember_for":"forever"}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(eventTypes(firstEvents), "permission_request") {
+		t.Fatal("first run did not ask permission")
+	}
+
+	second := startRunWithClient(t, ts.URL, "default", "cli:test")
+	secondEvents, err := collectSSE(t, ts.URL+second.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, ts.URL, second.RunID, permissionID(t, event), "token", `{"allow":true}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executed.Load() != 2 {
+		t.Fatalf("tool executions = %d, want 2", executed.Load())
+	}
+	if !contains(eventTypes(secondEvents), "permission_request") {
+		t.Fatalf("second run events = %v, want client-scoped cache miss", eventTypes(secondEvents))
+	}
+}
+
 func newTestServer(t *testing.T, host Host) *Server {
 	return newTestServerWithTimeout(t, host, time.Second)
+}
+
+func newTestServerWithPolicy(t *testing.T, host Host, policy PermissionPolicy) *Server {
+	t.Helper()
+	now := time.Date(2026, 5, 23, 20, 46, 0, 0, time.UTC)
+	srv, err := New(Options{
+		Host:              host,
+		Token:             "token",
+		PermissionPolicy:  policy,
+		Now:               func() time.Time { return now },
+		NewID:             sequenceIDs(),
+		PermissionTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
 }
 
 func newTestServerWithTimeout(t *testing.T, host Host, timeout time.Duration) *Server {
@@ -469,7 +619,13 @@ func postJSON(t *testing.T, url, token, body string) *http.Response {
 
 func startRun(t *testing.T, baseURL, sessionID string) startRunResponse {
 	t.Helper()
-	resp := postJSON(t, baseURL+"/v1/sessions/"+sessionID+"/runs", "token", `{"text":"go","client_id":"cli:test"}`)
+	return startRunWithClient(t, baseURL, sessionID, "cli:test")
+}
+
+func startRunWithClient(t *testing.T, baseURL, sessionID, clientID string) startRunResponse {
+	t.Helper()
+	body := fmt.Sprintf(`{"text":"go","client_id":%s}`, strconv.Quote(clientID))
+	resp := postJSON(t, baseURL+"/v1/sessions/"+sessionID+"/runs", "token", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("start status = %d, want %d", resp.StatusCode, http.StatusCreated)


### PR DESCRIPTION
## Summary

- Add a daemon-neutral permission policy hook that can allow, deny, or prompt before `permission_request` emission.
- Add Peggy permission tiers (`prompt`, `read_only`, `trusted`) with default/per-channel settings and daemon client/channel derivation.
- Wire tiers into `peggy serve`, standalone `peggy --coding`, and standalone Telegram's permission path.
- Scope daemon remembered permission decisions by daemon client so Telegram allows do not silently authorize terminal requests.
- Document recommended CLI/Telegram tier setups and trust boundaries.

## Verification

- `go test ./daemon -count=1`
- `go test ./agents/peggy -count=1`
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./daemon ./agents/peggy ./agents/peggy/channels/telegram ./cmd/glue -count=1`
- `go test ./agents/peggy/... -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #173.
