### PR TITLE
tools/mcp: add JSON-RPC client lifecycle and stdio transport

### DIFF
--- a/tools/mcp/client.go
+++ b/tools/mcp/client.go
@@ -1,0 +1,262 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ProtocolVersion is the MCP protocol version this package speaks.
+const ProtocolVersion = "2025-11-25"
+
+const defaultTimeout = 30 * time.Second
+
+// ServerConfig configures one MCP server connection.
+type ServerConfig struct {
+	Name string
+
+	// Stdio transport fields. Command is argv[0], never a shell string.
+	Command string
+	Args    []string
+	Env     []string
+	WorkDir string
+
+	// Timeout caps lifecycle and request waits when callers do not supply a
+	// tighter context deadline.
+	Timeout time.Duration
+
+	// MaxStderrBytes caps retained stderr diagnostics from stdio servers.
+	MaxStderrBytes int
+}
+
+// Implementation describes an MCP peer.
+type Implementation struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// InitializeResult is the portion of MCP initialize results needed by this
+// package.
+type InitializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities,omitempty"`
+	ServerInfo      Implementation `json:"serverInfo,omitempty"`
+	Instructions    string         `json:"instructions,omitempty"`
+}
+
+// RPCError is a JSON-RPC error returned by an MCP server.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if len(e.Data) > 0 {
+		return fmt.Sprintf("mcp: rpc error %d: %s: %s", e.Code, e.Message, strings.TrimSpace(string(e.Data)))
+	}
+	return fmt.Sprintf("mcp: rpc error %d: %s", e.Code, e.Message)
+}
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+type transport interface {
+	Encode(any) error
+	Decode(*rpcResponse) error
+	Close() error
+	Stderr() string
+}
+
+// Client is one initialized MCP client session.
+type Client struct {
+	tr transport
+
+	mu     sync.Mutex
+	nextID int64
+
+	init InitializeResult
+}
+
+// NewStdioClient starts a stdio MCP server and completes lifecycle
+// negotiation.
+func NewStdioClient(ctx context.Context, cfg ServerConfig) (*Client, error) {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	tr, err := startStdioTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	c := &Client{tr: tr}
+
+	initCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	if err := c.initialize(initCtx); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+// InitializeResult returns the negotiated server information.
+func (c *Client) InitializeResult() InitializeResult {
+	if c == nil {
+		return InitializeResult{}
+	}
+	return c.init
+}
+
+// Request sends a JSON-RPC request and decodes the result into result when
+// result is non-nil.
+func (c *Client) Request(ctx context.Context, method string, params any, result any) error {
+	if c == nil || c.tr == nil {
+		return errors.New("mcp: nil client")
+	}
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return errors.New("mcp: method is required")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.nextID++
+	id := c.nextID
+	if err := c.tr.Encode(rpcRequest{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}); err != nil {
+		return err
+	}
+
+	type readResult struct {
+		resp rpcResponse
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		resp, err := c.readResponse(id)
+		ch <- readResult{resp: resp, err: err}
+	}()
+
+	select {
+	case got := <-ch:
+		if got.err != nil {
+			return got.err
+		}
+		if result == nil {
+			return nil
+		}
+		if len(got.resp.Result) == 0 {
+			return nil
+		}
+		if err := json.Unmarshal(got.resp.Result, result); err != nil {
+			return fmt.Errorf("mcp: decode %s result: %w", method, err)
+		}
+		return nil
+	case <-ctx.Done():
+		_ = c.Close()
+		return ctx.Err()
+	}
+}
+
+// Notify sends a JSON-RPC notification.
+func (c *Client) Notify(ctx context.Context, method string, params any) error {
+	if c == nil || c.tr == nil {
+		return errors.New("mcp: nil client")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return errors.New("mcp: method is required")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.tr.Encode(rpcRequest{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+	})
+}
+
+// Stderr returns retained stderr diagnostics for stdio transports.
+func (c *Client) Stderr() string {
+	if c == nil || c.tr == nil {
+		return ""
+	}
+	return c.tr.Stderr()
+}
+
+// Close releases the underlying transport.
+func (c *Client) Close() error {
+	if c == nil || c.tr == nil {
+		return nil
+	}
+	return c.tr.Close()
+}
+
+func (c *Client) initialize(ctx context.Context) error {
+	var init InitializeResult
+	if err := c.Request(ctx, "initialize", map[string]any{
+		"protocolVersion": ProtocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]string{
+			"name":    "glue",
+			"version": "0",
+		},
+	}, &init); err != nil {
+		return err
+	}
+	if init.ProtocolVersion != ProtocolVersion {
+		return fmt.Errorf("mcp: incompatible protocol version %q, want %q", init.ProtocolVersion, ProtocolVersion)
+	}
+	if err := c.Notify(ctx, "notifications/initialized", nil); err != nil {
+		return err
+	}
+	c.init = init
+	return nil
+}
+
+func (c *Client) readResponse(wantID int64) (rpcResponse, error) {
+	for {
+		var resp rpcResponse
+		if err := c.tr.Decode(&resp); err != nil {
+			return rpcResponse{}, err
+		}
+		if len(resp.ID) == 0 {
+			continue
+		}
+		if resp.JSONRPC != "2.0" {
+			return rpcResponse{}, fmt.Errorf("mcp: response jsonrpc = %q, want 2.0", resp.JSONRPC)
+		}
+		if strings.TrimSpace(string(resp.ID)) != fmt.Sprintf("%d", wantID) {
+			return rpcResponse{}, fmt.Errorf("mcp: response id %s, want %d", strings.TrimSpace(string(resp.ID)), wantID)
+		}
+		if resp.Error != nil {
+			return rpcResponse{}, resp.Error
+		}
+		return resp, nil
+	}
+}

--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -1,0 +1,208 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStdioClientInitialize(t *testing.T) {
+	c, err := NewStdioClient(context.Background(), helperConfig("success"))
+	if err != nil {
+		t.Fatalf("NewStdioClient: %v", err)
+	}
+	defer c.Close()
+	if got := c.InitializeResult().ProtocolVersion; got != ProtocolVersion {
+		t.Fatalf("protocol = %q, want %q", got, ProtocolVersion)
+	}
+	if got := c.InitializeResult().ServerInfo.Name; got != "fake-mcp" {
+		t.Fatalf("server name = %q", got)
+	}
+}
+
+func TestStdioClientRejectsIncompatibleProtocol(t *testing.T) {
+	_, err := NewStdioClient(context.Background(), helperConfig("incompatible"))
+	if err == nil || !strings.Contains(err.Error(), "incompatible protocol") {
+		t.Fatalf("NewStdioClient error = %v", err)
+	}
+}
+
+func TestStdioClientSurfacesRPCError(t *testing.T) {
+	c, err := NewStdioClient(context.Background(), helperConfig("rpc_error"))
+	if err != nil {
+		t.Fatalf("NewStdioClient: %v", err)
+	}
+	defer c.Close()
+
+	err = c.Request(context.Background(), "tools/list", nil, nil)
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("Request error = %T %v, want RPCError", err, err)
+	}
+	if rpcErr.Code != -32001 || rpcErr.Message != "boom" {
+		t.Fatalf("rpc error = %+v", rpcErr)
+	}
+}
+
+func TestStdioClientRejectsWrongResponseID(t *testing.T) {
+	_, err := NewStdioClient(context.Background(), helperConfig("wrong_id"))
+	if err == nil || !strings.Contains(err.Error(), "response id") {
+		t.Fatalf("NewStdioClient error = %v", err)
+	}
+}
+
+func TestStdioClientCapturesStderr(t *testing.T) {
+	cfg := helperConfig("stderr")
+	cfg.MaxStderrBytes = 12
+	c, err := NewStdioClient(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewStdioClient: %v", err)
+	}
+	defer c.Close()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if got := c.Stderr(); got == "stderr-line-" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stderr = %q", c.Stderr())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestStdioClientInitializeCancellationCleansUp(t *testing.T) {
+	cfg := helperConfig("hang")
+	cfg.Timeout = 50 * time.Millisecond
+	start := time.Now()
+	_, err := NewStdioClient(context.Background(), cfg)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("NewStdioClient error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("cancellation cleanup took %s", elapsed)
+	}
+}
+
+func helperConfig(scenario string) ServerConfig {
+	return ServerConfig{
+		Name:    "fake",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestMCPHelperProcess", "--"},
+		Env: []string{
+			"MCP_HELPER=1",
+			"MCP_SCENARIO=" + scenario,
+		},
+		Timeout: 2 * time.Second,
+	}
+}
+
+func TestMCPHelperProcess(t *testing.T) {
+	if os.Getenv("MCP_HELPER") != "1" {
+		return
+	}
+	if err := runMCPHelper(os.Getenv("MCP_SCENARIO")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+type helperRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func runMCPHelper(scenario string) error {
+	dec := json.NewDecoder(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+
+	var initReq helperRequest
+	if err := dec.Decode(&initReq); err != nil {
+		return err
+	}
+	if initReq.Method != "initialize" {
+		return fmt.Errorf("first method = %q, want initialize", initReq.Method)
+	}
+	switch scenario {
+	case "wrong_id":
+		return enc.Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      99,
+			"result":  initializeResult(ProtocolVersion),
+		})
+	case "incompatible":
+		if err := writeHelperResult(enc, initReq.ID, initializeResult("2024-11-05")); err != nil {
+			return err
+		}
+		return readInitialized(dec)
+	case "hang":
+		time.Sleep(10 * time.Second)
+		return nil
+	case "stderr":
+		fmt.Fprint(os.Stderr, "stderr-line-with-extra-data")
+	}
+
+	if err := writeHelperResult(enc, initReq.ID, initializeResult(ProtocolVersion)); err != nil {
+		return err
+	}
+	if err := readInitialized(dec); err != nil {
+		return err
+	}
+	if scenario != "rpc_error" {
+		return nil
+	}
+	var req helperRequest
+	if err := dec.Decode(&req); err != nil {
+		return err
+	}
+	return enc.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(req.ID),
+		"error": map[string]any{
+			"code":    -32001,
+			"message": "boom",
+			"data":    map[string]any{"detail": "test"},
+		},
+	})
+}
+
+func initializeResult(version string) map[string]any {
+	return map[string]any{
+		"protocolVersion": version,
+		"capabilities":    map[string]any{},
+		"serverInfo": map[string]string{
+			"name":    "fake-mcp",
+			"version": "0.1.0",
+		},
+	}
+}
+
+func writeHelperResult(enc *json.Encoder, id json.RawMessage, result any) error {
+	return enc.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(id),
+		"result":  result,
+	})
+}
+
+func readInitialized(dec *json.Decoder) error {
+	var req helperRequest
+	if err := dec.Decode(&req); err != nil {
+		return err
+	}
+	if req.Method != "notifications/initialized" {
+		return fmt.Errorf("method = %q, want notifications/initialized", req.Method)
+	}
+	if len(req.ID) != 0 {
+		return fmt.Errorf("initialized notification has id %s", req.ID)
+	}
+	return nil
+}

