### PR TITLE
tools/mcp: expose MCP tools as glue tools

### DIFF
--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -156,6 +157,9 @@ func runMCPHelper(scenario string) error {
 	if err := readInitialized(dec); err != nil {
 		return err
 	}
+	if scenario == "tools" || scenario == "bad_schema" || scenario == "collision" {
+		return runMCPToolScenario(dec, enc, scenario)
+	}
 	if scenario != "rpc_error" {
 		return nil
 	}
@@ -172,6 +176,122 @@ func runMCPHelper(scenario string) error {
 			"data":    map[string]any{"detail": "test"},
 		},
 	})
+}
+
+func runMCPToolScenario(dec *json.Decoder, enc *json.Encoder, scenario string) error {
+	for {
+		var req helperRequest
+		if err := dec.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		switch req.Method {
+		case "tools/list":
+			if err := writeHelperResult(enc, req.ID, helperToolsList(scenario)); err != nil {
+				return err
+			}
+		case "tools/call":
+			if err := handleHelperToolCall(enc, req); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+		}
+	}
+}
+
+func helperToolsList(scenario string) map[string]any {
+	switch scenario {
+	case "bad_schema":
+		return map[string]any{
+			"tools": []map[string]any{{
+				"name":        "bad.schema",
+				"description": "bad schema",
+				"inputSchema": "not an object",
+			}},
+		}
+	case "collision":
+		return map[string]any{
+			"tools": []map[string]any{
+				{"name": "a-b", "inputSchema": json.RawMessage(`{"type":"object"}`)},
+				{"name": "a_b", "inputSchema": json.RawMessage(`{"type":"object"}`)},
+			},
+		}
+	default:
+		return map[string]any{
+			"tools": []map[string]any{
+				{
+					"name":         "weather.lookup",
+					"title":        "Weather Lookup",
+					"description":  "returns a short forecast",
+					"inputSchema":  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"],"additionalProperties":false}`),
+					"outputSchema": json.RawMessage(`{"type":"object","properties":{"temperature_c":{"type":"number"}}}`),
+					"annotations":  map[string]any{"readOnlyHint": true},
+				},
+				{"name": "no_schema", "description": "returns structured content"},
+				{"name": "image.tool", "inputSchema": json.RawMessage(`{"type":"object"}`)},
+				{"name": "error.tool", "inputSchema": json.RawMessage(`{"type":"object"}`)},
+				{"name": "rpc.fail", "inputSchema": json.RawMessage(`{"type":"object"}`)},
+			},
+		}
+	}
+}
+
+func handleHelperToolCall(enc *json.Encoder, req helperRequest) error {
+	var params struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return err
+	}
+	switch params.Name {
+	case "weather.lookup":
+		city, _ := params.Arguments["city"].(string)
+		return writeHelperResult(enc, req.ID, map[string]any{
+			"content": []map[string]any{{
+				"type": "text",
+				"text": "weather for " + city,
+			}},
+			"structuredContent": map[string]any{
+				"city":          city,
+				"temperature_c": 21,
+			},
+		})
+	case "no_schema":
+		return writeHelperResult(enc, req.ID, map[string]any{
+			"structuredContent": map[string]any{"answer": 42},
+		})
+	case "image.tool":
+		return writeHelperResult(enc, req.ID, map[string]any{
+			"content": []map[string]any{{
+				"type":     "image",
+				"data":     "abc",
+				"mimeType": "image/png",
+			}},
+		})
+	case "error.tool":
+		return writeHelperResult(enc, req.ID, map[string]any{
+			"isError": true,
+			"content": []map[string]any{{
+				"type": "text",
+				"text": "tool failed",
+			}},
+		})
+	case "rpc.fail":
+		return enc.Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      json.RawMessage(req.ID),
+			"error": map[string]any{
+				"code":    -32002,
+				"message": "call exploded",
+			},
+		})
+	default:
+		return fmt.Errorf("unknown helper tool %q", params.Name)
+	}
 }
 
 func initializeResult(version string) map[string]any {

--- a/tools/mcp/doc.go
+++ b/tools/mcp/doc.go
@@ -2,7 +2,8 @@
 // Protocol servers from glue hosts.
 //
 // This package follows ADR-0011. The first implementation supports JSON-RPC
-// lifecycle negotiation over stdio only. Mapping MCP tools to glue.Tool values,
-// Streamable HTTP, resources, prompts, sampling, elicitation, and OAuth are
-// deferred follow-up surfaces.
+// lifecycle negotiation over stdio, discovery of MCP server tools, and mapping
+// those tools to permission-gated glue.Tool values. Streamable HTTP, Peggy
+// settings, resources, prompts, sampling, elicitation, and OAuth are deferred
+// follow-up surfaces.
 package mcp

--- a/tools/mcp/tools.go
+++ b/tools/mcp/tools.go
@@ -1,0 +1,373 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/erain/glue"
+)
+
+var emptyObjectSchema = json.RawMessage(`{"type":"object","additionalProperties":false}`)
+
+// Options configures an MCP manager. It is intentionally empty for the first
+// stdio/tool-mapping slice so future compatibility options have a stable home.
+type Options struct{}
+
+// Manager owns initialized MCP clients and exposes their discovered tools as
+// ordinary glue tools.
+type Manager struct {
+	clients []*Client
+	tools   []glue.Tool
+}
+
+// NewManager initializes each configured stdio MCP server, discovers its
+// tools, and maps them to glue.Tool values.
+func NewManager(ctx context.Context, configs []ServerConfig, _ Options) (*Manager, error) {
+	m := &Manager{}
+	seen := map[string]struct{}{}
+	for _, cfg := range configs {
+		serverName := strings.TrimSpace(cfg.Name)
+		if serverName == "" {
+			_ = m.Close()
+			return nil, errors.New("mcp: server name is required")
+		}
+		serverPart := sanitizeNamePart(serverName)
+		if serverPart == "" {
+			_ = m.Close()
+			return nil, fmt.Errorf("mcp: server name %q has no valid tool-name characters", cfg.Name)
+		}
+
+		client, err := NewStdioClient(ctx, cfg)
+		if err != nil {
+			_ = m.Close()
+			return nil, fmt.Errorf("mcp: server %q: %w", serverName, err)
+		}
+		m.clients = append(m.clients, client)
+
+		tools, err := listGlueTools(ctx, client, cfg, serverName, serverPart, seen)
+		if err != nil {
+			_ = m.Close()
+			return nil, fmt.Errorf("mcp: server %q: %w", serverName, err)
+		}
+		m.tools = append(m.tools, tools...)
+	}
+	return m, nil
+}
+
+// Tools returns the discovered glue tools.
+func (m *Manager) Tools() []glue.Tool {
+	if m == nil {
+		return nil
+	}
+	return append([]glue.Tool(nil), m.tools...)
+}
+
+// Close releases all MCP client transports owned by the manager.
+func (m *Manager) Close() error {
+	if m == nil {
+		return nil
+	}
+	var errs []error
+	for _, client := range m.clients {
+		if err := client.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type listToolsResult struct {
+	Tools []toolDefinition `json:"tools"`
+}
+
+type toolDefinition struct {
+	Name         string          `json:"name"`
+	Title        string          `json:"title,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	InputSchema  json.RawMessage `json:"inputSchema,omitempty"`
+	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
+	Annotations  map[string]any  `json:"annotations,omitempty"`
+}
+
+type callToolResult struct {
+	Content           []json.RawMessage `json:"content,omitempty"`
+	StructuredContent json.RawMessage   `json:"structuredContent,omitempty"`
+	IsError           bool              `json:"isError,omitempty"`
+}
+
+type callToolParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+func listGlueTools(ctx context.Context, client *Client, cfg ServerConfig, serverName, serverPart string, seen map[string]struct{}) ([]glue.Tool, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeoutFor(cfg))
+	defer cancel()
+
+	var listed listToolsResult
+	if err := client.Request(reqCtx, "tools/list", nil, &listed); err != nil {
+		return nil, err
+	}
+
+	out := make([]glue.Tool, 0, len(listed.Tools))
+	for _, def := range listed.Tools {
+		tool, err := mapTool(client, cfg, serverName, serverPart, def, seen)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
+func mapTool(client *Client, cfg ServerConfig, serverName, serverPart string, def toolDefinition, seen map[string]struct{}) (glue.Tool, error) {
+	originalName := strings.TrimSpace(def.Name)
+	if originalName == "" {
+		return glue.Tool{}, errors.New("mcp: tool name is required")
+	}
+	toolPart := sanitizeNamePart(originalName)
+	if toolPart == "" {
+		return glue.Tool{}, fmt.Errorf("mcp: tool name %q has no valid tool-name characters", originalName)
+	}
+	glueName := "mcp_" + serverPart + "_" + toolPart
+	if _, ok := seen[glueName]; ok {
+		return glue.Tool{}, fmt.Errorf("mcp: tool name collision for %q", glueName)
+	}
+	seen[glueName] = struct{}{}
+
+	schema, err := normalizeSchema(def.InputSchema, "inputSchema", originalName)
+	if err != nil {
+		return glue.Tool{}, err
+	}
+	if len(def.OutputSchema) > 0 {
+		if _, err := normalizeSchema(def.OutputSchema, "outputSchema", originalName); err != nil {
+			return glue.Tool{}, err
+		}
+	}
+
+	remote := remoteTool{
+		client:       client,
+		serverName:   serverName,
+		glueName:     glueName,
+		originalName: originalName,
+		timeout:      timeoutFor(cfg),
+		outputSchema: compactRaw(def.OutputSchema),
+		annotations:  cloneMap(def.Annotations),
+	}
+
+	return glue.Tool{
+		ToolSpec: glue.ToolSpec{
+			Name:               glueName,
+			Description:        toolDescription(serverName, def),
+			Parameters:         schema,
+			RequiresPermission: true,
+			PermissionAction:   "mcp_call",
+			PermissionTarget: func(glue.ToolCall) string {
+				return serverName + "." + originalName
+			},
+		},
+		Execute: remote.execute,
+	}, nil
+}
+
+type remoteTool struct {
+	client       *Client
+	serverName   string
+	glueName     string
+	originalName string
+	timeout      time.Duration
+	outputSchema json.RawMessage
+	annotations  map[string]any
+}
+
+func (t remoteTool) execute(ctx context.Context, call glue.ToolCall) (glue.ToolResult, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+
+	args := json.RawMessage(`{}`)
+	if len(bytes.TrimSpace(call.Arguments)) > 0 {
+		args = call.Arguments
+	}
+
+	var result callToolResult
+	if err := t.client.Request(reqCtx, "tools/call", callToolParams{
+		Name:      t.originalName,
+		Arguments: args,
+	}, &result); err != nil {
+		var rpcErr *RPCError
+		if errors.As(err, &rpcErr) {
+			return glue.ErrorResult(err), nil
+		}
+		return glue.ToolResult{}, err
+	}
+	return t.mapResult(result), nil
+}
+
+func (t remoteTool) mapResult(result callToolResult) glue.ToolResult {
+	metadata := map[string]any{
+		"mcp_server":    t.serverName,
+		"mcp_tool":      t.originalName,
+		"mcp_glue_tool": t.glueName,
+	}
+	if len(t.outputSchema) > 0 {
+		metadata["mcp_output_schema"] = decodeRaw(t.outputSchema)
+	}
+	if len(t.annotations) > 0 {
+		metadata["mcp_annotations"] = t.annotations
+	}
+	if len(result.StructuredContent) > 0 {
+		metadata["mcp_structured_content"] = decodeRaw(result.StructuredContent)
+	}
+
+	content := make([]glue.ContentPart, 0, len(result.Content))
+	var nonText []any
+	var nonTextRaw []json.RawMessage
+	for _, raw := range result.Content {
+		var part struct {
+			Type string `json:"type"`
+			Text string `json:"text,omitempty"`
+		}
+		if err := json.Unmarshal(raw, &part); err != nil {
+			nonText = append(nonText, string(raw))
+			nonTextRaw = append(nonTextRaw, raw)
+			continue
+		}
+		if part.Type == "text" {
+			content = append(content, glue.ContentPart{Type: glue.ContentTypeText, Text: part.Text})
+			continue
+		}
+		nonText = append(nonText, decodeRaw(raw))
+		nonTextRaw = append(nonTextRaw, raw)
+	}
+	if len(nonText) > 0 {
+		metadata["mcp_non_text_content"] = nonText
+	}
+	if len(content) == 0 {
+		if fallback := fallbackContent(result.StructuredContent, nonTextRaw); fallback != "" {
+			content = append(content, glue.ContentPart{Type: glue.ContentTypeText, Text: fallback})
+		}
+	}
+
+	return glue.ToolResult{
+		Content:  content,
+		IsError:  result.IsError,
+		Metadata: metadata,
+	}
+}
+
+func timeoutFor(cfg ServerConfig) time.Duration {
+	if cfg.Timeout > 0 {
+		return cfg.Timeout
+	}
+	return defaultTimeout
+}
+
+func sanitizeNamePart(s string) string {
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range strings.TrimSpace(s) {
+		r = unicode.ToLower(r)
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func normalizeSchema(raw json.RawMessage, field, tool string) (json.RawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return append(json.RawMessage(nil), emptyObjectSchema...), nil
+	}
+	compacted := compactRaw(raw)
+	var obj map[string]any
+	if err := json.Unmarshal(compacted, &obj); err != nil {
+		return nil, fmt.Errorf("mcp: tool %q %s is malformed: %w", tool, field, err)
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("mcp: tool %q %s must be a JSON object", tool, field)
+	}
+	return compacted, nil
+}
+
+func toolDescription(serverName string, def toolDefinition) string {
+	title := strings.TrimSpace(def.Title)
+	desc := strings.TrimSpace(def.Description)
+	switch {
+	case title != "" && desc != "":
+		return fmt.Sprintf("MCP %s/%s: %s", serverName, title, desc)
+	case desc != "":
+		return fmt.Sprintf("MCP %s: %s", serverName, desc)
+	case title != "":
+		return fmt.Sprintf("MCP %s: %s", serverName, title)
+	default:
+		return fmt.Sprintf("MCP tool %s/%s", serverName, def.Name)
+	}
+}
+
+func fallbackContent(structured json.RawMessage, nonText []json.RawMessage) string {
+	if len(structured) > 0 {
+		return string(compactRaw(structured))
+	}
+	if len(nonText) == 1 {
+		return string(compactRaw(nonText[0]))
+	}
+	if len(nonText) > 1 {
+		return compactRawArray(nonText)
+	}
+	return ""
+}
+
+func compactRaw(raw json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return append(json.RawMessage(nil), raw...)
+	}
+	return append(json.RawMessage(nil), buf.Bytes()...)
+}
+
+func compactRawArray(values []json.RawMessage) string {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i, value := range values {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.Write(compactRaw(value))
+	}
+	buf.WriteByte(']')
+	return buf.String()
+}
+
+func decodeRaw(raw json.RawMessage) any {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	return v
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/tools/mcp/tools_test.go
+++ b/tools/mcp/tools_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestManagerExposesMCPTools(t *testing.T) {
+	cfg := helperConfig("tools")
+	cfg.Name = "fake-server"
+	mgr, err := NewManager(context.Background(), []ServerConfig{cfg}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	tool := requireTool(t, mgr.Tools(), "mcp_fake_server_weather_lookup")
+	if !tool.RequiresPermission {
+		t.Fatal("RequiresPermission = false, want true")
+	}
+	if tool.PermissionAction != "mcp_call" {
+		t.Fatalf("PermissionAction = %q, want mcp_call", tool.PermissionAction)
+	}
+	if got := tool.PermissionTarget(glue.ToolCall{}); got != "fake-server.weather.lookup" {
+		t.Fatalf("PermissionTarget = %q", got)
+	}
+	if got := string(tool.Parameters); got != `{"type":"object","properties":{"city":{"type":"string"}},"required":["city"],"additionalProperties":false}` {
+		t.Fatalf("parameters = %s", got)
+	}
+	if !strings.Contains(tool.Description, "fake-server/Weather Lookup") {
+		t.Fatalf("description = %q", tool.Description)
+	}
+
+	result, err := tool.Execute(context.Background(), glue.ToolCall{
+		Name:      tool.Name,
+		Arguments: json.RawMessage(`{"city":"Paris"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("IsError = true")
+	}
+	if len(result.Content) != 1 || result.Content[0].Text != "weather for Paris" {
+		t.Fatalf("content = %#v", result.Content)
+	}
+	if result.Metadata["mcp_server"] != "fake-server" || result.Metadata["mcp_tool"] != "weather.lookup" {
+		t.Fatalf("metadata = %#v", result.Metadata)
+	}
+	structured, ok := result.Metadata["mcp_structured_content"].(map[string]any)
+	if !ok || structured["city"] != "Paris" || structured["temperature_c"].(float64) != 21 {
+		t.Fatalf("structured metadata = %#v", result.Metadata["mcp_structured_content"])
+	}
+	if _, ok := result.Metadata["mcp_output_schema"].(map[string]any); !ok {
+		t.Fatalf("output schema metadata = %#v", result.Metadata["mcp_output_schema"])
+	}
+	if _, ok := result.Metadata["mcp_annotations"].(map[string]any); !ok {
+		t.Fatalf("annotations metadata = %#v", result.Metadata["mcp_annotations"])
+	}
+}
+
+func TestManagerUsesDefaultSchemaAndRendersStructuredFallback(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("tools")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	tool := requireTool(t, mgr.Tools(), "mcp_fake_no_schema")
+	if got := string(tool.Parameters); got != string(emptyObjectSchema) {
+		t.Fatalf("parameters = %s", got)
+	}
+	result, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(result.Content) != 1 || result.Content[0].Text != `{"answer":42}` {
+		t.Fatalf("content = %#v", result.Content)
+	}
+}
+
+func TestManagerMapsNonTextAndToolErrorResults(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("tools")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	imageTool := requireTool(t, mgr.Tools(), "mcp_fake_image_tool")
+	imageResult, err := imageTool.Execute(context.Background(), glue.ToolCall{Name: imageTool.Name})
+	if err != nil {
+		t.Fatalf("image Execute: %v", err)
+	}
+	if len(imageResult.Content) != 1 || !strings.Contains(imageResult.Content[0].Text, `"type":"image"`) {
+		t.Fatalf("image fallback content = %#v", imageResult.Content)
+	}
+	nonText, ok := imageResult.Metadata["mcp_non_text_content"].([]any)
+	if !ok || len(nonText) != 1 {
+		t.Fatalf("non-text metadata = %#v", imageResult.Metadata["mcp_non_text_content"])
+	}
+
+	errorTool := requireTool(t, mgr.Tools(), "mcp_fake_error_tool")
+	errorResult, err := errorTool.Execute(context.Background(), glue.ToolCall{Name: errorTool.Name})
+	if err != nil {
+		t.Fatalf("error Execute: %v", err)
+	}
+	if !errorResult.IsError || len(errorResult.Content) != 1 || errorResult.Content[0].Text != "tool failed" {
+		t.Fatalf("error result = %#v", errorResult)
+	}
+}
+
+func TestManagerMapsRPCErrorToToolResult(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("tools")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	tool := requireTool(t, mgr.Tools(), "mcp_fake_rpc_fail")
+	result, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !result.IsError || len(result.Content) != 1 || !strings.Contains(result.Content[0].Text, "call exploded") {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestManagerRejectsMalformedSchema(t *testing.T) {
+	_, err := NewManager(context.Background(), []ServerConfig{helperConfig("bad_schema")}, Options{})
+	if err == nil || !strings.Contains(err.Error(), "inputSchema") {
+		t.Fatalf("NewManager error = %v, want inputSchema error", err)
+	}
+}
+
+func TestManagerRejectsToolNameCollision(t *testing.T) {
+	_, err := NewManager(context.Background(), []ServerConfig{helperConfig("collision")}, Options{})
+	if err == nil || !strings.Contains(err.Error(), "collision") {
+		t.Fatalf("NewManager error = %v, want collision error", err)
+	}
+}
+
+func requireTool(t *testing.T, tools []glue.Tool, name string) glue.Tool {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("tool %q not found in %#v", name, tools)
+	return glue.Tool{}
+}


### PR DESCRIPTION
## Summary

- add `tools/mcp.Manager` to initialize configured stdio MCP servers, call `tools/list`, and expose discovered tools as `glue.Tool` values
- namespace/sanitize MCP tool names, preserve schemas, and apply default `mcp_call` permission metadata
- map `tools/call` text, structured, non-text, `isError`, and JSON-RPC error responses into deterministic glue tool results
- extend the fake MCP subprocess tests for discovery, calls, schema failures, collisions, permission metadata, and result mapping

## Verification

- `go test ./tools/mcp -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #181.
