### PR TITLE
tools/mcp: add Streamable HTTP transport

### DIFF
--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -129,11 +129,13 @@ and emits a stderr diagnostic.
 | `coding.allowed_binaries` | `go`, `git`, `make`, `node`, `npm`, `python`, `python3` | Basename allowlist for `shell_exec`; model calls cannot run arbitrary paths. |
 | `coding.allow_overwrite` | `false` | Host policy for replacing existing files. The model must still pass `overwrite: true`, and the permission prompt must allow the call. |
 | `mcp.servers.<name>.enabled` | `false` | Register tools from a configured MCP server. Enable only for trusted local servers or explicitly trusted services. |
-| `mcp.servers.<name>.transport` | `stdio` | Only `stdio` is supported today. Streamable HTTP is a planned M4 follow-up. |
+| `mcp.servers.<name>.transport` | `stdio` | `stdio` or Streamable HTTP (`http`). |
 | `mcp.servers.<name>.command` | none | Executable path or basename for stdio MCP servers. This is argv-based, not a shell string. |
 | `mcp.servers.<name>.args` | `[]` | Stdio server argv arguments. |
 | `mcp.servers.<name>.env` | `[]` | Explicit `KEY=value` environment entries passed to the stdio server. Peggy does not inherit the full parent env by default. |
 | `mcp.servers.<name>.work_dir` | current process dir | Working directory for the stdio server. `~` and `$HOME` expand. |
+| `mcp.servers.<name>.url` | none | Streamable HTTP MCP endpoint URL. Required for `transport: "http"`. |
+| `mcp.servers.<name>.headers_env` | `{}` | Map HTTP header names to env var names. Peggy resolves the env vars at startup and does not write secret values back to settings. |
 | `mcp.servers.<name>.timeout_seconds` | `30` | Timeout for initialize, `tools/list`, and individual `tools/call` requests. |
 | `permissions.default_tier` | `prompt` | Permission tier for side-effecting tools when a channel has no override. One of `prompt`, `read_only`, or `trusted`. |
 | `permissions.channels.<name>` | inherited | Channel override keyed by `cli`, `telegram`, or a future daemon client prefix. |
@@ -287,10 +289,11 @@ that denial to the model as a tool error.
 
 ## MCP Tools
 
-Peggy can register tools from local stdio MCP servers. MCP tools are
-permission-gated by default because the server is external code or a
-remote service boundary: even a tool named `search` may read private
-data, mutate state, exfiltrate content, or spend money.
+Peggy can register tools from local stdio MCP servers and Streamable
+HTTP MCP endpoints. MCP tools are permission-gated by default because
+the server is external code or a remote service boundary: even a tool
+named `search` may read private data, mutate state, exfiltrate content,
+or spend money.
 
 ```json
 {
@@ -304,6 +307,26 @@ data, mutate state, exfiltrate content, or spend money.
         "env": ["LOG_LEVEL=warn"],
         "work_dir": "/path/to/workspace",
         "timeout_seconds": 30
+      }
+    }
+  }
+}
+```
+
+For HTTP servers, keep tokens in environment variables and point
+`headers_env` at those variable names:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "linear": {
+        "enabled": true,
+        "transport": "http",
+        "url": "https://example.invalid/mcp",
+        "headers_env": {
+          "Authorization": "LINEAR_MCP_AUTH_HEADER"
+        }
       }
     }
   }