--- a/tools/mcp/doc.go
+++ b/tools/mcp/doc.go
@@ -1,0 +1,8 @@
+// Package mcp implements the client foundation for consuming Model Context
+// Protocol servers from glue hosts.
+//
+// This package follows ADR-0011. The first implementation supports JSON-RPC
+// lifecycle negotiation over stdio only. Mapping MCP tools to glue.Tool values,
+// Streamable HTTP, resources, prompts, sampling, elicitation, and OAuth are
+// deferred follow-up surfaces.
+package mcp

--- a/tools/mcp/stdio.go
+++ b/tools/mcp/stdio.go
@@ -1,0 +1,184 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultMaxStderrBytes = 8192
+	defaultShutdownWait   = 2 * time.Second
+)
+
+type stdioTransport struct {
+	enc *json.Encoder
+	dec *json.Decoder
+
+	stdin io.WriteCloser
+	cmd   *exec.Cmd
+
+	stderr *limitedBuffer
+	waitCh chan error
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func startStdioTransport(cfg ServerConfig) (*stdioTransport, error) {
+	if strings.TrimSpace(cfg.Command) == "" {
+		return nil, errors.New("mcp: stdio command is required")
+	}
+	maxStderr := cfg.MaxStderrBytes
+	if maxStderr <= 0 {
+		maxStderr = defaultMaxStderrBytes
+	}
+	cmd := exec.Command(cfg.Command, cfg.Args...)
+	cmd.Env = append([]string(nil), cfg.Env...)
+	cmd.Dir = cfg.WorkDir
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: stderr pipe: %w", err)
+	}
+
+	tr := &stdioTransport{
+		enc:    json.NewEncoder(stdin),
+		dec:    json.NewDecoder(stdout),
+		stdin:  stdin,
+		cmd:    cmd,
+		stderr: newLimitedBuffer(maxStderr),
+		waitCh: make(chan error, 1),
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("mcp: start %s: %w", cfg.Command, err)
+	}
+	go func() {
+		_, _ = io.Copy(tr.stderr, stderrPipe)
+	}()
+	go func() {
+		tr.waitCh <- cmd.Wait()
+	}()
+	return tr, nil
+}
+
+func (t *stdioTransport) Encode(v any) error {
+	if t == nil || t.enc == nil {
+		return errors.New("mcp: nil stdio transport")
+	}
+	if err := t.enc.Encode(v); err != nil {
+		return fmt.Errorf("mcp: write stdio message: %w", err)
+	}
+	return nil
+}
+
+func (t *stdioTransport) Decode(resp *rpcResponse) error {
+	if t == nil || t.dec == nil {
+		return errors.New("mcp: nil stdio transport")
+	}
+	if err := t.dec.Decode(resp); err != nil {
+		return fmt.Errorf("mcp: read stdio message: %w", err)
+	}
+	return nil
+}
+
+func (t *stdioTransport) Close() error {
+	if t == nil {
+		return nil
+	}
+	t.closeOnce.Do(func() {
+		if t.stdin != nil {
+			_ = t.stdin.Close()
+		}
+		select {
+		case err := <-t.waitCh:
+			t.closeErr = ignoreExpectedExit(err)
+			return
+		case <-time.After(defaultShutdownWait):
+		}
+
+		if t.cmd != nil && t.cmd.Process != nil {
+			_ = t.cmd.Process.Signal(syscall.SIGTERM)
+		}
+		select {
+		case err := <-t.waitCh:
+			t.closeErr = ignoreExpectedExit(err)
+			return
+		case <-time.After(defaultShutdownWait):
+		}
+
+		if t.cmd != nil && t.cmd.Process != nil {
+			_ = t.cmd.Process.Kill()
+		}
+		if err := <-t.waitCh; err != nil {
+			t.closeErr = fmt.Errorf("mcp: killed stdio server: %w", err)
+		}
+	})
+	return t.closeErr
+}
+
+func (t *stdioTransport) Stderr() string {
+	if t == nil || t.stderr == nil {
+		return ""
+	}
+	return t.stderr.String()
+}
+
+func ignoreExpectedExit(err error) error {
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ProcessState != nil && exitErr.ProcessState.Exited() {
+		return nil
+	}
+	return err
+}
+
+type limitedBuffer struct {
+	mu    sync.Mutex
+	limit int
+	data  []byte
+}
+
+func newLimitedBuffer(limit int) *limitedBuffer {
+	return &limitedBuffer{limit: limit}
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	written := len(p)
+	if b.limit <= 0 {
+		return written, nil
+	}
+	space := b.limit - len(b.data)
+	if space <= 0 {
+		return written, nil
+	}
+	if len(p) > space {
+		p = p[:space]
+	}
+	b.data = append(b.data, p...)
+	return written, nil
+}
+
+func (b *limitedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(append([]byte(nil), b.data...))
+}


### PR DESCRIPTION
## Summary

- Add `tools/mcp` with the MCP `2025-11-25` protocol version, initialize/initialized lifecycle, serialized JSON-RPC requests, notifications, and RPC error handling.
- Add stdio transport process management with argv-only subprocess start, explicit env, stdin/stdout JSON-RPC, stderr capture, and shutdown cleanup.
- Add deterministic fake-process tests covering lifecycle success, incompatible protocol, RPC errors, wrong response IDs, stderr truncation, and cancellation cleanup.
- Add package docs pointing to ADR-0011 and deferred surfaces.

## Verification

- `go test ./tools/mcp -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #179.
