### PR TITLE
cmd/glue: display run token usage on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
 - `--prompt` — prompt text (required).
 - `--model` — model id or `gemini/<model>` (default `gemini-2.5-flash`).
 - `--store` — file session store directory (default `.glue/sessions`).
+- `--usage` — print provider-reported token usage to stderr when available.
 - `--env` — `.env` file to load before reading `GEMINI_API_KEY`. Repeatable;
   shell environment wins on conflict.
 
@@ -642,6 +643,8 @@ Use `--base-url`, `--token`, or `--metadata` when connecting to an
 explicit daemon endpoint. Use `--inspect` for a compact authenticated
 status-and-tools preflight, or `--status` / `--tools` to render each
 view separately. Each inspect mode also has a `-json` form for scripts.
+Add `--usage` to `run` or prompt-mode `connect` to print provider-reported
+token usage on stderr without changing streamed stdout.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:

--- a/agents/glue-review/fixture_test.go
+++ b/agents/glue-review/fixture_test.go
@@ -32,7 +32,7 @@ type fixture struct {
 
 // fixtureReplayAttempts allows the non-deterministic OpenRouter free
 // router two retries when an upstream model returns a provider-quality
-// failure instead of a review. Each attempt has runAgentInRepo's
+// failure or stalls instead of a review. Each attempt has runAgentInRepo's
 // 180-second timeout, so the worst case stays bounded for CI.
 const fixtureReplayAttempts = 3
 
@@ -123,8 +123,9 @@ var fixtures = []fixture{
 // Skipped quietly when no provider key is in env (matches the existing
 // TestLiveReviewSmoke gating convention). The OpenRouter free router is
 // intentionally non-deterministic, so known upstream-quality faults
-// (empty/preamble-only responses or malformed tool-call JSON) get two
-// retries before the last attempt is judged normally.
+// (empty/preamble-only responses, malformed tool-call JSON, or stalled
+// upstream responses) get two retries before the last attempt is judged
+// normally.
 func TestFixtureReplay(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -178,6 +179,9 @@ func TestFixtureReplayRetryClassifiers(t *testing.T) {
 
 	if !isRetryableFixtureReplayError(fmt.Errorf("rc=1 stderr=openrouter: tool call %q invalid JSON arguments", "git_diff_branch")) {
 		t.Fatal("invalid JSON tool-call error should be retryable")
+	}
+	if !isRetryableFixtureReplayError(fmt.Errorf("rc=1 stderr=[failover] openrouter failed: context deadline exceeded")) {
+		t.Fatal("context deadline from live upstream should be retryable")
 	}
 	if !isUpstreamRateLimit(fmt.Errorf("openrouter http 429: Rate limit exceeded")) {
 		t.Fatal("429 rate limit should be classified as upstream rate limit")
@@ -240,7 +244,8 @@ func runFixtureReplay(t *testing.T, repo, provider, fixtureName string) (string,
 func isRetryableFixtureReplayError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "invalid JSON arguments") ||
-		(strings.Contains(msg, "tool call") && strings.Contains(msg, "invalid JSON"))
+		(strings.Contains(msg, "tool call") && strings.Contains(msg, "invalid JSON")) ||
+		strings.Contains(msg, "context deadline exceeded")
 }
 
 func isRetryableFixtureReplayReview(review string) bool {

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -181,7 +181,7 @@ session history and memory store.
 ```sh
 peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
-glue connect --prompt "summarize today's plan" --id cli:daily
+glue connect --prompt "summarize today's plan" --id cli:daily --usage
 ```
 
 Useful `serve` flags:
@@ -199,7 +199,9 @@ Useful `serve` flags:
   over the daemon protocol for the connected client to answer.
 
 Startup output prints the `base_url` and metadata path, never the
-bearer token. Stop the daemon with SIGINT/SIGTERM.
+bearer token. Add `--usage` to prompt-mode `glue connect` when you want
+provider-reported token usage on stderr. Stop the daemon with
+SIGINT/SIGTERM.
 
 Telegram can attach to the same daemon:
 

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -95,6 +95,21 @@ type startRunResult struct {
 	EventsURL string `json:"events_url"`
 }
 
+type connectRunDonePayload struct {
+	Text        string         `json:"text"`
+	Message     *glue.Message  `json:"message,omitempty"`
+	NewMessages []glue.Message `json:"new_messages,omitempty"`
+}
+
+type usageSummary struct {
+	HasUsage         bool
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	TotalTokens      int64
+}
+
 type daemonToolCatalog struct {
 	Tools []daemonToolCatalogEntry `json:"tools"`
 }
@@ -194,6 +209,7 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 	prompt := flags.String("prompt", "", "prompt text")
 	model := flags.String("model", defaultModel, "model id or gemini/<model>")
 	storeDir := flags.String("store", ".glue/sessions", "session store directory")
+	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
 
@@ -239,10 +255,11 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 	}
 	if wroteDelta {
 		fmt.Fprintln(stdout)
-		return nil
-	}
-	if response.Text != "" {
+	} else if response.Text != "" {
 		fmt.Fprintln(stdout, response.Text)
+	}
+	if *showUsage {
+		writeUsageSummary(stderr, summarizeUsage(response.NewMessages))
 	}
 	return nil
 }
@@ -320,6 +337,7 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	model := flags.String("model", "", "per-run model override")
 	role := flags.String("role", "", "per-run role override")
 	maxTurns := flags.Int("max-turns", 0, "per-run loop turn budget")
+	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
 	showTools := flags.Bool("tools", false, "list daemon tools and exit without starting a run")
 	toolsJSON := flags.Bool("tools-json", false, "print --tools output as JSON")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
@@ -379,7 +397,7 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *showInspect {
 		return runConnectInspect(ctx, cfg, *inspectJSON, stdout, client)
 	}
-	return runConnect(ctx, cfg, stdin, stdout, stderr, client)
+	return runConnect(ctx, cfg, *showUsage, stdin, stdout, stderr, client)
 }
 
 func resolveConnectConfig(cfg connectConfig) (connectConfig, error) {
@@ -427,7 +445,7 @@ func resolveConnectConfig(cfg connectConfig) (connectConfig, error) {
 	return cfg, nil
 }
 
-func runConnect(ctx context.Context, cfg connectConfig, stdin io.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
+func runConnect(ctx context.Context, cfg connectConfig, showUsage bool, stdin io.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
 	start, err := startDaemonRun(ctx, cfg, client)
 	if err != nil {
 		return err
@@ -441,7 +459,7 @@ func runConnect(ctx context.Context, cfg connectConfig, stdin io.Reader, stdout 
 		case <-done:
 		}
 	}()
-	return streamDaemonRun(ctx, cfg, start, bufio.NewReader(stdin), stdout, stderr, client)
+	return streamDaemonRun(ctx, cfg, start, showUsage, bufio.NewReader(stdin), stdout, stderr, client)
 }
 
 func runConnectTools(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
@@ -631,7 +649,7 @@ func startDaemonRun(ctx context.Context, cfg connectConfig, client httpDoer) (st
 	return out, nil
 }
 
-func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResult, input *bufio.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
+func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResult, showUsage bool, input *bufio.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+start.EventsURL, nil)
 	if err != nil {
 		return err
@@ -686,10 +704,25 @@ func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResul
 		case "run_done":
 			if wroteDelta {
 				fmt.Fprintln(stdout)
-				return nil
+			} else {
+				done, err := decodePayload[connectRunDonePayload](event.Payload)
+				if err != nil {
+					return err
+				}
+				if done.Text != "" {
+					fmt.Fprintln(stdout, done.Text)
+				}
 			}
-			if text := payloadString(event.Payload, "text"); text != "" {
-				fmt.Fprintln(stdout, text)
+			if showUsage {
+				done, err := decodePayload[connectRunDonePayload](event.Payload)
+				if err != nil {
+					return err
+				}
+				messages := done.NewMessages
+				if len(messages) == 0 && done.Message != nil {
+					messages = []glue.Message{*done.Message}
+				}
+				writeUsageSummary(stderr, summarizeUsage(messages))
 			}
 			return nil
 		case "run_error":
@@ -706,6 +739,45 @@ func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResul
 		return err
 	}
 	return errors.New("daemon event stream closed before terminal event")
+}
+
+func summarizeUsage(messages []glue.Message) usageSummary {
+	var summary usageSummary
+	for _, message := range messages {
+		if message.Role != glue.MessageRoleAssistant || message.Usage == nil {
+			continue
+		}
+		usage := message.Usage
+		summary.HasUsage = true
+		summary.InputTokens += usage.InputTokens
+		summary.OutputTokens += usage.OutputTokens
+		summary.CacheReadTokens += usage.CacheReadTokens
+		summary.CacheWriteTokens += usage.CacheWriteTokens
+		total := usage.TotalTokens
+		if total == 0 {
+			total = usage.InputTokens + usage.OutputTokens
+		}
+		summary.TotalTokens += total
+	}
+	return summary
+}
+
+func writeUsageSummary(w io.Writer, summary usageSummary) {
+	if !summary.HasUsage {
+		return
+	}
+	parts := []string{
+		fmt.Sprintf("input=%d", summary.InputTokens),
+		fmt.Sprintf("output=%d", summary.OutputTokens),
+	}
+	if summary.CacheReadTokens != 0 {
+		parts = append(parts, fmt.Sprintf("cache_read=%d", summary.CacheReadTokens))
+	}
+	if summary.CacheWriteTokens != 0 {
+		parts = append(parts, fmt.Sprintf("cache_write=%d", summary.CacheWriteTokens))
+	}
+	parts = append(parts, fmt.Sprintf("total=%d", summary.TotalTokens))
+	fmt.Fprintf(w, "usage: %s\n", strings.Join(parts, " "))
 }
 
 func promptPermission(input *bufio.Reader, stderr io.Writer, perm connectPermissionPayload) (connectPermissionDecision, error) {
@@ -899,6 +971,7 @@ Flags:
   --base-url Connect daemon base URL override.
   --role     Connect role override.
   --max-turns Connect loop turn budget override.
+  --usage   Run/connect mode: print token usage summary to stderr when available.
   --inspect  Connect mode: show daemon status and tools without starting a run.
   --inspect-json
              Connect --inspect mode: print JSON.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -145,6 +145,62 @@ func TestRunCLIStreamsOutputAndLoadsEnv(t *testing.T) {
 	t.Cleanup(func() { os.Unsetenv("GLUE_TEST_ENV") })
 }
 
+func TestRunCLIUsageReportsTokens(t *testing.T) {
+	t.Parallel()
+
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: "hello"},
+		{Type: glue.ProviderEventDone, Message: &glue.Message{
+			Role: glue.MessageRoleAssistant,
+			Usage: &glue.Usage{
+				InputTokens:     3,
+				OutputTokens:    2,
+				CacheReadTokens: 1,
+				TotalTokens:     5,
+			},
+		}},
+	}}}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run",
+		"--prompt", "say hi",
+		"--store", t.TempDir(),
+		"--usage",
+	}, &stdout, &stderr, fakeFactory(provider))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != "hello\n" {
+		t.Fatalf("stdout = %q, want streamed text", stdout.String())
+	}
+	if got, want := stderr.String(), "usage: input=3 output=2 cache_read=1 total=5\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestRunCLIUsageSilentWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{textTurn("ok")}}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run",
+		"--prompt", "go",
+		"--store", t.TempDir(),
+		"--usage",
+	}, &stdout, &stderr, fakeFactory(provider))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != "ok\n" {
+		t.Fatalf("stdout = %q, want ok", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want no usage output", stderr.String())
+	}
+}
+
 func TestRunCLIMultipleEnvFilesShellEnvWins(t *testing.T) {
 	t.Setenv("GLUE_TEST_FROM_SHELL", "shell-value")
 	os.Unsetenv("GLUE_TEST_FROM_FILE_A")
@@ -553,6 +609,95 @@ func TestRunCLIConnectStartsRunAndStreamsText(t *testing.T) {
 	}
 	if got.Text != "hello" || got.Model != "gemini/custom" || got.Role != "reviewer" || got.MaxTurns != 3 || got.ClientID == "" {
 		t.Fatalf("start payload = %+v", got)
+	}
+}
+
+func TestRunCLIConnectUsageReportsTokens(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/default/runs":
+			writeJSONResponse(t, w, http.StatusCreated, startRunResult{RunID: "run_1", SessionID: "default", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			writeSSETest(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "done"}})
+			writeSSETest(t, w, daemon.EventEnvelope{Type: "run_done", Payload: connectRunDonePayload{
+				NewMessages: []glue.Message{
+					{
+						Role: glue.MessageRoleAssistant,
+						Usage: &glue.Usage{
+							InputTokens:     3,
+							OutputTokens:    2,
+							CacheReadTokens: 1,
+							TotalTokens:     5,
+						},
+					},
+					{
+						Role: glue.MessageRoleAssistant,
+						Usage: &glue.Usage{
+							InputTokens:  4,
+							OutputTokens: 1,
+							TotalTokens:  5,
+						},
+					},
+				},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--prompt", "hello",
+		"--usage",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != "done\n" {
+		t.Fatalf("stdout = %q, want streamed text", stdout.String())
+	}
+	if got, want := stderr.String(), "usage: input=7 output=3 cache_read=1 total=10\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestRunCLIConnectUsageSilentWhenMissing(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/default/runs":
+			writeJSONResponse(t, w, http.StatusCreated, startRunResult{RunID: "run_1", SessionID: "default", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			writeSSETest(t, w, daemon.EventEnvelope{Type: "run_done", Payload: connectRunDonePayload{Text: "fallback"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--prompt", "hello",
+		"--usage",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != "fallback\n" {
+		t.Fatalf("stdout = %q, want fallback text", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want no usage output", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `--usage` to `glue run` and prompt-mode `glue connect`
- aggregate provider-reported usage across assistant messages produced by the run
- print usage summaries to stderr so streamed stdout remains unchanged
- document the Peggy/operator usage flow
- harden the OpenRouter live fixture retry classifier for upstream stalls that surface as `context deadline exceeded`

## Validation

- `go test ./cmd/glue -run 'TestRunCLI(Usage|StreamsOutput|ConnectUsage|ConnectStartsRunAndStreamsText|ConnectInspectsDaemon|ConnectRequiresPrompt|ConnectRejectsMultiple)' -count=1`
- `go test ./cmd/glue -count=1`
- `go test ./agents/glue-review -run 'TestFixtureReplayRetryClassifiers|TestFixtureReplayReviewMatchers|TestFixtureReplayFixBlockMatcher' -count=1`
- `git diff --check -- agents/glue-review/fixture_test.go cmd/glue/main.go cmd/glue/main_test.go README.md agents/peggy/README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`

Closes #202.
