### PR TITLE
agents/peggy: register configured MCP servers

### DIFF
--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -128,6 +128,13 @@ and emits a stderr diagnostic.
 | `coding.work_dir` | current directory | Workspace root for `read_file`, `write_file`, `shell_exec`, and git helpers. `~` and `$HOME` expand. |
 | `coding.allowed_binaries` | `go`, `git`, `make`, `node`, `npm`, `python`, `python3` | Basename allowlist for `shell_exec`; model calls cannot run arbitrary paths. |
 | `coding.allow_overwrite` | `false` | Host policy for replacing existing files. The model must still pass `overwrite: true`, and the permission prompt must allow the call. |
+| `mcp.servers.<name>.enabled` | `false` | Register tools from a configured MCP server. Enable only for trusted local servers or explicitly trusted services. |
+| `mcp.servers.<name>.transport` | `stdio` | Only `stdio` is supported today. Streamable HTTP is a planned M4 follow-up. |
+| `mcp.servers.<name>.command` | none | Executable path or basename for stdio MCP servers. This is argv-based, not a shell string. |
+| `mcp.servers.<name>.args` | `[]` | Stdio server argv arguments. |
+| `mcp.servers.<name>.env` | `[]` | Explicit `KEY=value` environment entries passed to the stdio server. Peggy does not inherit the full parent env by default. |
+| `mcp.servers.<name>.work_dir` | current process dir | Working directory for the stdio server. `~` and `$HOME` expand. |
+| `mcp.servers.<name>.timeout_seconds` | `30` | Timeout for initialize, `tools/list`, and individual `tools/call` requests. |
 | `permissions.default_tier` | `prompt` | Permission tier for side-effecting tools when a channel has no override. One of `prompt`, `read_only`, or `trusted`. |
 | `permissions.channels.<name>` | inherited | Channel override keyed by `cli`, `telegram`, or a future daemon client prefix. |
 
@@ -277,6 +284,37 @@ Allow? [y] once, [s] session, [t] target, [n] deny:
 Remembered choices last only for the current `peggy` process. If stdin
 is unavailable or reaches EOF, Peggy denies the side effect and surfaces
 that denial to the model as a tool error.
