### PR TITLE
cmd/glue: render daemon status from connect

### DIFF
--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -108,6 +108,14 @@ type daemonToolCatalogEntry struct {
 	PermissionTargetPreview string          `json:"permission_target_preview,omitempty"`
 }
 
+type daemonStatus struct {
+	OK           bool     `json:"ok"`
+	Version      int      `json:"version"`
+	ActiveRuns   int      `json:"active_runs"`
+	ToolsCount   int      `json:"tools_count"`
+	Capabilities []string `json:"capabilities"`
+}
+
 type connectPermissionPayload struct {
 	PermissionID string                 `json:"permission_id"`
 	Request      glue.PermissionRequest `json:"request"`
@@ -309,6 +317,8 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	maxTurns := flags.Int("max-turns", 0, "per-run loop turn budget")
 	showTools := flags.Bool("tools", false, "list daemon tools and exit without starting a run")
 	toolsJSON := flags.Bool("tools-json", false, "print --tools output as JSON")
+	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
+	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
 
@@ -318,7 +328,13 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *toolsJSON {
 		*showTools = true
 	}
-	if !*showTools && strings.TrimSpace(*prompt) == "" {
+	if *statusJSON {
+		*showStatus = true
+	}
+	if *showTools && *showStatus {
+		return errors.New("choose only one of --tools or --status")
+	}
+	if !*showTools && !*showStatus && strings.TrimSpace(*prompt) == "" {
 		return errors.New("missing required --prompt")
 	}
 	if err := loadEnvFiles(envs); err != nil {
@@ -340,6 +356,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showTools {
 		return runConnectTools(ctx, cfg, *toolsJSON, stdout, client)
+	}
+	if *showStatus {
+		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
 	}
 	return runConnect(ctx, cfg, stdin, stdout, stderr, client)
 }
@@ -418,6 +437,55 @@ func runConnectTools(ctx context.Context, cfg connectConfig, jsonOutput bool, st
 	}
 	writeDaemonToolCatalog(stdout, catalog.Tools)
 	return nil
+}
+
+func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	status, err := fetchDaemonStatus(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(status)
+	}
+	writeDaemonStatus(stdout, status)
+	return nil
+}
+
+func fetchDaemonStatus(ctx context.Context, cfg connectConfig, client httpDoer) (daemonStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/status", nil)
+	if err != nil {
+		return daemonStatus{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonStatus{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonStatus{}, fmt.Errorf("daemon status: %s", httpStatusError(resp))
+	}
+	var status daemonStatus
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return daemonStatus{}, err
+	}
+	return status, nil
+}
+
+func writeDaemonStatus(w io.Writer, status daemonStatus) {
+	state := "error"
+	if status.OK {
+		state = "ok"
+	}
+	fmt.Fprintf(w, "status: %s\n", state)
+	fmt.Fprintf(w, "version: %d\n", status.Version)
+	fmt.Fprintf(w, "active_runs: %d\n", status.ActiveRuns)
+	fmt.Fprintf(w, "tools_count: %d\n", status.ToolsCount)
+	if len(status.Capabilities) > 0 {
+		fmt.Fprintf(w, "capabilities: %s\n", strings.Join(status.Capabilities, ", "))
+	}
 }
 
 func fetchDaemonTools(ctx context.Context, cfg connectConfig, client httpDoer) (daemonToolCatalog, error) {
@@ -761,16 +829,17 @@ func printUsage(w io.Writer) {
   glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--env <path>]
   glue serve [default|gemini] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--env <path>]
   glue connect --prompt <text> [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --status [--status-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --tools [--tools-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
   serve    Start a local HTTP+SSE daemon for Glue sessions.
-  connect  Start a daemon run, or inspect daemon tools with --tools.
+  connect  Start a daemon run, or inspect daemon status/tools.
 
 Flags:
   --id       Session id. Defaults to "default".
-  --prompt   Prompt text. Required unless connect --tools is set.
+  --prompt   Prompt text. Required unless connect --status/--tools is set.
   --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
   --store    File session store directory. Defaults to .glue/sessions.
   --work     Working directory for serve mode. Defaults to ".".
@@ -780,6 +849,9 @@ Flags:
   --base-url Connect daemon base URL override.
   --role     Connect role override.
   --max-turns Connect loop turn budget override.
+  --status   Connect mode: show daemon status and exit without starting a run.
+  --status-json
+             Connect --status mode: print JSON.
   --tools    Connect mode: list daemon tools and exit without starting a run.
   --tools-json
              Connect --tools mode: print JSON.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -646,7 +646,97 @@ func TestRunCLIConnectListsToolsJSON(t *testing.T) {
 	}
 }
 
-func TestRunCLIConnectRequiresPromptUnlessTools(t *testing.T) {
+func TestRunCLIConnectShowsStatus(t *testing.T) {
+	var sawStatus bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/status":
+			sawStatus = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("status method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("status auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
+				OK:           true,
+				Version:      1,
+				ActiveRuns:   2,
+				ToolsCount:   5,
+				Capabilities: []string{"runs", "tools", "status"},
+			})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--status",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawStatus || sawRun {
+		t.Fatalf("sawStatus=%v sawRun=%v", sawStatus, sawRun)
+	}
+	for _, want := range []string{
+		"status: ok",
+		"version: 1",
+		"active_runs: 2",
+		"tools_count: 5",
+		"capabilities: runs, tools, status",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectShowsStatusJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemonStatus{
+			OK:           true,
+			Version:      1,
+			Capabilities: []string{"status"},
+		})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--status-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var status daemonStatus
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if !status.OK || status.Version != 1 || len(status.Capabilities) != 1 || status.Capabilities[0] != "status" {
+		t.Fatalf("status = %+v", status)
+	}
+}
+
+func TestRunCLIConnectRequiresPromptUnlessInspectMode(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runCLIWithDeps(context.Background(), []string{
 		"connect",
@@ -659,6 +749,24 @@ func TestRunCLIConnectRequiresPromptUnlessTools(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "missing required --prompt") {
 		t.Fatalf("stderr = %q, want missing prompt error", stderr.String())
+	}
+}
+
+func TestRunCLIConnectRejectsMultipleInspectModes(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--status",
+		"--tools",
+		"--base-url", "http://daemon",
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code == 0 {
+		t.Fatal("code = 0, want inspect mode validation failure")
+	}
+	if !strings.Contains(stderr.String(), "choose only one") {
+		t.Fatalf("stderr = %q, want mode conflict error", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- adds `glue connect --status` to fetch and render authenticated daemon runtime status
- adds `--status-json` for scriptable output
- prevents ambiguous combined inspect modes like `--status --tools`

## Product impact
Terminal users can now inspect the live daemon they are connected to before prompting it: protocol version, active run count, tool count, and capabilities. This completes the status side of the daemon/client discovery loop.

## Validation
- `go test ./cmd/glue -run 'TestRunCLIConnect(ShowsStatus|ListsTools|RequiresPrompt|RejectsMultiple|StartsRunAndStreamsText)|TestResolveConnectConfigUsesMetadataAndOverrides' -count=1`
- `go test ./cmd/glue -count=1`
- `git diff --check -- cmd/glue/main.go cmd/glue/main_test.go`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
