### PR TITLE
cmd/glue: add combined daemon inspect mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,18 +633,22 @@ Once `serve` is running, `connect` starts one daemon run, streams text
 events, and brokers permission requests in the terminal:
 
 ```sh
+go run ./cmd/glue connect --inspect
 go run ./cmd/glue connect --prompt "Say hi" --id local-dev
 ```
 
 By default, `connect` reads the same metadata file written by `serve`.
 Use `--base-url`, `--token`, or `--metadata` when connecting to an
-explicit daemon endpoint.
+explicit daemon endpoint. Use `--inspect` for a compact authenticated
+status-and-tools preflight, or `--status` / `--tools` to render each
+view separately. Each inspect mode also has a `-json` form for scripts.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:
 
 ```sh
 go run ./agents/peggy/cmd/peggy serve --coding --workdir .
+go run ./cmd/glue connect --inspect
 go run ./cmd/glue connect --prompt "Say hi to Peggy" --id cli:daily
 ```
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -51,6 +51,7 @@ peggy --coding --workdir . "read the failing test and propose a fix"
 # 6. Optional: keep one Peggy process running and connect to it.
 go install github.com/erain/glue/cmd/glue@latest  # if needed
 peggy serve --coding --workdir .
+glue connect --inspect
 glue connect --prompt "what should I do next?" --id cli:daily
 ```
 
@@ -179,6 +180,7 @@ session history and memory store.
 
 ```sh
 peggy serve --config ~/.config/peggy/settings.json
+glue connect --inspect
 glue connect --prompt "summarize today's plan" --id cli:daily
 ```
 
@@ -238,10 +240,11 @@ Recommended v0.3 daily-driver shape:
 }
 ```
 
-Run `peggy serve --config ~/.config/peggy/settings.json`, connect from
-a terminal with `glue connect --prompt "..." --id cli:daily`, and start
-Telegram with `peggy-telegram --daemon`. The daemon prints the base URL
-and metadata path but never prints the bearer token.
+Run `peggy serve --config ~/.config/peggy/settings.json`, inspect the
+live daemon with `glue connect --inspect`, connect from a terminal with
+`glue connect --prompt "..." --id cli:daily`, and start Telegram with
+`peggy-telegram --daemon`. The daemon prints the base URL and metadata
+path but never prints the bearer token.
 
 ## Coding Tools
 

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -116,6 +116,11 @@ type daemonStatus struct {
 	Capabilities []string `json:"capabilities"`
 }
 
+type daemonInspect struct {
+	Status daemonStatus             `json:"status"`
+	Tools  []daemonToolCatalogEntry `json:"tools"`
+}
+
 type connectPermissionPayload struct {
 	PermissionID string                 `json:"permission_id"`
 	Request      glue.PermissionRequest `json:"request"`
@@ -319,6 +324,8 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	toolsJSON := flags.Bool("tools-json", false, "print --tools output as JSON")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
+	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
+	inspectJSON := flags.Bool("inspect-json", false, "print --inspect output as JSON")
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
 
@@ -331,10 +338,19 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *statusJSON {
 		*showStatus = true
 	}
-	if *showTools && *showStatus {
-		return errors.New("choose only one of --tools or --status")
+	if *inspectJSON {
+		*showInspect = true
 	}
-	if !*showTools && !*showStatus && strings.TrimSpace(*prompt) == "" {
+	inspectModes := 0
+	for _, enabled := range []bool{*showTools, *showStatus, *showInspect} {
+		if enabled {
+			inspectModes++
+		}
+	}
+	if inspectModes > 1 {
+		return errors.New("choose only one of --tools, --status, or --inspect")
+	}
+	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" {
 		return errors.New("missing required --prompt")
 	}
 	if err := loadEnvFiles(envs); err != nil {
@@ -359,6 +375,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
+	}
+	if *showInspect {
+		return runConnectInspect(ctx, cfg, *inspectJSON, stdout, client)
 	}
 	return runConnect(ctx, cfg, stdin, stdout, stderr, client)
 }
@@ -453,6 +472,25 @@ func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, s
 	return nil
 }
 
