### PR TITLE
agents/peggy: v0.3.0 multi-channel daemon release polish

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to the `peggy` agent. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com); this project does
 not formally follow SemVer until v1.0.
 
+## v0.3.0 — 2026-05-24
+
+Peggy can now run as one local daemon shared by terminal and Telegram
+clients. The release completes M3 from tracker
+[#110](https://github.com/erain/glue/issues/110): one long-running
+Peggy process owns the provider, memory/session store, coding tools,
+and permission cache while clients attach over the local HTTP+SSE
+daemon protocol.
+
+### Added
+
+- **Local daemon mode.** `peggy serve` starts Peggy behind the
+  ADR-0010 HTTP+SSE daemon protocol, writes local connection metadata,
+  supports generated or explicit bearer tokens, and shuts down cleanly
+  on SIGINT/SIGTERM.
+- **Terminal daemon client.** `glue connect` attaches to `peggy serve`,
+  starts runs, streams assistant text, brokers permission requests in
+  the terminal, and cancels the run on SIGINT.
+- **Telegram daemon-client mode.** `peggy-telegram --daemon` keeps the
+  Telegram allowlist and inline permission buttons while using the
+  shared Peggy daemon for provider, memory, coding tools, and
+  permission cache.
+- **Daemon-brokered permissions.** Side-effecting coding tools emit
+  `permission_request` events and wait for the owning client to answer
+  over the daemon protocol.
+- **Channel-scoped permission tiers.** Peggy settings can assign
+  `prompt`, `read_only`, or `trusted` behavior per channel/client,
+  e.g. trusted local terminal with prompted or read-only Telegram.
+- **Client-scoped remembered daemon decisions.** A remembered Telegram
+  allow no longer silently authorizes terminal requests, or vice versa.
+
+### Changed
+
+- `peggy.Version` is now `0.3.0`.
+- Peggy README, Telegram README, and the top-level README now document
+  the multi-channel daemon happy path and permission-tier setup.
+- Release smoke coverage now drives the daemon path with trusted CLI
+  and read-only Telegram tiers using a fake provider.
+
+### Known limitations
+
+- The daemon is local-first and protected by a bearer token; it is not
+  a hosted multi-user auth model.
+- Runs are still stream-owned. Detached/background runs and replay
+  endpoints are future work.
+- Remembered permission decisions are in-memory and disappear when the
+  daemon restarts. Persistent per-user policy remains a follow-up.
+- Telegram replies are still one final message per turn; edit-in-place
+  streaming is deferred.
+- No MCP client yet; that remains M4.
+
 ## v0.2.0 — 2026-05-23
 
 Peggy can now act as a permission-gated coding assistant in trusted
@@ -141,4 +192,4 @@ sessions and is reachable from the CLI or Telegram. Tracker:
   by hand at release time and pinned by a test.
 
 [Tracker #110](https://github.com/erain/glue/issues/110) is the
-canonical roadmap. M3 ("multi-channel daemon") is the next milestone.
+canonical roadmap. M4 ("ecosystem") is the next milestone.

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -4,10 +4,12 @@
 > remembers you across sessions, and curates facts on her own.
 
 A long-running personal-assistant agent built on the
-[glue](../..) framework. **v0.2** ships:
+[glue](../..) framework. **v0.3** ships:
 
 - a single-prompt **CLI** (`peggy`)
 - a **Telegram bot** binary (`peggy-telegram`) with a chat-id allowlist
+- a local **HTTP+SSE daemon** (`peggy serve`) shared by terminal and
+  Telegram clients
 - model-callable **`remember` / `recall` tools** for durable
   cross-session memory
 - **token-aware summarizing compaction** so long sessions don't blow
@@ -17,12 +19,13 @@ A long-running personal-assistant agent built on the
 - opt-in local **coding tools** for reading files, writing files,
   running allowlisted commands, and inspecting git branch context
 - per-call permission prompts for side-effecting coding tools in the
-  CLI and Telegram
+  CLI, Telegram, and daemon clients
+- per-channel permission tiers (`prompt`, `read_only`, `trusted`)
 - four model backends: Codex (ChatGPT subscription), Gemini,
   OpenRouter, NVIDIA build
 
 Tracker: [#110](https://github.com/erain/glue/issues/110). M3
-("multi-channel daemon") is active.
+("multi-channel daemon") is the v0.3 release milestone.
 
 ## Quickstart
 
@@ -201,6 +204,35 @@ uses the `cli` tier and `telegram:<chat_id>` uses the `telegram` tier.
 Use this to keep a trusted local terminal fast while making Telegram
 ask every time, or to make Telegram read-only.
 
+Recommended v0.3 daily-driver shape:
+
+```json
+{
+  "store": {
+    "type": "sqlite",
+    "path": "~/.peggy/peggy.db"
+  },
+  "coding": {
+    "enabled": true,
+    "work_dir": "/path/to/trusted/repo",
+    "allowed_binaries": ["go", "git", "make"],
+    "allow_overwrite": false
+  },
+  "permissions": {
+    "default_tier": "prompt",
+    "channels": {
+      "cli": "trusted",
+      "telegram": "prompt"
+    }
+  }
+}
+```
+
+Run `peggy serve --config ~/.config/peggy/settings.json`, connect from
+a terminal with `glue connect --prompt "..." --id cli:daily`, and start
+Telegram with `peggy-telegram --daemon`. The daemon prints the base URL
+and metadata path but never prints the bearer token.
+
 ## Coding Tools
 
 Coding mode is opt-in. Enable it in `settings.json` with
@@ -284,7 +316,7 @@ that made them, so a Telegram allow does not silently authorize a
 terminal request.
 
 Coding mode is a trusted-local workflow. The tool layer constrains
-paths, binaries, overwrites, output size, and permissions, but v0.2
+paths, binaries, overwrites, output size, and permissions, but Peggy
 uses the host process via `glue.LocalExecutor`; it is not a container
 or VM sandbox.
 
@@ -336,8 +368,9 @@ near-term follow-up.
 
 ## What Peggy supports today
 
-- **Single-prompt CLI** (`peggy`) and **Telegram bot** (`peggy-telegram`)
-  on the same agent + same session store.
+- **Single-prompt CLI** (`peggy`), **daemon mode** (`peggy serve`),
+  terminal daemon client (`glue connect`), and **Telegram bot**
+  (`peggy-telegram`) in standalone or daemon-client mode.
 - File or SQLite session persistence. SQLite enables cross-session
   FTS5 search.
 - **Model-callable `remember` / `recall` tools** for durable
@@ -349,12 +382,13 @@ near-term follow-up.
 - Opt-in **local coding mode** for CLI and Telegram: read files, write
   files, run allowlisted commands, and inspect git branch context with
   per-call permission prompts for side effects.
+- **Permission tiers** by channel/client: prompt, read-only, or trusted.
 - All four shipped providers: `codex` (ChatGPT subscription),
   `gemini`, `openrouter`, `nvidia`. Codex is the default and uses
   your existing ChatGPT subscription via `codex login` — no per-token
   bill.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.2 summary and
+See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.3 summary and
 known limitations.
 
 ## Channels
@@ -382,13 +416,10 @@ external transports. The pattern is designed in
 Per tracker [#110](https://github.com/erain/glue/issues/110), in
 priority order:
 
-- **M3 — multi-channel daemon.** `peggy serve` plus daemon clients so
-  one long-running Peggy serves a terminal, Telegram, and future
-  clients concurrently. Next up: per-channel permission tiers.
 - **M4 — ecosystem.** MCP client (stdio + HTTP), cost tracking,
   `providers/anthropic` when budget allows.
 
-Near-term follow-ups that may slip into v0.2.x patches: a `peggy
+Near-term follow-ups that may slip into v0.3.x patches: a `peggy
 memories` subcommand (list / export / forget), edit-in-place
 Telegram streaming, FTS5 prefix-match on session ids for
 channel-scoped recall.

--- a/agents/peggy/channels/telegram/doc.go
+++ b/agents/peggy/channels/telegram/doc.go
@@ -2,10 +2,11 @@
 // implements peggy.Channel against the Telegram Bot API using a
 // stdlib-only HTTP client (no third-party SDK).
 //
-// v0.2 supports text messages with long-polling, a chat-id allowlist,
-// and inline-keyboard permission prompts for Peggy coding tools.
-// Edit-in-place streaming, image / voice / file messages, and
-// webhook-mode are deferred follow-ups.
+// v0.3 supports text messages with long-polling, a chat-id allowlist,
+// inline-keyboard permission prompts for Peggy coding tools, and an
+// optional daemon-client mode against peggy serve. Edit-in-place
+// streaming, image / voice / file messages, and webhook-mode are
+// deferred follow-ups.
 //
 // Design: docs/adr/0008-channel-adapter.md.
 package telegram

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -61,6 +62,70 @@ func TestPeggyDaemonCodingPermissionViaDaemon(t *testing.T) {
 	}
 }
 
+func TestPeggyV03ReleaseSmoke(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "write_file", `{"path":"cli.txt","content":"trusted cli"}`),
+		peggyTextTurn("cli done"),
+		toolCallTurn("c2", "write_file", `{"path":"telegram.txt","content":"blocked telegram"}`),
+		peggyTextTurn("telegram done"),
+	}}
+	p, err := New(Options{
+		Settings: Settings{
+			Coding: CodingSettings{
+				Enabled:        true,
+				WorkDir:        workDir,
+				AllowOverwrite: true,
+			},
+			Permissions: PermissionSettings{
+				DefaultTier: string(PermissionTierPrompt),
+				Channels: map[string]string{
+					PermissionChannelCLI:      string(PermissionTierTrusted),
+					PermissionChannelTelegram: string(PermissionTierReadOnly),
+				},
+			},
+		},
+		Provider: provider,
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	srv, err := daemon.New(daemon.Options{
+		Host:             p.Agent(),
+		Token:            "tok",
+		PermissionPolicy: NewDaemonPermissionPolicy(p.Settings().Permissions),
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cliStart := startPeggyDaemonRunWithClient(t, ts.URL, "default", "cli:test")
+	cliEvents := collectPeggyDaemonEvents(t, ts.URL, cliStart.RunID, cliStart.EventsURL)
+	if eventSeen(cliEvents, "permission_request") {
+		t.Fatalf("cli events = %v, want trusted tier without prompt", eventTypes(cliEvents))
+	}
+	if got := readFileString(t, filepath.Join(workDir, "cli.txt")); got != "trusted cli" {
+		t.Fatalf("cli.txt = %q", got)
+	}
+
+	telegramStart := startPeggyDaemonRunWithClient(t, ts.URL, "telegram:123", "telegram:123")
+	telegramEvents := collectPeggyDaemonEvents(t, ts.URL, telegramStart.RunID, telegramStart.EventsURL)
+	if eventSeen(telegramEvents, "permission_request") {
+		t.Fatalf("telegram events = %v, want read_only tier without prompt", eventTypes(telegramEvents))
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "telegram.txt")); err == nil {
+		t.Fatal("telegram.txt exists; read_only tier should deny write_file")
+	}
+	if !strings.Contains(toolEndTextFromDaemon(t, telegramEvents), "telegram channel is read-only") {
+		t.Fatalf("telegram tool error missing read_only reason")
+	}
+}
+
 type startRunResponse struct {
 	RunID     string `json:"run_id"`
 	EventsURL string `json:"events_url"`
@@ -68,8 +133,13 @@ type startRunResponse struct {
 
 func startPeggyDaemonRun(t *testing.T, baseURL string) startRunResponse {
 	t.Helper()
-	body := bytes.NewBufferString(`{"text":"write the note","client_id":"cli:test","max_turns":3}`)
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/sessions/default/runs", body)
+	return startPeggyDaemonRunWithClient(t, baseURL, "default", "cli:test")
+}
+
+func startPeggyDaemonRunWithClient(t *testing.T, baseURL, sessionID, clientID string) startRunResponse {
+	t.Helper()
+	body := bytes.NewBufferString(`{"text":"write the note","client_id":` + strconv.Quote(clientID) + `,"max_turns":3}`)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/sessions/"+sessionID+"/runs", body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,4 +261,33 @@ func readFileString(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return string(data)
+}
+
+func toolEndTextFromDaemon(t *testing.T, events []daemon.EventEnvelope) string {
+	t.Helper()
+	for _, event := range events {
+		if event.Type != "tool_end" {
+			continue
+		}
+		payload, ok := event.Payload.(map[string]any)
+		if !ok {
+			t.Fatalf("tool_end payload = %#v", event.Payload)
+		}
+		result, ok := payload["tool_result"].(map[string]any)
+		if !ok {
+			t.Fatalf("tool_end missing result: %#v", payload)
+		}
+		content, ok := result["content"].([]any)
+		if !ok || len(content) == 0 {
+			t.Fatalf("tool_end missing content: %#v", result)
+		}
+		part, ok := content[0].(map[string]any)
+		if !ok {
+			t.Fatalf("tool_end content = %#v", content[0])
+		}
+		text, _ := part["text"].(string)
+		return text
+	}
+	t.Fatal("missing tool_end event")
+	return ""
 }

--- a/agents/peggy/doc.go
+++ b/agents/peggy/doc.go
@@ -9,11 +9,12 @@
 //     system prompt so the model sees who Peggy is and who you are
 //     on every turn.
 //   - settings.json — JSON config (provider, model, store path,
-//     compaction knobs).
+//     compaction knobs, coding tools, channels, and permission tiers).
 //
-// v0.2 ships the single-prompt CLI, Telegram channel, durable memory,
-// and opt-in local coding tools with per-call permission prompts. The
-// daemon mode arrives in a later milestone. Tracker:
+// v0.3 ships the single-prompt CLI, Telegram channel, durable memory,
+// opt-in local coding tools, and a local HTTP+SSE daemon so terminal
+// and Telegram clients can share one long-running Peggy process.
+// Tracker:
 // https://github.com/erain/glue/issues/110.
 //
 // Design rule (per ADR-0005): every product concern lives in this

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -17,7 +17,7 @@ import (
 
 // Version is the package version string surfaced by `peggy --version`.
 // Bumped by hand at release time.
-const Version = "0.2.0"
+const Version = "0.3.0"
 
 const (
 	defaultDaemonListenAddr      = "127.0.0.1:0"

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -28,8 +28,8 @@ func TestRun_Version(t *testing.T) {
 // whose --version still says "-dev". Bump the constant deliberately
 // at release time, and update this test to match.
 func TestVersionPinned(t *testing.T) {
-	if Version != "0.2.0" {
-		t.Fatalf("Version = %q, want %q", Version, "0.2.0")
+	if Version != "0.3.0" {
+		t.Fatalf("Version = %q, want %q", Version, "0.3.0")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bump Peggy to `0.3.0` and update the pinned version test.
- Add a v0.3.0 changelog section for daemon mode, terminal/Telegram daemon clients, daemon-brokered permissions, and channel permission tiers.
- Update package docs and Peggy README around the v0.3 daily-driver daemon setup.
- Add a deterministic v0.3 daemon release smoke covering trusted CLI vs read-only Telegram policy through the real Peggy daemon path.

## Verification

- `go test ./agents/peggy -count=1`
- `go test ./agents/peggy/... -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #175.