+
+## MCP Tools
+
+Peggy can register tools from local stdio MCP servers. MCP tools are
+permission-gated by default because the server is external code or a
+remote service boundary: even a tool named `search` may read private
+data, mutate state, exfiltrate content, or spend money.
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "filesystem": {
+        "enabled": true,
+        "transport": "stdio",
+        "command": "mcp-server-filesystem",
+        "args": ["/path/to/workspace"],
+        "env": ["LOG_LEVEL=warn"],
+        "work_dir": "/path/to/workspace",
+        "timeout_seconds": 30
+      }
+    }
+  }
+}
+```
+
+Discovered MCP tools are exposed to the model as namespaced tools such
+as `mcp_filesystem_read_file`. Permission prompts use the existing
+channel tier settings: `prompt` asks the owning client, `read_only`
+denies before execution, and `trusted` allows the call subject to the
+server configuration and timeout.
 
 The permission choices are intentionally small:
 

--- a/agents/peggy/cmd/peggy-telegram/main.go
+++ b/agents/peggy/cmd/peggy-telegram/main.go
@@ -120,7 +120,7 @@ Flags:
 	}
 	var permission *telegram.Permission
 	var agentPermission glue.Permission
-	if settings.Coding.Enabled {
+	if settings.Coding.Enabled || peggy.MCPEnabled(settings.MCP) {
 		permission = telegram.NewPermission(telegram.PermissionOptions{Stderr: stderr})
 		agentPermission = peggy.NewTieredPermission(
 			permission,

--- a/agents/peggy/doc.go
+++ b/agents/peggy/doc.go
@@ -9,11 +9,13 @@
 //     system prompt so the model sees who Peggy is and who you are
 //     on every turn.
 //   - settings.json — JSON config (provider, model, store path,
-//     compaction knobs, coding tools, channels, and permission tiers).
+//     compaction knobs, coding tools, MCP servers, channels, and
+//     permission tiers).
 //
 // v0.3 ships the single-prompt CLI, Telegram channel, durable memory,
-// opt-in local coding tools, and a local HTTP+SSE daemon so terminal
-// and Telegram clients can share one long-running Peggy process.
+// opt-in local coding tools, configured MCP tool servers, and a local
+// HTTP+SSE daemon so terminal and Telegram clients can share one
+// long-running Peggy process.
 // Tracker:
 // https://github.com/erain/glue/issues/110.
 //

--- a/agents/peggy/mcp.go
+++ b/agents/peggy/mcp.go
@@ -1,0 +1,96 @@
+package peggy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/erain/glue"
+	toolsmcp "github.com/erain/glue/tools/mcp"
+)
+
+const defaultMCPTransport = "stdio"
+
+// MCPEnabled reports whether any MCP server is explicitly enabled.
+func MCPEnabled(settings MCPSettings) bool {
+	for _, server := range settings.Servers {
+		if server.Enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// MCPTools initializes Peggy's configured MCP servers and returns their
+// discovered glue tools plus the manager that owns the server lifecycles.
+func MCPTools(ctx context.Context, settings MCPSettings) ([]glue.Tool, *toolsmcp.Manager, MCPSettings, error) {
+	configs, normalized, err := MCPServerConfigs(settings)
+	if err != nil {
+		return nil, nil, normalized, err
+	}
+	if len(configs) == 0 {
+		return nil, nil, normalized, nil
+	}
+	manager, err := toolsmcp.NewManager(ctx, configs, toolsmcp.Options{})
+	if err != nil {
+		return nil, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	return manager.Tools(), manager, normalized, nil
+}
+
+// MCPServerConfigs converts Peggy settings into tools/mcp server configs.
+func MCPServerConfigs(settings MCPSettings) ([]toolsmcp.ServerConfig, MCPSettings, error) {
+	normalized, err := expandMCPSettings(settings)
+	if err != nil {
+		return nil, normalized, err
+	}
+	if len(normalized.Servers) == 0 {
+		return nil, normalized, nil
+	}
+
+	names := make([]string, 0, len(normalized.Servers))
+	for name := range normalized.Servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var configs []toolsmcp.ServerConfig
+	for _, name := range names {
+		server := normalized.Servers[name]
+		transport := strings.ToLower(strings.TrimSpace(server.Transport))
+		if transport == "" {
+			transport = defaultMCPTransport
+			server.Transport = transport
+		}
+		normalized.Servers[name] = server
+		if !server.Enabled {
+			continue
+		}
+		if transport != defaultMCPTransport {
+			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s transport %q is not supported yet", name, server.Transport)
+		}
+		if strings.TrimSpace(server.Command) == "" {
+			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s.command is required", name)
+		}
+		server.Command = strings.TrimSpace(server.Command)
+		if server.TimeoutSeconds < 0 {
+			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s.timeout_seconds must be >= 0", name)
+		}
+		normalized.Servers[name] = server
+
+		cfg := toolsmcp.ServerConfig{
+			Name:    name,
+			Command: server.Command,
+			Args:    append([]string(nil), server.Args...),
+			Env:     append([]string(nil), server.Env...),
+			WorkDir: server.WorkDir,
+		}
+		if server.TimeoutSeconds > 0 {
+			cfg.Timeout = time.Duration(server.TimeoutSeconds) * time.Second
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, normalized, nil
+}

--- a/agents/peggy/mcp_test.go
+++ b/agents/peggy/mcp_test.go
@@ -1,0 +1,306 @@
+package peggy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+	filestore "github.com/erain/glue/stores/file"
+)
+
+func TestLoadSettingsMCPServers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	raw := []byte(`{
+  "store": {"type": "file", "path": "$HOME/sessions"},
+  "mcp": {
+    "servers": {
+      "fake": {
+        "enabled": true,
+        "transport": "stdio",
+        "command": "fake-mcp",
+        "args": ["--root", "$HOME/work"],
+        "env": ["LOG_LEVEL=warn"],
+        "work_dir": "$HOME/work",
+        "timeout_seconds": 7
+      },
+      "future": {
+        "enabled": false,
+        "transport": "http",
+        "url": "https://example.invalid/mcp",
+        "headers_env": {"Authorization": "FAKE_AUTH_HEADER"}
+      }
+    }
+  }
+}`)
+	if err := os.WriteFile(cfgPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	settings, _, err := LoadSettings(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	fake := settings.MCP.Servers["fake"]
+	if !fake.Enabled || fake.Transport != "stdio" || fake.Command != "fake-mcp" {
+		t.Fatalf("fake server = %+v", fake)
+	}
+	if got := fake.WorkDir; got != filepath.Join(home, "work") {
+		t.Fatalf("work_dir = %q", got)
+	}
+	if fake.TimeoutSeconds != 7 || len(fake.Env) != 1 || fake.Env[0] != "LOG_LEVEL=warn" {
+		t.Fatalf("fake server = %+v", fake)
+	}
+	future := settings.MCP.Servers["future"]
+	if future.Enabled || future.Transport != "http" || future.HeadersEnv["Authorization"] != "FAKE_AUTH_HEADER" {
+		t.Fatalf("future server = %+v", future)
+	}
+}
+
+func TestMCPServerConfigsRejectsUnsupportedEnabledTransport(t *testing.T) {
+	_, _, err := MCPServerConfigs(MCPSettings{Servers: map[string]MCPServerSettings{
+		"remote": {Enabled: true, Transport: "http", URL: "https://example.invalid/mcp"},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("MCPServerConfigs error = %v, want unsupported transport", err)
+	}
+}
+
+func TestPeggyRegistersMCPToolsWhenEnabled(t *testing.T) {
+	provider := &fakeProvider{text: "ok"}
+	p := newMCPTestPeggy(t, provider, glue.AllowAll{}, mcpTestServer("tools", ""))
+
+	if _, err := p.Prompt(context.Background(), "s", "what tools are available?", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(provider.requests) == 0 {
+		t.Fatal("provider not called")
+	}
+	var names []string
+	for _, tool := range provider.requests[0].Tools {
+		names = append(names, tool.Name)
+	}
+	if !containsString(names, "mcp_fake_echo") {
+		t.Fatalf("tools = %v, missing mcp_fake_echo", names)
+	}
+}
+
+func TestPeggyMCPToolUsesPermissionPath(t *testing.T) {
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("call_1", "mcp_fake_echo", `{"text":"hi"}`),
+		peggyTextTurn("done"),
+	}}
+	perm := &recordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	p := newMCPTestPeggy(t, provider, perm, mcpTestServer("tools", ""))
+
+	if _, err := p.Prompt(context.Background(), "s", "call echo", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(perm.requests) != 1 {
+		t.Fatalf("permission requests = %d, want 1", len(perm.requests))
+	}
+	req := perm.requests[0]
+	if req.Tool != "mcp_fake_echo" || req.Action != "mcp_call" || req.Target != "fake.echo" {
+		t.Fatalf("permission request = %+v", req)
+	}
+	if string(req.Args) != `{"text":"hi"}` {
+		t.Fatalf("permission args = %s", req.Args)
+	}
+}
+
+func TestPeggyMCPReadOnlyTierDeniesBeforeExecution(t *testing.T) {
+	callFile := filepath.Join(t.TempDir(), "called")
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("call_1", "mcp_fake_echo", `{"text":"hi"}`),
+		peggyTextTurn("done"),
+	}}
+	inner := &recordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	perm := NewTieredPermission(inner, PermissionTierReadOnly, PermissionChannelCLI)
+	p := newMCPTestPeggy(t, provider, perm, mcpTestServerWithFiles("tools", "", callFile))
+
+	if _, err := p.Prompt(context.Background(), "s", "call echo", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(inner.requests) != 0 {
+		t.Fatalf("inner permission requests = %d, want 0", len(inner.requests))
+	}
+	if _, err := os.Stat(callFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("call marker err = %v, want not exist", err)
+	}
+}
+
+func TestPeggyCloseClosesMCPManager(t *testing.T) {
+	closeFile := filepath.Join(t.TempDir(), "closed")
+	p := newMCPTestPeggy(t, &fakeProvider{text: "ok"}, glue.AllowAll{}, mcpTestServer("tools", closeFile))
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if raw, err := os.ReadFile(closeFile); err == nil && string(raw) == "closed" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("close marker %s was not written", closeFile)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func newMCPTestPeggy(t *testing.T, provider glue.Provider, permission glue.Permission, server MCPServerSettings) *Peggy {
+	t.Helper()
+	p, err := New(Options{
+		Settings: Settings{
+			MCP: MCPSettings{Servers: map[string]MCPServerSettings{"fake": server}},
+		},
+		Provider:   provider,
+		Store:      filestore.New(filepath.Join(t.TempDir(), "sessions")),
+		Permission: permission,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func mcpTestServer(scenario, closeFile string) MCPServerSettings {
+	return mcpTestServerWithFiles(scenario, closeFile, "")
+}
+
+func mcpTestServerWithFiles(scenario, closeFile, callFile string) MCPServerSettings {
+	env := []string{
+		"PEGGY_MCP_HELPER=1",
+		"PEGGY_MCP_SCENARIO=" + scenario,
+	}
+	if closeFile != "" {
+		env = append(env, "PEGGY_MCP_CLOSE_FILE="+closeFile)
+	}
+	if callFile != "" {
+		env = append(env, "PEGGY_MCP_CALL_FILE="+callFile)
+	}
+	return MCPServerSettings{
+		Enabled:        true,
+		Transport:      "stdio",
+		Command:        os.Args[0],
+		Args:           []string{"-test.run=TestPeggyMCPHelperProcess", "--"},
+		Env:            env,
+		TimeoutSeconds: 2,
+	}
+}
+
+func TestPeggyMCPHelperProcess(t *testing.T) {
+	if os.Getenv("PEGGY_MCP_HELPER") != "1" {
+		return
+	}
+	closeFile := os.Getenv("PEGGY_MCP_CLOSE_FILE")
+	err := runPeggyMCPHelper()
+	if closeFile != "" {
+		_ = os.WriteFile(closeFile, []byte("closed"), 0o600)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+type peggyMCPHelperRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func runPeggyMCPHelper() error {
+	dec := json.NewDecoder(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+
+	var initReq peggyMCPHelperRequest
+	if err := dec.Decode(&initReq); err != nil {
+		return err
+	}
+	if initReq.Method != "initialize" {
+		return fmt.Errorf("first method = %q, want initialize", initReq.Method)
+	}
+	if err := writePeggyMCPResult(enc, initReq.ID, map[string]any{
+		"protocolVersion": "2025-11-25",
+		"capabilities":    map[string]any{},
+		"serverInfo": map[string]string{
+			"name":    "fake-peggy-mcp",
+			"version": "0.1.0",
+		},
+	}); err != nil {
+		return err
+	}
+
+	var initialized peggyMCPHelperRequest
+	if err := dec.Decode(&initialized); err != nil {
+		return err
+	}
+	if initialized.Method != "notifications/initialized" {
+		return fmt.Errorf("method = %q, want notifications/initialized", initialized.Method)
+	}
+
+	for {
+		var req peggyMCPHelperRequest
+		if err := dec.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		switch req.Method {
+		case "tools/list":
+			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
+				"tools": []map[string]any{{
+					"name":        "echo",
+					"description": "echoes text",
+					"inputSchema": json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}},"additionalProperties":false}`),
+				}},
+			}); err != nil {
+				return err
+			}
+		case "tools/call":
+			if callFile := os.Getenv("PEGGY_MCP_CALL_FILE"); callFile != "" {
+				_ = os.WriteFile(callFile, []byte("called"), 0o600)
+			}
+			var params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments,omitempty"`
+			}
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				return err
+			}
+			if params.Name != "echo" {
+				return fmt.Errorf("tool call name = %q, want echo", params.Name)
+			}
+			text, _ := params.Arguments["text"].(string)
+			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
+				"content": []map[string]any{{"type": "text", "text": text}},
+			}); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+		}
+	}
+}
+
+func writePeggyMCPResult(enc *json.Encoder, id json.RawMessage, result any) error {
+	return enc.Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(id),
+		"result":  result,
+	})
+}

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -42,8 +42,8 @@ type Options struct {
 
 	// Permission answers side-effecting tool requests. Nil means
 	// side-effecting tools are denied by the core loop. The CLI
-	// supplies an interactive implementation when coding tools are
-	// enabled.
+	// supplies an interactive implementation when coding or MCP tools
+	// are enabled.
 	Permission glue.Permission
 
 	// Stderr collects diagnostic warnings (missing SOUL.md etc).
@@ -76,6 +76,8 @@ type Peggy struct {
 	settings Settings
 	soul     string
 	stderr   io.Writer
+
+	mcpManager io.Closer
 }
 
 // New builds a Peggy from the supplied Options. Settings defaults
@@ -152,6 +154,15 @@ func New(opts Options) (*Peggy, error) {
 	}
 	settings.Coding = codingSettings
 	tools = append(tools, codingTools...)
+
+	mcpTools, mcpManager, mcpSettings, err := MCPTools(context.Background(), settings.MCP)
+	if err != nil {
+		return nil, err
+	}
+	settings.MCP = mcpSettings
+	p.settings = settings
+	p.mcpManager = mcpManager
+	tools = append(tools, mcpTools...)
 	tools = append(tools, opts.ExtraTools...)
 
 	p.agent = glue.NewAgent(glue.AgentOptions{
@@ -183,10 +194,14 @@ func (p *Peggy) Close() error {
 	if p == nil {
 		return nil
 	}
-	if closer, ok := p.store.(io.Closer); ok {
-		return closer.Close()
+	var errs []error
+	if p.mcpManager != nil {
+		errs = append(errs, p.mcpManager.Close())
 	}
-	return nil
+	if closer, ok := p.store.(io.Closer); ok {
+		errs = append(errs, closer.Close())
+	}
+	return errors.Join(errs...)
 }
 
 // Prompt runs one turn against the given session id and streams the

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -131,12 +131,14 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 	}
 
 	var permission glue.Permission
-	if settings.Coding.Enabled {
+	if settings.Coding.Enabled || MCPEnabled(settings.MCP) {
 		permission = NewTieredPermission(
 			NewCLIPermission(CLIPermissionOptions{Stdin: stdin, Stderr: stderr}),
 			PermissionTierForChannel(settings.Permissions, PermissionChannelCLI),
 			PermissionChannelCLI,
 		)
+	}
+	if settings.Coding.Enabled {
 		workDir := settings.Coding.WorkDir
 		if strings.TrimSpace(workDir) == "" {
 			workDir = "."

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -40,6 +40,10 @@ type Settings struct {
 	// default; enable only for trusted local workspaces.
 	Coding CodingSettings `json:"coding"`
 
+	// MCP configures external Model Context Protocol servers whose
+	// discovered tools Peggy can register. Disabled by default.
+	MCP MCPSettings `json:"mcp"`
+
 	// Permissions configures Peggy's side-effect permission policy.
 	// Defaults to prompt for every channel.
 	Permissions PermissionSettings `json:"permissions"`
@@ -84,6 +88,26 @@ type CodingSettings struct {
 	// write_file. The model must also pass overwrite=true and the
 	// Permission implementation must allow the call.
 	AllowOverwrite bool `json:"allow_overwrite"`
+}
+
+// MCPSettings configures external MCP tool servers.
+type MCPSettings struct {
+	Servers map[string]MCPServerSettings `json:"servers,omitempty"`
+}
+
+// MCPServerSettings configures one named MCP server. Stdio is the only
+// supported enabled transport for now; HTTP fields are decoded so the
+// settings shape is forward-compatible with ADR-0011.
+type MCPServerSettings struct {
+	Enabled        bool              `json:"enabled"`
+	Transport      string            `json:"transport"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	Env            []string          `json:"env,omitempty"`
+	WorkDir        string            `json:"work_dir,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	HeadersEnv     map[string]string `json:"headers_env,omitempty"`
 }
 
 // PermissionSettings configures Peggy permission tiers. Channel keys are
@@ -156,6 +180,13 @@ func LoadSettings(path string) (Settings, string, error) {
 			return Settings{}, resolved, err
 		}
 		s.Coding.WorkDir = expanded
+	}
+	if len(s.MCP.Servers) > 0 {
+		expanded, err := expandMCPSettings(s.MCP)
+		if err != nil {
+			return Settings{}, resolved, err
+		}
+		s.MCP = expanded
 	}
 	return s, resolved, nil
 }
@@ -231,6 +262,37 @@ func expandPath(p string) (string, error) {
 	p = strings.ReplaceAll(p, "${HOME}", os.Getenv("HOME"))
 	p = strings.ReplaceAll(p, "$HOME", os.Getenv("HOME"))
 	return p, nil
+}
+
+func expandMCPSettings(settings MCPSettings) (MCPSettings, error) {
+	if len(settings.Servers) == 0 {
+		return settings, nil
+	}
+	expanded := MCPSettings{Servers: make(map[string]MCPServerSettings, len(settings.Servers))}
+	for name, server := range settings.Servers {
+		if server.WorkDir != "" {
+			workDir, err := expandPath(server.WorkDir)
+			if err != nil {
+				return MCPSettings{}, fmt.Errorf("peggy: mcp.servers.%s.work_dir: %w", name, err)
+			}
+			server.WorkDir = workDir
+		}
+		if len(server.Args) > 0 {
+			server.Args = append([]string(nil), server.Args...)
+		}
+		if len(server.Env) > 0 {
+			server.Env = append([]string(nil), server.Env...)
+		}
+		if len(server.HeadersEnv) > 0 {
+			headers := make(map[string]string, len(server.HeadersEnv))
+			for header, envName := range server.HeadersEnv {
+				headers[header] = envName
+			}
+			server.HeadersEnv = headers
+		}
+		expanded.Servers[name] = server
+	}
+	return expanded, nil
 }
 
 // fillDefaults applies the documented defaults for any zero-valued


### PR DESCRIPTION
## Summary

- add Peggy `mcp.servers` settings for enabled stdio MCP servers, including work dir expansion, timeout conversion, and clear unsupported-transport errors
- initialize configured MCP servers during `peggy.New`, register discovered MCP tools after coding tools, and close the MCP manager from `Peggy.Close()`
- enable the existing CLI and Telegram permission handlers when MCP tools are configured, even if local coding tools are off
- document MCP stdio settings and trust boundaries in the Peggy README
- add deterministic Peggy-level fake MCP server coverage for settings, registration, permission tiers, and close cleanup

## Verification

- `go test ./agents/peggy ./tools/mcp -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #183.
