### PR TITLE
daemon: add runtime status endpoint

### DIFF
--- a/daemon/run.go
+++ b/daemon/run.go
@@ -56,6 +56,12 @@ func (r *run) finish() {
 	r.signalLocked()
 }
 
+func (r *run) isDone() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
 func (r *run) eventsFrom(index int) ([]EventEnvelope, bool, <-chan struct{}) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -176,6 +176,14 @@ type permissionDecisionResponse struct {
 	Accepted     bool   `json:"accepted"`
 }
 
+type statusResponse struct {
+	OK           bool     `json:"ok"`
+	Version      int      `json:"version"`
+	ActiveRuns   int      `json:"active_runs"`
+	ToolsCount   int      `json:"tools_count"`
+	Capabilities []string `json:"capabilities"`
+}
+
 type toolCatalogResponse struct {
 	Tools []toolCatalogEntry `json:"tools"`
 }
@@ -239,6 +247,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/v1/status" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleStatus(w, r)
+		return
+	}
+
 	if r.URL.Path == "/v1/tools" {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
@@ -291,6 +308,26 @@ func (s *Server) authorized(r *http.Request) bool {
 	want := "Bearer " + s.token
 	got := r.Header.Get("Authorization")
 	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	toolsCount := 0
+	if host, ok := s.host.(ToolCatalogHost); ok {
+		toolsCount = len(host.ToolCatalog())
+	}
+	writeJSON(w, http.StatusOK, statusResponse{
+		OK:         true,
+		Version:    protocolVersion,
+		ActiveRuns: s.activeRunCount(),
+		ToolsCount: toolsCount,
+		Capabilities: []string{
+			"runs",
+			"events",
+			"permissions",
+			"tools",
+			"status",
+		},
+	})
 }
 
 func (s *Server) handleStartRun(w http.ResponseWriter, r *http.Request, sessionID string) {
@@ -490,6 +527,18 @@ func (s *Server) getRun(id string) *run {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.runs[id]
+}
+
+func (s *Server) activeRunCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var count int
+	for _, run := range s.runs {
+		if run != nil && !run.isDone() {
+			count++
+		}
+	}
+	return count
 }
 
 func parseStartRunPath(path string) (string, bool) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -173,6 +173,86 @@ func TestServerToolsCatalogUnsupportedHost(t *testing.T) {
 	}
 }
 
+func TestServerStatus(t *testing.T) {
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider: scriptedProvider{},
+		Tools: []glue.Tool{{
+			ToolSpec: glue.ToolSpec{Name: "demo_tool"},
+		}},
+	})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/status", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var status statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.OK || status.Version != protocolVersion || status.ActiveRuns != 0 || status.ToolsCount != 1 {
+		t.Fatalf("status = %+v", status)
+	}
+	for _, want := range []string{"runs", "events", "permissions", "tools", "status"} {
+		if !contains(status.Capabilities, want) {
+			t.Fatalf("capabilities = %v, missing %q", status.Capabilities, want)
+		}
+	}
+}
+
+func TestServerStatusCountsActiveRuns(t *testing.T) {
+	provider := &blockingProvider{started: make(chan struct{}), canceled: make(chan struct{})}
+	agent := glue.NewAgent(glue.AgentOptions{Provider: provider})
+	srv := newTestServer(t, agent)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := startRun(t, ts.URL, "default")
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for run start")
+	}
+
+	resp := getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var status statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status.ActiveRuns != 1 {
+		t.Fatalf("active_runs = %d, want 1", status.ActiveRuns)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/runs/"+start.RunID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	cancelResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelResp.Body.Close()
+	select {
+	case <-provider.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cancellation")
+	}
+}
+
 func TestServerStartsRunAndStreamsEvents(t *testing.T) {
 	agent := glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{events: []glue.ProviderEvent{
 		{Type: glue.ProviderEventStart},

--- a/docs/adr/0010-daemon-protocol.md
+++ b/docs/adr/0010-daemon-protocol.md
@@ -129,7 +129,28 @@ The daemon must never log bearer tokens, provider keys, Telegram bot
 tokens, or raw permission args unless a future explicit debug flag says
 so.
 
-### 4. Tool catalog
+### 4. Status and tool catalog
+
+Daemon clients can inspect authenticated runtime status:
+
+```http
+GET /v1/status
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "version": 1,
+  "active_runs": 0,
+  "tools_count": 4,
+  "capabilities": ["runs", "events", "permissions", "tools", "status"]
+}
+```
+
+`GET /v1/health` remains unauthenticated and intentionally minimal;
+`GET /v1/status` is for clients that already have daemon credentials.
 
 Daemon clients can inspect the hosted agent's current tool surface:
 


### PR DESCRIPTION
## Summary
- adds authenticated `GET /v1/status` with protocol version, active run count, tool count, and capability flags
- keeps unauthenticated `/v1/health` unchanged
- documents status in ADR-0010

## Product impact
Clients and future OpenClaw-style UIs can now distinguish basic daemon liveness from authenticated runtime/capability status. This complements `/v1/tools` and gives UI clients a cheap startup probe.

## Validation
- `go test ./daemon -run 'TestServerStatus|TestServerToolsCatalog|TestServerAuthAndHealth|TestServerStartsRunAndStreamsEvents' -count=1`
- `go test ./daemon -count=1`
- `git diff --check -- daemon/server.go daemon/server_test.go daemon/run.go docs/adr/0010-daemon-protocol.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