--- a/agents/peggy/mcp.go
+++ b/agents/peggy/mcp.go
@@ -3,6 +3,7 @@ package peggy
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -62,35 +63,72 @@ func MCPServerConfigs(settings MCPSettings) ([]toolsmcp.ServerConfig, MCPSetting
 		transport := strings.ToLower(strings.TrimSpace(server.Transport))
 		if transport == "" {
 			transport = defaultMCPTransport
-			server.Transport = transport
 		}
+		server.Transport = transport
 		normalized.Servers[name] = server
 		if !server.Enabled {
 			continue
 		}
-		if transport != defaultMCPTransport {
-			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s transport %q is not supported yet", name, server.Transport)
-		}
-		if strings.TrimSpace(server.Command) == "" {
-			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s.command is required", name)
-		}
-		server.Command = strings.TrimSpace(server.Command)
 		if server.TimeoutSeconds < 0 {
 			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s.timeout_seconds must be >= 0", name)
 		}
 		normalized.Servers[name] = server
 
 		cfg := toolsmcp.ServerConfig{
-			Name:    name,
-			Command: server.Command,
-			Args:    append([]string(nil), server.Args...),
-			Env:     append([]string(nil), server.Env...),
-			WorkDir: server.WorkDir,
+			Name:      name,
+			Transport: transport,
 		}
 		if server.TimeoutSeconds > 0 {
 			cfg.Timeout = time.Duration(server.TimeoutSeconds) * time.Second
 		}
+		switch transport {
+		case toolsmcp.TransportStdio:
+			if strings.TrimSpace(server.Command) == "" {
+				return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s.command is required", name)
+			}
+			server.Command = strings.TrimSpace(server.Command)
+			normalized.Servers[name] = server
+			cfg.Command = server.Command
+			cfg.Args = append([]string(nil), server.Args...)
+			cfg.Env = append([]string(nil), server.Env...)
+			cfg.WorkDir = server.WorkDir
+		case toolsmcp.TransportHTTP:
+			if strings.TrimSpace(server.URL) == "" {
+				return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s.url is required", name)
+			}
+			cfg.URL = strings.TrimSpace(server.URL)
+			headers, err := resolveMCPHeaders(name, server.HeadersEnv)
+			if err != nil {
+				return nil, normalized, err
+			}
+			cfg.Headers = headers
+		default:
+			return nil, normalized, fmt.Errorf("peggy: mcp.servers.%s transport %q is not supported", name, server.Transport)
+		}
 		configs = append(configs, cfg)
 	}
 	return configs, normalized, nil
+}
+
+func resolveMCPHeaders(serverName string, headersEnv map[string]string) (map[string]string, error) {
+	if len(headersEnv) == 0 {
+		return nil, nil
+	}
+	headers := make(map[string]string, len(headersEnv))
+	for header, envName := range headersEnv {
+		header = strings.TrimSpace(header)
+		envName = strings.TrimSpace(envName)
+		if header == "" {
+			return nil, fmt.Errorf("peggy: mcp.servers.%s.headers_env contains an empty header name", serverName)
+		}
+		if envName == "" {
+			return nil, fmt.Errorf("peggy: mcp.servers.%s.headers_env.%s is empty", serverName, header)
+		}
+		value, ok := os.LookupEnv(envName)
+		if !ok || value == "" {
+			return nil, fmt.Errorf("peggy: mcp.servers.%s.headers_env.%s env var %s is not set", serverName, header, envName)
+		}
+		headers[header] = value
+	}
+	return headers, nil
 }

