### PR TITLE
daemon: expose hosted tool catalog

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -97,6 +97,26 @@ func NewAgent(options AgentOptions) *Agent {
 	}
 }
 
+// ToolCatalog returns a cloned provider-visible catalog of the agent's
+// configured tools, including permission metadata for hosts that need to
+// display or expose the tool surface without starting a session.
+func (a *Agent) ToolCatalog() []ToolSpec {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	tools := cloneTools(a.tools)
+	if len(tools) == 0 {
+		return nil
+	}
+	specs := make([]ToolSpec, len(tools))
+	for i, tool := range tools {
+		specs[i] = tool.ToolSpec
+	}
+	return specs
+}
+
 func rolesFromSlice(roles []Role) map[string]Role {
 	if len(roles) == 0 {
 		return nil

--- a/agent_test.go
+++ b/agent_test.go
@@ -2,6 +2,7 @@ package glue
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -329,6 +330,38 @@ func TestAgentSessionReusesByID(t *testing.T) {
 	second, _ := agent.Session(context.Background(), "abc")
 	if first != second {
 		t.Fatal("Session(id) returned different instances on second call")
+	}
+}
+
+func TestAgentToolCatalogClonesToolSpecs(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(AgentOptions{
+		Tools: []Tool{{
+			ToolSpec: ToolSpec{
+				Name:               "demo",
+				Description:        "demo tool",
+				Parameters:         json.RawMessage(`{"type":"object"}`),
+				RequiresPermission: true,
+				PermissionAction:   "demo_action",
+				PermissionTarget: func(call ToolCall) string {
+					return "target:" + call.Name
+				},
+			},
+		}},
+	})
+
+	catalog := agent.ToolCatalog()
+	if len(catalog) != 1 {
+		t.Fatalf("catalog len = %d, want 1", len(catalog))
+	}
+	if catalog[0].Name != "demo" || catalog[0].PermissionAction != "demo_action" || catalog[0].PermissionTarget(ToolCall{Name: "demo"}) != "target:demo" {
+		t.Fatalf("catalog[0] = %+v", catalog[0])
+	}
+	catalog[0].Parameters[0] = '['
+	again := agent.ToolCatalog()
+	if string(again[0].Parameters) != `{"type":"object"}` {
+		t.Fatalf("catalog parameters were aliased: %s", string(again[0].Parameters))
 	}
 }
 

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -28,6 +28,12 @@ type Host interface {
 	Session(ctx context.Context, id string, options ...glue.SessionOption) (*glue.Session, error)
 }
 
+// ToolCatalogHost is optionally implemented by hosts that can expose the
+// provider-visible tool surface without starting a run.
+type ToolCatalogHost interface {
+	ToolCatalog() []glue.ToolSpec
+}
+
 // Options configures [New].
 type Options struct {
 	// Host is required. A *glue.Agent satisfies this interface.
@@ -170,6 +176,19 @@ type permissionDecisionResponse struct {
 	Accepted     bool   `json:"accepted"`
 }
 
+type toolCatalogResponse struct {
+	Tools []toolCatalogEntry `json:"tools"`
+}
+
+type toolCatalogEntry struct {
+	Name                    string          `json:"name"`
+	Description             string          `json:"description,omitempty"`
+	Parameters              json.RawMessage `json:"parameters,omitempty"`
+	RequiresPermission      bool            `json:"requires_permission"`
+	PermissionAction        string          `json:"permission_action,omitempty"`
+	PermissionTargetPreview string          `json:"permission_target_preview,omitempty"`
+}
+
 // New constructs a daemon Server.
 func New(opts Options) (*Server, error) {
 	if opts.Host == nil {
@@ -217,6 +236,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if !s.authorized(r) {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "missing or invalid bearer token", false)
+		return
+	}
+
+	if r.URL.Path == "/v1/tools" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleTools(w, r)
 		return
 	}
 
@@ -290,6 +318,30 @@ func (s *Server) handleStartRun(w http.ResponseWriter, r *http.Request, sessionI
 		SessionID: sessionID,
 		EventsURL: "/v1/runs/" + url.PathEscape(run.id) + "/events",
 	})
+}
+
+func (s *Server) handleTools(w http.ResponseWriter, _ *http.Request) {
+	host, ok := s.host.(ToolCatalogHost)
+	if !ok {
+		writeJSON(w, http.StatusOK, toolCatalogResponse{Tools: []toolCatalogEntry{}})
+		return
+	}
+	specs := host.ToolCatalog()
+	tools := make([]toolCatalogEntry, 0, len(specs))
+	for _, spec := range specs {
+		entry := toolCatalogEntry{
+			Name:               spec.Name,
+			Description:        spec.Description,
+			Parameters:         append(json.RawMessage(nil), spec.Parameters...),
+			RequiresPermission: spec.RequiresPermission,
+			PermissionAction:   spec.PermissionAction,
+		}
+		if spec.PermissionTarget != nil {
+			entry.PermissionTargetPreview = spec.PermissionTarget(glue.ToolCall{Name: spec.Name})
+		}
+		tools = append(tools, entry)
+	}
+	writeJSON(w, http.StatusOK, toolCatalogResponse{Tools: tools})
 }
 
 func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, req startRunRequest) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -71,6 +71,12 @@ func (p *blockingProvider) Stream(ctx context.Context, _ glue.ProviderRequest) (
 	return ch, nil
 }
 