+func runConnectInspect(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	status, err := fetchDaemonStatus(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	catalog, err := fetchDaemonTools(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	inspect := daemonInspect{Status: status, Tools: catalog.Tools}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(inspect)
+	}
+	writeDaemonInspect(stdout, inspect)
+	return nil
+}
+
 func fetchDaemonStatus(ctx context.Context, cfg connectConfig, client httpDoer) (daemonStatus, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/status", nil)
 	if err != nil {
@@ -488,6 +526,13 @@ func writeDaemonStatus(w io.Writer, status daemonStatus) {
 	}
 }
 
+func writeDaemonInspect(w io.Writer, inspect daemonInspect) {
+	writeDaemonStatus(w, inspect.Status)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "tools:")
+	writeDaemonToolCatalogIndented(w, inspect.Tools, "  ")
+}
+
 func fetchDaemonTools(ctx context.Context, cfg connectConfig, client httpDoer) (daemonToolCatalog, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/tools", nil)
 	if err != nil {
@@ -513,23 +558,27 @@ func fetchDaemonTools(ctx context.Context, cfg connectConfig, client httpDoer) (
 }
 
 func writeDaemonToolCatalog(w io.Writer, tools []daemonToolCatalogEntry) {
+	writeDaemonToolCatalogIndented(w, tools, "")
+}
+
+func writeDaemonToolCatalogIndented(w io.Writer, tools []daemonToolCatalogEntry, indent string) {
 	if len(tools) == 0 {
-		fmt.Fprintln(w, "No daemon tools reported.")
+		fmt.Fprintf(w, "%sNo daemon tools reported.\n", indent)
 		return
 	}
 	for i, tool := range tools {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintln(w, tool.Name)
+		fmt.Fprintf(w, "%s%s\n", indent, tool.Name)
 		if tool.Description != "" {
-			fmt.Fprintf(w, "  description: %s\n", oneLine(tool.Description))
+			fmt.Fprintf(w, "%s  description: %s\n", indent, oneLine(tool.Description))
 		}
 		if tool.RequiresPermission || tool.PermissionAction != "" || tool.PermissionTargetPreview != "" {
-			fmt.Fprintf(w, "  permission: %s %s\n", tool.PermissionAction, tool.PermissionTargetPreview)
+			fmt.Fprintf(w, "%s  permission: %s %s\n", indent, tool.PermissionAction, tool.PermissionTargetPreview)
 		}
 		if len(tool.Parameters) > 0 {
-			fmt.Fprintf(w, "  parameters: %s\n", compactJSON(tool.Parameters))
+			fmt.Fprintf(w, "%s  parameters: %s\n", indent, compactJSON(tool.Parameters))
 		}
 	}
 }
@@ -829,6 +878,7 @@ func printUsage(w io.Writer) {
   glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--env <path>]
   glue serve [default|gemini] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--env <path>]
   glue connect --prompt <text> [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --inspect [--inspect-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --status [--status-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --tools [--tools-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
@@ -839,7 +889,7 @@ Commands:
 
 Flags:
   --id       Session id. Defaults to "default".
-  --prompt   Prompt text. Required unless connect --status/--tools is set.
+  --prompt   Prompt text. Required unless connect --inspect/--status/--tools is set.
   --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
   --store    File session store directory. Defaults to .glue/sessions.
   --work     Working directory for serve mode. Defaults to ".".
@@ -849,6 +899,9 @@ Flags:
   --base-url Connect daemon base URL override.
   --role     Connect role override.
   --max-turns Connect loop turn budget override.
+  --inspect  Connect mode: show daemon status and tools without starting a run.
+  --inspect-json
+             Connect --inspect mode: print JSON.
   --status   Connect mode: show daemon status and exit without starting a run.
   --status-json
              Connect --status mode: print JSON.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -736,6 +736,124 @@ func TestRunCLIConnectShowsStatusJSON(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectInspectsDaemon(t *testing.T) {
+	var sawStatus bool
+	var sawTools bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/status":
+			sawStatus = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("status method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("status auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
+				OK:           true,
+				Version:      1,
+				ActiveRuns:   2,
+				ToolsCount:   1,
+				Capabilities: []string{"runs", "tools", "status"},
+			})
+		case "/v1/tools":
+			sawTools = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("tools method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("tools auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{Tools: []daemonToolCatalogEntry{{
+				Name:                    "mcp_fake_echo",
+				Description:             "MCP fake: echoes text",
+				RequiresPermission:      true,
+				PermissionAction:        "mcp_call",
+				PermissionTargetPreview: "fake.echo",
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--inspect",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawStatus || !sawTools || sawRun {
+		t.Fatalf("sawStatus=%v sawTools=%v sawRun=%v", sawStatus, sawTools, sawRun)
+	}
+	for _, want := range []string{
+		"status: ok",
+		"active_runs: 2",
+		"tools_count: 1",
+		"tools:",
+		"mcp_fake_echo",
+		"description: MCP fake: echoes text",
+		"permission: mcp_call fake.echo",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/status":
+			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
+				OK:           true,
+				Version:      1,
+				Capabilities: []string{"status", "tools"},
+			})
+		case "/v1/tools":
+			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{Tools: []daemonToolCatalogEntry{{
+				Name:               "shell_exec",
+				RequiresPermission: true,
+				PermissionAction:   "exec",
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--inspect-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var inspect daemonInspect
+	if err := json.Unmarshal(stdout.Bytes(), &inspect); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if !inspect.Status.OK || inspect.Status.Version != 1 {
+		t.Fatalf("status = %+v", inspect.Status)
+	}
+	if len(inspect.Tools) != 1 || inspect.Tools[0].Name != "shell_exec" || inspect.Tools[0].PermissionAction != "exec" {
+		t.Fatalf("tools = %+v", inspect.Tools)
+	}
+}
+
 func TestRunCLIConnectRequiresPromptUnlessInspectMode(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runCLIWithDeps(context.Background(), []string{
@@ -757,7 +875,7 @@ func TestRunCLIConnectRejectsMultipleInspectModes(t *testing.T) {
 	code := runCLIWithDeps(context.Background(), []string{
 		"connect",
 		"--status",
-		"--tools",
+		"--inspect",
 		"--base-url", "http://daemon",
 		"--token", "tok",
 		"--metadata", "",


### PR DESCRIPTION
## Summary

- add `glue connect --inspect` to fetch daemon status and tools in one authenticated preflight
- add `glue connect --inspect-json` with a combined `{status, tools}` payload
- keep inspect modes mutually exclusive and prompt-free, matching the existing status/tools behavior
- document the updated Peggy/operator loop

## Validation

- `go test ./cmd/glue -run 'TestRunCLIConnect(InspectsDaemon|ShowsStatus|ListsTools|RequiresPrompt|RejectsMultiple|StartsRunAndStreamsText)|TestResolveConnectConfigUsesMetadataAndOverrides' -count=1`
- `go test ./cmd/glue -count=1`
- `git diff --check -- cmd/glue/main.go cmd/glue/main_test.go README.md agents/peggy/README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`

Closes #200.