--- a/agents/peggy/mcp_test.go
+++ b/agents/peggy/mcp_test.go
@@ -68,10 +68,53 @@ func TestLoadSettingsMCPServers(t *testing.T) {
 
 func TestMCPServerConfigsRejectsUnsupportedEnabledTransport(t *testing.T) {
 	_, _, err := MCPServerConfigs(MCPSettings{Servers: map[string]MCPServerSettings{
-		"remote": {Enabled: true, Transport: "http", URL: "https://example.invalid/mcp"},
+		"remote": {Enabled: true, Transport: "ftp", URL: "https://example.invalid/mcp"},
 	}})
 	if err == nil || !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("MCPServerConfigs error = %v, want unsupported transport", err)
+	}
+}
+
+func TestMCPServerConfigsHTTPResolvesHeadersEnv(t *testing.T) {
+	t.Setenv("PEGGY_TEST_MCP_AUTH", "Bearer secret")
+	configs, normalized, err := MCPServerConfigs(MCPSettings{Servers: map[string]MCPServerSettings{
+		"remote": {
+			Enabled:        true,
+			Transport:      "HTTP",
+			URL:            "https://example.invalid/mcp",
+			HeadersEnv:     map[string]string{"Authorization": "PEGGY_TEST_MCP_AUTH"},
+			TimeoutSeconds: 5,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("MCPServerConfigs: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("configs = %d, want 1", len(configs))
+	}
+	cfg := configs[0]
+	if cfg.Transport != "http" || cfg.URL != "https://example.invalid/mcp" || cfg.Headers["Authorization"] != "Bearer secret" {
+		t.Fatalf("config = %+v", cfg)
+	}
+	if normalized.Servers["remote"].Transport != "http" {
+		t.Fatalf("normalized transport = %q", normalized.Servers["remote"].Transport)
+	}
+	if got := normalized.Servers["remote"].HeadersEnv["Authorization"]; got != "PEGGY_TEST_MCP_AUTH" {
+		t.Fatalf("normalized headers_env = %q", got)
+	}
+}
+
+func TestMCPServerConfigsHTTPMissingHeaderEnvErrors(t *testing.T) {
+	_, _, err := MCPServerConfigs(MCPSettings{Servers: map[string]MCPServerSettings{
+		"remote": {
+			Enabled:    true,
+			Transport:  "http",
+			URL:        "https://example.invalid/mcp",
+			HeadersEnv: map[string]string{"Authorization": "PEGGY_TEST_MISSING_AUTH"},
+		},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "PEGGY_TEST_MISSING_AUTH") {
+		t.Fatalf("MCPServerConfigs error = %v, want missing env error", err)
 	}
 }
 

--- a/tools/mcp/client.go
+++ b/tools/mcp/client.go
@@ -15,15 +15,31 @@ const ProtocolVersion = "2025-11-25"
 
 const defaultTimeout = 30 * time.Second
 
+const (
+	// TransportStdio launches an MCP server subprocess over stdin/stdout.
+	TransportStdio = "stdio"
+	// TransportHTTP uses MCP Streamable HTTP against a configured endpoint.
+	TransportHTTP = "http"
+)
+
 // ServerConfig configures one MCP server connection.
 type ServerConfig struct {
 	Name string
+
+	// Transport is "stdio" or "http". Empty means "stdio" for backward
+	// compatibility with the first MCP client slice.
+	Transport string
 
 	// Stdio transport fields. Command is argv[0], never a shell string.
 	Command string
 	Args    []string
 	Env     []string
 	WorkDir string
+
+	// HTTP transport fields. URL is the MCP endpoint. Headers are already
+	// resolved static header values; callers should keep secrets out of logs.
+	URL     string
+	Headers map[string]string
 
 	// Timeout caps lifecycle and request waits when callers do not supply a
 	// tighter context deadline.
@@ -80,10 +96,14 @@ type rpcResponse struct {
 }
 
 type transport interface {
-	Encode(any) error
-	Decode(*rpcResponse) error
+	Request(context.Context, rpcRequest) (rpcResponse, error)
+	Notify(context.Context, rpcRequest) error
 	Close() error
 	Stderr() string
+}
+
+type protocolVersionSetter interface {
+	SetProtocolVersion(string)
 }
 
 // Client is one initialized MCP client session.
@@ -96,6 +116,28 @@ type Client struct {
 	init InitializeResult
 }
 
+// NewClient starts the configured MCP transport and completes lifecycle
+// negotiation. Empty cfg.Transport defaults to stdio.
+func NewClient(ctx context.Context, cfg ServerConfig) (*Client, error) {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	var tr transport
+	var err error
+	switch normalizedTransport(cfg.Transport) {
+	case TransportStdio:
+		tr, err = startStdioTransport(cfg)
+	case TransportHTTP:
+		tr, err = startHTTPTransport(cfg)
+	default:
+		err = fmt.Errorf("mcp: unsupported transport %q", cfg.Transport)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return newInitializedClient(ctx, cfg, tr)
+}
+
 // NewStdioClient starts a stdio MCP server and completes lifecycle
 // negotiation.
 func NewStdioClient(ctx context.Context, cfg ServerConfig) (*Client, error) {
@@ -106,8 +148,24 @@ func NewStdioClient(ctx context.Context, cfg ServerConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &Client{tr: tr}
+	return newInitializedClient(ctx, cfg, tr)
+}
 
+// NewHTTPClient connects to a Streamable HTTP MCP server and completes
+// lifecycle negotiation.
+func NewHTTPClient(ctx context.Context, cfg ServerConfig) (*Client, error) {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	tr, err := startHTTPTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return newInitializedClient(ctx, cfg, tr)
+}
+
+func newInitializedClient(ctx context.Context, cfg ServerConfig, tr transport) (*Client, error) {
+	c := &Client{tr: tr}
 	initCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 	if err := c.initialize(initCtx); err != nil {
@@ -140,44 +198,52 @@ func (c *Client) Request(ctx context.Context, method string, params any, result 
 
 	c.nextID++
 	id := c.nextID
-	if err := c.tr.Encode(rpcRequest{
+	resp, err := c.tr.Request(ctx, rpcRequest{
 		JSONRPC: "2.0",
 		ID:      id,
 		Method:  method,
 		Params:  params,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
-
-	type readResult struct {
-		resp rpcResponse
-		err  error
+	if err := validateResponse(resp, id); err != nil {
+		return err
 	}
-	ch := make(chan readResult, 1)
-	go func() {
-		resp, err := c.readResponse(id)
-		ch <- readResult{resp: resp, err: err}
-	}()
-
-	select {
-	case got := <-ch:
-		if got.err != nil {
-			return got.err
-		}
-		if result == nil {
-			return nil
-		}
-		if len(got.resp.Result) == 0 {
-			return nil
-		}
-		if err := json.Unmarshal(got.resp.Result, result); err != nil {
-			return fmt.Errorf("mcp: decode %s result: %w", method, err)
-		}
+	if result == nil {
 		return nil
-	case <-ctx.Done():
-		_ = c.Close()
-		return ctx.Err()
 	}
+	if len(resp.Result) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(resp.Result, result); err != nil {
+		return fmt.Errorf("mcp: decode %s result: %w", method, err)
+	}
+	return nil
+}
+
+func validateResponse(resp rpcResponse, wantID int64) error {
+	if len(resp.ID) == 0 {
+		return errors.New("mcp: response missing id")
+	}
+	if resp.JSONRPC != "2.0" {
+		return fmt.Errorf("mcp: response jsonrpc = %q, want 2.0", resp.JSONRPC)
+	}
+	if strings.TrimSpace(string(resp.ID)) != fmt.Sprintf("%d", wantID) {
+		return fmt.Errorf("mcp: response id %s, want %d", strings.TrimSpace(string(resp.ID)), wantID)
+	}
+	if resp.Error != nil {
+		return resp.Error
+	}
+	return nil
+}
+
+func normalizedTransport(transport string) string {
+	transport = strings.ToLower(strings.TrimSpace(transport))
+	if transport == "" {
+		return TransportStdio
+	}
+	return transport
 }
 
 // Notify sends a JSON-RPC notification.
@@ -194,7 +260,7 @@ func (c *Client) Notify(ctx context.Context, method string, params any) error {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.tr.Encode(rpcRequest{
+	return c.tr.Notify(ctx, rpcRequest{
 		JSONRPC: "2.0",
 		Method:  method,
 		Params:  params,
@@ -232,31 +298,12 @@ func (c *Client) initialize(ctx context.Context) error {
 	if init.ProtocolVersion != ProtocolVersion {
 		return fmt.Errorf("mcp: incompatible protocol version %q, want %q", init.ProtocolVersion, ProtocolVersion)
 	}
+	if setter, ok := c.tr.(protocolVersionSetter); ok {
+		setter.SetProtocolVersion(init.ProtocolVersion)
+	}
 	if err := c.Notify(ctx, "notifications/initialized", nil); err != nil {
 		return err
 	}
 	c.init = init
 	return nil
-}
-
-func (c *Client) readResponse(wantID int64) (rpcResponse, error) {
-	for {
-		var resp rpcResponse
-		if err := c.tr.Decode(&resp); err != nil {
-			return rpcResponse{}, err
-		}
-		if len(resp.ID) == 0 {
-			continue
-		}
-		if resp.JSONRPC != "2.0" {
-			return rpcResponse{}, fmt.Errorf("mcp: response jsonrpc = %q, want 2.0", resp.JSONRPC)
-		}
-		if strings.TrimSpace(string(resp.ID)) != fmt.Sprintf("%d", wantID) {
-			return rpcResponse{}, fmt.Errorf("mcp: response id %s, want %d", strings.TrimSpace(string(resp.ID)), wantID)
-		}
-		if resp.Error != nil {
-			return rpcResponse{}, resp.Error
-		}
-		return resp, nil
-	}
 }

--- a/tools/mcp/doc.go
+++ b/tools/mcp/doc.go
@@ -1,9 +1,9 @@
 // Package mcp implements the client foundation for consuming Model Context
 // Protocol servers from glue hosts.
 //
-// This package follows ADR-0011. The first implementation supports JSON-RPC
-// lifecycle negotiation over stdio, discovery of MCP server tools, and mapping
-// those tools to permission-gated glue.Tool values. Streamable HTTP, Peggy
-// settings, resources, prompts, sampling, elicitation, and OAuth are deferred
-// follow-up surfaces.
+// This package follows ADR-0011. It supports JSON-RPC lifecycle negotiation
+// over stdio and Streamable HTTP, discovery of MCP server tools, and mapping
+// those tools to permission-gated glue.Tool values. Resources, prompts,
+// sampling, elicitation, OAuth, and dynamic discovery are deferred follow-up
+// surfaces.
 package mcp

--- a/tools/mcp/http.go
+++ b/tools/mcp/http.go
@@ -1,0 +1,198 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+const maxHTTPErrorBodyBytes = 4096
+
+type httpTransport struct {
+	client  *http.Client
+	url     string
+	headers map[string]string
+
+	mu              sync.RWMutex
+	protocolVersion string
+}
+
+func startHTTPTransport(cfg ServerConfig) (*httpTransport, error) {
+	rawURL := strings.TrimSpace(cfg.URL)
+	if rawURL == "" {
+		return nil, errors.New("mcp: http url is required")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: parse http url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("mcp: http url scheme %q is not supported", parsed.Scheme)
+	}
+	headers := make(map[string]string, len(cfg.Headers))
+	for k, v := range cfg.Headers {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			return nil, errors.New("mcp: http header name is required")
+		}
+		headers[key] = v
+	}
+	return &httpTransport{
+		client:  http.DefaultClient,
+		url:     parsed.String(),
+		headers: headers,
+	}, nil
+}
+
+func (t *httpTransport) Request(ctx context.Context, req rpcRequest) (rpcResponse, error) {
+	return t.post(ctx, req, true)
+}
+
+func (t *httpTransport) Notify(ctx context.Context, req rpcRequest) error {
+	resp, err := t.post(ctx, req, false)
+	if err != nil {
+		return err
+	}
+	if resp.Error != nil {
+		return resp.Error
+	}
+	return nil
+}
+
+func (t *httpTransport) Close() error { return nil }
+
+func (t *httpTransport) Stderr() string { return "" }
+
+func (t *httpTransport) SetProtocolVersion(version string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.protocolVersion = version
+}
+
+func (t *httpTransport) post(ctx context.Context, msg rpcRequest, expectResponse bool) (rpcResponse, error) {
+	if t == nil || t.client == nil {
+		return rpcResponse{}, errors.New("mcp: nil http transport")
+	}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(msg); err != nil {
+		return rpcResponse{}, fmt.Errorf("mcp: encode http message: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, &body)
+	if err != nil {
+		return rpcResponse{}, fmt.Errorf("mcp: build http request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	if version := t.currentProtocolVersion(); version != "" {
+		req.Header.Set("MCP-Protocol-Version", version)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return rpcResponse{}, fmt.Errorf("mcp: http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, maxHTTPErrorBodyBytes))
+		detail := strings.TrimSpace(string(raw))
+		if detail != "" {
+			return rpcResponse{}, fmt.Errorf("mcp: http status %s: %s", resp.Status, detail)
+		}
+		return rpcResponse{}, fmt.Errorf("mcp: http status %s", resp.Status)
+	}
+	if resp.StatusCode == http.StatusAccepted && !expectResponse {
+		return rpcResponse{}, nil
+	}
+
+	mediaType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if mediaType == "" {
+		return rpcResponse{}, errors.New("mcp: http response missing content type")
+	}
+	mediaType, _, err = mime.ParseMediaType(mediaType)
+	if err != nil {
+		return rpcResponse{}, fmt.Errorf("mcp: parse http content type: %w", err)
+	}
+	switch mediaType {
+	case "application/json":
+		if !expectResponse && resp.ContentLength == 0 {
+			return rpcResponse{}, nil
+		}
+		var out rpcResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			if !expectResponse && errors.Is(err, io.EOF) {
+				return rpcResponse{}, nil
+			}
+			return rpcResponse{}, fmt.Errorf("mcp: decode http json response: %w", err)
+		}
+		return out, nil
+	case "text/event-stream":
+		return readSSEResponse(resp.Body)
+	default:
+		return rpcResponse{}, fmt.Errorf("mcp: unsupported http content type %q", mediaType)
+	}
+}
+
+func (t *httpTransport) currentProtocolVersion() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.protocolVersion
+}
+
+func readSSEResponse(r io.Reader) (rpcResponse, error) {
+	scanner := bufio.NewScanner(r)
+	var data []string
+	flush := func() (rpcResponse, bool, error) {
+		if len(data) == 0 {
+			return rpcResponse{}, false, nil
+		}
+		payload := strings.Join(data, "\n")
+		data = nil
+		if strings.TrimSpace(payload) == "" {
+			return rpcResponse{}, false, nil
+		}
+		var resp rpcResponse
+		if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+			return rpcResponse{}, false, fmt.Errorf("mcp: decode http sse response: %w", err)
+		}
+		return resp, true, nil
+	}
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if line == "" {
+			if resp, ok, err := flush(); ok || err != nil {
+				return resp, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			value := strings.TrimPrefix(line, "data:")
+			if strings.HasPrefix(value, " ") {
+				value = strings.TrimPrefix(value, " ")
+			}
+			data = append(data, value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return rpcResponse{}, fmt.Errorf("mcp: read http sse response: %w", err)
+	}
+	if resp, ok, err := flush(); ok || err != nil {
+		return resp, err
+	}
+	return rpcResponse{}, errors.New("mcp: http sse response contained no data")
+}

--- a/tools/mcp/http_test.go
+++ b/tools/mcp/http_test.go
@@ -1,0 +1,217 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+func TestHTTPManagerDiscoversAndCallsTools(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	var missingProtocol []string
+	var authFailures []string
+	var initializeProtocol string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var req httpTestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		methods = append(methods, req.Method)
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			authFailures = append(authFailures, req.Method+":"+got)
+		}
+		if req.Method == "initialize" {
+			initializeProtocol = r.Header.Get("MCP-Protocol-Version")
+		} else if got := r.Header.Get("MCP-Protocol-Version"); got != ProtocolVersion {
+			missingProtocol = append(missingProtocol, req.Method+":"+got)
+		}
+		mu.Unlock()
+
+		switch req.Method {
+		case "initialize":
+			writeHTTPJSON(t, w, req.ID, initializeResult(ProtocolVersion))
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeHTTPJSON(t, w, req.ID, map[string]any{
+				"tools": []map[string]any{{
+					"name":        "echo",
+					"description": "echoes text",
+					"inputSchema": json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}}}`),
+				}},
+			})
+		case "tools/call":
+			var params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments,omitempty"`
+			}
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				t.Errorf("decode params: %v", err)
+			}
+			writeHTTPJSON(t, w, req.ID, map[string]any{
+				"content": []map[string]any{{"type": "text", "text": params.Arguments["text"]}},
+			})
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	mgr, err := NewManager(context.Background(), []ServerConfig{{
+		Name:      "remote",
+		Transport: TransportHTTP,
+		URL:       srv.URL,
+		Headers:   map[string]string{"Authorization": "Bearer test-token"},
+		Timeout:   2 * time.Second,
+	}}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	tool := requireHTTPTool(t, mgr.Tools(), "mcp_remote_echo")
+	result, err := tool.Execute(context.Background(), glue.ToolCall{
+		Name:      tool.Name,
+		Arguments: json.RawMessage(`{"text":"hello"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(result.Content) != 1 || result.Content[0].Text != "hello" {
+		t.Fatalf("result = %#v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if initializeProtocol != "" {
+		t.Fatalf("initialize protocol header = %q, want empty", initializeProtocol)
+	}
+	if len(missingProtocol) != 0 {
+		t.Fatalf("missing protocol headers: %v", missingProtocol)
+	}
+	if len(authFailures) != 0 {
+		t.Fatalf("auth header failures: %v", authFailures)
+	}
+	for _, want := range []string{"initialize", "notifications/initialized", "tools/list", "tools/call"} {
+		if !containsMethod(methods, want) {
+			t.Fatalf("methods = %v, missing %s", methods, want)
+		}
+	}
+}
+
+func TestHTTPTransportParsesSSEResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req httpTestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		switch req.Method {
+		case "initialize":
+			writeHTTPJSON(t, w, req.ID, initializeResult(ProtocolVersion))
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			w.Header().Set("Content-Type", "text/event-stream")
+			payload := jsonRPCResponse(req.ID, map[string]any{
+				"tools": []map[string]any{{"name": "sse_tool"}},
+			})
+			raw, _ := json.Marshal(payload)
+			_, _ = w.Write([]byte("event: message\n"))
+			_, _ = w.Write([]byte("data: " + string(raw) + "\n\n"))
+		default:
+			t.Errorf("unexpected method %q", req.Method)
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	mgr, err := NewManager(context.Background(), []ServerConfig{{
+		Name:      "sse",
+		Transport: TransportHTTP,
+		URL:       srv.URL,
+		Timeout:   2 * time.Second,
+	}}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+	requireHTTPTool(t, mgr.Tools(), "mcp_sse_sse_tool")
+}
+
+func TestHTTPClientRejectsInvalidContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	_, err := NewHTTPClient(context.Background(), ServerConfig{
+		Name:    "bad",
+		URL:     srv.URL,
+		Timeout: time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported http content type") {
+		t.Fatalf("NewHTTPClient error = %v, want content-type error", err)
+	}
+}
+
+type httpTestRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func writeHTTPJSON(t *testing.T, w http.ResponseWriter, id json.RawMessage, result any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(jsonRPCResponse(id, result)); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func jsonRPCResponse(id json.RawMessage, result any) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      json.RawMessage(id),
+		"result":  result,
+	}
+}
+
+func requireHTTPTool(t *testing.T, tools []glue.Tool, name string) glue.Tool {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("tool %q not found in %#v", name, tools)
+	return glue.Tool{}
+}
+
+func containsMethod(methods []string, want string) bool {
+	for _, method := range methods {
+		if method == want {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/mcp/stdio.go
+++ b/tools/mcp/stdio.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,7 +77,36 @@ func startStdioTransport(cfg ServerConfig) (*stdioTransport, error) {
 	return tr, nil
 }
 
-func (t *stdioTransport) Encode(v any) error {
+func (t *stdioTransport) Request(ctx context.Context, req rpcRequest) (rpcResponse, error) {
+	if err := t.encode(req); err != nil {
+		return rpcResponse{}, err
+	}
+	type readResult struct {
+		resp rpcResponse
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		resp, err := t.readResponse()
+		ch <- readResult{resp: resp, err: err}
+	}()
+	select {
+	case got := <-ch:
+		return got.resp, got.err
+	case <-ctx.Done():
+		_ = t.Close()
+		return rpcResponse{}, ctx.Err()
+	}
+}
+
+func (t *stdioTransport) Notify(ctx context.Context, req rpcRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return t.encode(req)
+}
+
+func (t *stdioTransport) encode(v any) error {
 	if t == nil || t.enc == nil {
 		return errors.New("mcp: nil stdio transport")
 	}
@@ -86,14 +116,20 @@ func (t *stdioTransport) Encode(v any) error {
 	return nil
 }
 
-func (t *stdioTransport) Decode(resp *rpcResponse) error {
+func (t *stdioTransport) readResponse() (rpcResponse, error) {
 	if t == nil || t.dec == nil {
-		return errors.New("mcp: nil stdio transport")
+		return rpcResponse{}, errors.New("mcp: nil stdio transport")
 	}
-	if err := t.dec.Decode(resp); err != nil {
-		return fmt.Errorf("mcp: read stdio message: %w", err)
+	for {
+		var resp rpcResponse
+		if err := t.dec.Decode(&resp); err != nil {
+			return rpcResponse{}, fmt.Errorf("mcp: read stdio message: %w", err)
+		}
+		if len(resp.ID) == 0 {
+			continue
+		}
+		return resp, nil
 	}
-	return nil
 }
 
 func (t *stdioTransport) Close() error {

--- a/tools/mcp/tools.go
+++ b/tools/mcp/tools.go
@@ -26,8 +26,8 @@ type Manager struct {
 	tools   []glue.Tool
 }
 
-// NewManager initializes each configured stdio MCP server, discovers its
-// tools, and maps them to glue.Tool values.
+// NewManager initializes each configured MCP server, discovers its tools, and
+// maps them to glue.Tool values.
 func NewManager(ctx context.Context, configs []ServerConfig, _ Options) (*Manager, error) {
 	m := &Manager{}
 	seen := map[string]struct{}{}
@@ -43,7 +43,7 @@ func NewManager(ctx context.Context, configs []ServerConfig, _ Options) (*Manage
 			return nil, fmt.Errorf("mcp: server name %q has no valid tool-name characters", cfg.Name)
 		}
 
-		client, err := NewStdioClient(ctx, cfg)
+		client, err := NewClient(ctx, cfg)
 		if err != nil {
 			_ = m.Close()
 			return nil, fmt.Errorf("mcp: server %q: %w", serverName, err)


### PR DESCRIPTION
## Summary

- add transport selection to `tools/mcp.ServerConfig` while preserving stdio as the default
- refactor the client transport boundary so stdio and Streamable HTTP share lifecycle, `tools/list`, and `tools/call` mapping
- implement Streamable HTTP POST transport with JSON and SSE response parsing, static headers, request contexts, and `MCP-Protocol-Version` after initialization
- let Peggy enable HTTP MCP servers by resolving `headers_env` into static headers without storing secret values in normalized settings
- document HTTP MCP settings and add deterministic `httptest` plus Peggy settings coverage

## Verification

- `go test ./tools/mcp ./agents/peggy -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check -- . ':!.gitignore'`
- `env -u NVIDIA_API_KEY go test ./...`

Closes #185.