+type sessionOnlyHost struct{}
+
+func (sessionOnlyHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
 func TestServerAuthAndHealth(t *testing.T) {
 	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
 	ts := httptest.NewServer(srv)
@@ -95,6 +101,75 @@ func TestServerAuthAndHealth(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("bad token status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestServerToolsCatalog(t *testing.T) {
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: scriptedProvider{},
+		Tools: []glue.Tool{{
+			ToolSpec: glue.ToolSpec{
+				Name:               "demo_tool",
+				Description:        "Demo tool",
+				Parameters:         json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`),
+				RequiresPermission: true,
+				PermissionAction:   "demo_action",
+				PermissionTarget: func(call glue.ToolCall) string {
+					return "target:" + call.Name
+				},
+			},
+		}},
+	})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/tools", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/tools", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var catalog toolCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Tools) != 1 {
+		t.Fatalf("catalog len = %d, want 1", len(catalog.Tools))
+	}
+	tool := catalog.Tools[0]
+	if tool.Name != "demo_tool" || tool.Description != "Demo tool" || tool.PermissionAction != "demo_action" || tool.PermissionTargetPreview != "target:demo_tool" {
+		t.Fatalf("tool = %+v", tool)
+	}
+	if !tool.RequiresPermission {
+		t.Fatal("RequiresPermission = false, want true")
+	}
+	if !strings.Contains(string(tool.Parameters), `"name"`) {
+		t.Fatalf("parameters = %s", string(tool.Parameters))
+	}
+}
+
+func TestServerToolsCatalogUnsupportedHost(t *testing.T) {
+	srv := newTestServer(t, sessionOnlyHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/tools", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var catalog toolCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Tools) != 0 {
+		t.Fatalf("catalog = %+v, want empty", catalog.Tools)
 	}
 }
 
@@ -607,6 +682,22 @@ func postJSON(t *testing.T, url, token, body string) *http.Response {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func getJSON(t *testing.T, url, token string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}

--- a/docs/adr/0010-daemon-protocol.md
+++ b/docs/adr/0010-daemon-protocol.md
@@ -129,7 +129,36 @@ The daemon must never log bearer tokens, provider keys, Telegram bot
 tokens, or raw permission args unless a future explicit debug flag says
 so.
 
-### 4. Runs and sessions
+### 4. Tool catalog
+
+Daemon clients can inspect the hosted agent's current tool surface:
+
+```http
+GET /v1/tools
+```
+
+Response:
+
+```json
+{
+  "tools": [
+    {
+      "name": "mcp_filesystem_read_file",
+      "description": "MCP filesystem: Read a file",
+      "parameters": { "type": "object" },
+      "requires_permission": true,
+      "permission_action": "mcp_call",
+      "permission_target_preview": "filesystem.read_file"
+    }
+  ]
+}
+```
+
+`permission_target_preview` is best-effort because some local tools
+derive the final target from call arguments. Hosts that do not expose a
+catalog return an empty `tools` array.
+
+### 5. Runs and sessions
 
 A prompt run is started with:
 
@@ -179,7 +208,7 @@ The underlying `glue.Session` already serializes one prompt at a time
 per session. The daemon may accept concurrent runs for different
 sessions, but same-session runs are serialized by the session lock.
 
-### 5. Event envelope
+### 6. Event envelope
 
 Every SSE message uses the event type as the SSE `event:` name and a
 JSON envelope in `data:`.
@@ -226,7 +255,7 @@ others are loop events.
 it today. Providers may emit thinking internally, and a future
 additive loop event can map to this protocol name.
 
-### 6. Permission flow
+### 7. Permission flow
 
 The daemon installs a `glue.Permission` implementation for the hosted
 agent. That implementation does not decide policy itself. It brokers a
@@ -300,7 +329,7 @@ Safe defaults:
 This mirrors v0.2's CLI and Telegram behavior: side effects never run
 because a UI disappeared.
 
-### 7. Cancellation and disconnects
+### 8. Cancellation and disconnects
 
 The run owner can cancel with:
 
@@ -317,7 +346,7 @@ keeps resource ownership simple for terminal clients. Detached
 background runs are a future additive feature and will need replay or
 query endpoints.
 
-### 8. Error envelope
+### 9. Error envelope
 
 HTTP errors use:
 
@@ -344,7 +373,7 @@ Initial v1 codes:
 
 `run_error` SSE events use the same shape in `payload.error`.
 
-### 9. Session lookup
+### 10. Session lookup
 
 M3 needs enough session lookup for clients to render history and switch
 sessions:
@@ -359,7 +388,7 @@ The search route maps to existing `Agent.SearchSessions` when the
 store implements it. Prefix search for channel ids remains a store
 follow-up; v1 may support exact session id filters first.
 
-### 10. Consequences
+### 11. Consequences
 
 - Core `glue` does not gain channel concepts or UI policy.
 - Permission UX remains in the client: CLI can render `[y/s/t/n]`,


### PR DESCRIPTION
## Summary
- adds `Agent.ToolCatalog()` to return cloned tool specs with permission metadata
- adds authenticated `GET /v1/tools` to the daemon protocol
- documents the route in ADR-0010

## Product impact
Daemon clients can now inspect the hosted agent's available tools and permission metadata before starting a run. That gives future OpenClaw-style UIs a direct way to render Peggy status and tool surfaces without shelling out to `peggy mcp tools`.

## Validation
- `go test . -run TestAgentToolCatalogClonesToolSpecs -count=1`
- `go test ./daemon -run 'TestServerToolsCatalog|TestServerAuthAndHealth|TestServerStartsRunAndStreamsEvents' -count=1`
- `go test . ./daemon -count=1`
- `git diff --check -- agent.go agent_test.go daemon/server.go daemon/server_test.go docs/adr/0010-daemon-protocol.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
