### PR TITLE
agents/peggy: list configured MCP resources

### DIFF
--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -148,6 +148,7 @@ defaults above and emits a stderr diagnostic.
 
 ```
 peggy [flags] "<prompt text>"
+peggy mcp resources [flags]
 peggy mcp tools [flags]
 peggy serve [flags]
 
@@ -349,9 +350,15 @@ Inspect the configured MCP surface without constructing a model
 provider or running a prompt:
 
 ```sh
+peggy mcp resources --config ~/.config/peggy/settings.json
+peggy mcp resources --config ~/.config/peggy/settings.json --json
 peggy mcp tools --config ~/.config/peggy/settings.json
 peggy mcp tools --config ~/.config/peggy/settings.json --json
 ```
+
+`peggy mcp resources` lists resource metadata only; it does not fetch
+resource contents. Servers that do not advertise resource support are
+skipped.
 
 The permission choices are intentionally small:
 

--- a/agents/peggy/mcp.go
+++ b/agents/peggy/mcp.go
@@ -41,6 +41,28 @@ func MCPTools(ctx context.Context, settings MCPSettings) ([]glue.Tool, *toolsmcp
 	return manager.Tools(), manager, normalized, nil
 }
 
+// MCPResources initializes Peggy's configured MCP servers and returns
+// discovered resource metadata plus the manager that owns server lifecycles.
+func MCPResources(ctx context.Context, settings MCPSettings) ([]toolsmcp.Resource, *toolsmcp.Manager, MCPSettings, error) {
+	configs, normalized, err := MCPServerConfigs(settings)
+	if err != nil {
+		return nil, nil, normalized, err
+	}
+	if len(configs) == 0 {
+		return nil, nil, normalized, nil
+	}
+	manager, err := toolsmcp.NewManager(ctx, configs, toolsmcp.Options{})
+	if err != nil {
+		return nil, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	resources, err := manager.Resources(ctx)
+	if err != nil {
+		_ = manager.Close()
+		return nil, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	return resources, manager, normalized, nil
+}
+
 // MCPServerConfigs converts Peggy settings into tools/mcp server configs.
 func MCPServerConfigs(settings MCPSettings) ([]toolsmcp.ServerConfig, MCPSettings, error) {
 	normalized, err := expandMCPSettings(settings)

--- a/agents/peggy/mcp_test.go
+++ b/agents/peggy/mcp_test.go
@@ -276,14 +276,8 @@ func runPeggyMCPHelper() error {
 	if initReq.Method != "initialize" {
 		return fmt.Errorf("first method = %q, want initialize", initReq.Method)
 	}
-	if err := writePeggyMCPResult(enc, initReq.ID, map[string]any{
-		"protocolVersion": "2025-11-25",
-		"capabilities":    map[string]any{},
-		"serverInfo": map[string]string{
-			"name":    "fake-peggy-mcp",
-			"version": "0.1.0",
-		},
-	}); err != nil {
+	scenario := os.Getenv("PEGGY_MCP_SCENARIO")
+	if err := writePeggyMCPResult(enc, initReq.ID, peggyMCPInitializeResult(scenario)); err != nil {
 		return err
 	}
 
@@ -305,6 +299,9 @@ func runPeggyMCPHelper() error {
 		}
 		switch req.Method {
 		case "tools/list":
+			if scenario == "resources_only" {
+				return fmt.Errorf("resources_only server received tools/list")
+			}
 			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
 				"tools": []map[string]any{{
 					"name":        "echo",
@@ -334,9 +331,49 @@ func runPeggyMCPHelper() error {
 			}); err != nil {
 				return err
 			}
+		case "resources/list":
+			if scenario != "resources" && scenario != "resources_only" {
+				return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			}
+			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
+				"resources": []map[string]any{{
+					"uri":         "file:///workspace/README.md",
+					"name":        "readme",
+					"title":       "Project README",
+					"description": "repository overview",
+					"mimeType":    "text/markdown",
+					"annotations": map[string]any{"audience": []string{"assistant"}},
+					"size":        1234,
+				}},
+			}); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			return fmt.Errorf("method = %q, want tools/list, tools/call, or resources/list", req.Method)
 		}
+	}
+}
+
+func peggyMCPInitializeResult(scenario string) map[string]any {
+	capabilities := map[string]any{}
+	switch scenario {
+	case "resources":
+		capabilities = map[string]any{
+			"tools":     map[string]any{},
+			"resources": map[string]any{},
+		}
+	case "resources_only":
+		capabilities = map[string]any{
+			"resources": map[string]any{},
+		}
+	}
+	return map[string]any{
+		"protocolVersion": "2025-11-25",
+		"capabilities":    capabilities,
+		"serverInfo": map[string]string{
+			"name":    "fake-peggy-mcp",
+			"version": "0.1.0",
+		},
 	}
 }
 

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/erain/glue"
 	"github.com/erain/glue/daemon"
+	toolsmcp "github.com/erain/glue/tools/mcp"
 )
 
 // Version is the package version string surfaced by `peggy --version`.
@@ -184,14 +185,27 @@ type mcpToolCatalogEntry struct {
 	PermissionTarget   string          `json:"permission_target,omitempty"`
 }
 
+type mcpResourceCatalogEntry struct {
+	Server      string         `json:"server"`
+	URI         string         `json:"uri"`
+	Name        string         `json:"name"`
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	MIMEType    string         `json:"mime_type,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+	Size        *int64         `json:"size,omitempty"`
+}
+
 func runMCP(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	usage := func() {
 		fmt.Fprintf(stderr, `peggy mcp — inspect Peggy's configured MCP surface.
 
 Usage:
+  peggy mcp resources [flags]
   peggy mcp tools [flags]
 
 Commands:
+  resources  List resources discovered from enabled MCP servers.
   tools    List tools discovered from enabled MCP servers.
 `)
 	}
@@ -203,6 +217,8 @@ Commands:
 	case "-h", "--help", "help":
 		usage()
 		return 0
+	case "resources":
+		return runMCPResources(ctx, args[1:], stdout, stderr)
 	case "tools":
 		return runMCPTools(ctx, args[1:], stdout, stderr)
 	default:
@@ -210,6 +226,72 @@ Commands:
 		usage()
 		return 2
 	}
+}
+
+func runMCPResources(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy mcp resources", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy mcp resources — list resources from enabled MCP servers.
+
+Usage:
+  peggy mcp resources [flags]
+
+Examples:
+  peggy mcp resources --config ~/.config/peggy/settings.json
+  peggy mcp resources --json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy mcp resources: positional args not supported")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp resources: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy mcp resources: no settings.json found; using built-in defaults")
+	}
+
+	resources, manager, _, err := MCPResources(ctx, settings.MCP)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp resources: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := manager.Close(); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp resources: close: %v\n", err)
+		}
+	}()
+
+	catalog := buildMCPResourceCatalog(resources)
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(catalog); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp resources: encode catalog: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeMCPResourceCatalog(stdout, catalog)
+	return 0
 }
 
 func runMCPTools(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -296,6 +378,23 @@ func buildMCPToolCatalog(tools []glue.Tool) []mcpToolCatalogEntry {
 	return catalog
 }
 
+func buildMCPResourceCatalog(resources []toolsmcp.Resource) []mcpResourceCatalogEntry {
+	catalog := make([]mcpResourceCatalogEntry, 0, len(resources))
+	for _, resource := range resources {
+		catalog = append(catalog, mcpResourceCatalogEntry{
+			Server:      resource.Server,
+			URI:         resource.URI,
+			Name:        resource.Name,
+			Title:       resource.Title,
+			Description: resource.Description,
+			MIMEType:    resource.MIMEType,
+			Annotations: cloneResourceAnnotations(resource.Annotations),
+			Size:        cloneResourceSize(resource.Size),
+		})
+	}
+	return catalog
+}
+
 func writeMCPToolCatalog(w io.Writer, catalog []mcpToolCatalogEntry) {
 	if len(catalog) == 0 {
 		fmt.Fprintln(w, "No MCP tools configured.")
@@ -316,6 +415,58 @@ func writeMCPToolCatalog(w io.Writer, catalog []mcpToolCatalogEntry) {
 			fmt.Fprintf(w, "  parameters: %s\n", compactJSONLine(entry.Parameters))
 		}
 	}
+}
+
+func writeMCPResourceCatalog(w io.Writer, catalog []mcpResourceCatalogEntry) {
+	if len(catalog) == 0 {
+		fmt.Fprintln(w, "No MCP resources configured.")
+		return
+	}
+	for i, entry := range catalog {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, entry.URI)
+		fmt.Fprintf(w, "  server: %s\n", entry.Server)
+		fmt.Fprintf(w, "  name: %s\n", entry.Name)
+		if entry.Title != "" {
+			fmt.Fprintf(w, "  title: %s\n", singleLine(entry.Title))
+		}
+		if entry.Description != "" {
+			fmt.Fprintf(w, "  description: %s\n", singleLine(entry.Description))
+		}
+		if entry.MIMEType != "" {
+			fmt.Fprintf(w, "  mime_type: %s\n", entry.MIMEType)
+		}
+		if entry.Size != nil {
+			fmt.Fprintf(w, "  size: %d\n", *entry.Size)
+		}
+		if len(entry.Annotations) > 0 {
+			raw, err := json.Marshal(entry.Annotations)
+			if err == nil {
+				fmt.Fprintf(w, "  annotations: %s\n", compactJSONLine(raw))
+			}
+		}
+	}
+}
+
+func cloneResourceAnnotations(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneResourceSize(in *int64) *int64 {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func singleLine(s string) string {

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -227,6 +227,81 @@ func TestRunMCPToolsJSON(t *testing.T) {
 	}
 }
 
+func TestRunMCPResourcesNoServers(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "resources"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "No MCP resources configured.") {
+		t.Fatalf("stdout = %q, want empty catalog message", out.String())
+	}
+	if !strings.Contains(errOut.String(), "no settings.json found") {
+		t.Fatalf("stderr = %q, want settings diagnostic", errOut.String())
+	}
+}
+
+func TestRunMCPResourcesListsConfiguredResources(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("resources", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "resources", "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"file:///workspace/README.md",
+		"server: fake",
+		"name: readme",
+		"title: Project README",
+		"description: repository overview",
+		"mime_type: text/markdown",
+		"size: 1234",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stdout = %q, missing %q", text, want)
+		}
+	}
+}
+
+func TestRunMCPResourcesJSON(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("resources", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "resources", "--config", cfgPath, "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var catalog []mcpResourceCatalogEntry
+	if err := json.Unmarshal(out.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode catalog: %v\nstdout=%s", err, out.String())
+	}
+	if len(catalog) != 1 {
+		t.Fatalf("catalog len = %d, want 1: %+v", len(catalog), catalog)
+	}
+	entry := catalog[0]
+	if entry.Server != "fake" || entry.URI != "file:///workspace/README.md" || entry.Name != "readme" || entry.MIMEType != "text/markdown" {
+		t.Fatalf("catalog entry = %+v", entry)
+	}
+	if entry.Size == nil || *entry.Size != 1234 {
+		t.Fatalf("size = %+v", entry.Size)
+	}
+}
+
 func TestRunMCPUsage(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := Run(context.Background(), []string{"mcp", "bogus"}, &out, &errOut)

--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -151,13 +151,13 @@ func runMCPHelper(scenario string) error {
 		fmt.Fprint(os.Stderr, "stderr-line-with-extra-data")
 	}
 
-	if err := writeHelperResult(enc, initReq.ID, initializeResult(ProtocolVersion)); err != nil {
+	if err := writeHelperResult(enc, initReq.ID, initializeResultForScenario(ProtocolVersion, scenario)); err != nil {
 		return err
 	}
 	if err := readInitialized(dec); err != nil {
 		return err
 	}
-	if scenario == "tools" || scenario == "bad_schema" || scenario == "collision" {
+	if scenario == "tools" || scenario == "bad_schema" || scenario == "collision" || scenario == "resources" || scenario == "resources_only" {
 		return runMCPToolScenario(dec, enc, scenario)
 	}
 	if scenario != "rpc_error" {
@@ -189,6 +189,9 @@ func runMCPToolScenario(dec *json.Decoder, enc *json.Encoder, scenario string) e
 		}
 		switch req.Method {
 		case "tools/list":
+			if scenario == "resources_only" {
+				return fmt.Errorf("resources_only server received tools/list")
+			}
 			if err := writeHelperResult(enc, req.ID, helperToolsList(scenario)); err != nil {
 				return err
 			}
@@ -196,8 +199,15 @@ func runMCPToolScenario(dec *json.Decoder, enc *json.Encoder, scenario string) e
 			if err := handleHelperToolCall(enc, req); err != nil {
 				return err
 			}
+		case "resources/list":
+			if scenario != "resources" && scenario != "resources_only" {
+				return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			}
+			if err := writeHelperResult(enc, req.ID, helperResourcesList()); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			return fmt.Errorf("method = %q, want tools/list, tools/call, or resources/list", req.Method)
 		}
 	}
 }
@@ -236,6 +246,20 @@ func helperToolsList(scenario string) map[string]any {
 				{"name": "rpc.fail", "inputSchema": json.RawMessage(`{"type":"object"}`)},
 			},
 		}
+	}
+}
+
+func helperResourcesList() map[string]any {
+	return map[string]any{
+		"resources": []map[string]any{{
+			"uri":         "file:///workspace/README.md",
+			"name":        "readme",
+			"title":       "Project README",
+			"description": "repository overview",
+			"mimeType":    "text/markdown",
+			"annotations": map[string]any{"audience": []string{"assistant"}, "priority": 0.8},
+			"size":        1234,
+		}},
 	}
 }
 
@@ -295,9 +319,29 @@ func handleHelperToolCall(enc *json.Encoder, req helperRequest) error {
 }
 
 func initializeResult(version string) map[string]any {
+	return initializeResultWithCapabilities(version, map[string]any{})
+}
+
+func initializeResultForScenario(version, scenario string) map[string]any {
+	switch scenario {
+	case "resources":
+		return initializeResultWithCapabilities(version, map[string]any{
+			"tools":     map[string]any{},
+			"resources": map[string]any{},
+		})
+	case "resources_only":
+		return initializeResultWithCapabilities(version, map[string]any{
+			"resources": map[string]any{},
+		})
+	default:
+		return initializeResult(version)
+	}
+}
+
+func initializeResultWithCapabilities(version string, capabilities map[string]any) map[string]any {
 	return map[string]any{
 		"protocolVersion": version,
-		"capabilities":    map[string]any{},
+		"capabilities":    capabilities,
 		"serverInfo": map[string]string{
 			"name":    "fake-mcp",
 			"version": "0.1.0",

--- a/tools/mcp/doc.go
+++ b/tools/mcp/doc.go
@@ -2,8 +2,8 @@
 // Protocol servers from glue hosts.
 //
 // This package follows ADR-0011. It supports JSON-RPC lifecycle negotiation
-// over stdio and Streamable HTTP, discovery of MCP server tools, and mapping
-// those tools to permission-gated glue.Tool values. Resources, prompts,
-// sampling, elicitation, OAuth, and dynamic discovery are deferred follow-up
-// surfaces.
+// over stdio and Streamable HTTP, discovery of MCP server tools, mapping
+// those tools to permission-gated glue.Tool values, and read-only resource
+// metadata inspection. Prompts, resource reads, sampling, elicitation, OAuth,
+// and dynamic discovery are deferred follow-up surfaces.
 package mcp

--- a/tools/mcp/tools.go
+++ b/tools/mcp/tools.go
@@ -22,8 +22,14 @@ type Options struct{}
 // Manager owns initialized MCP clients and exposes their discovered tools as
 // ordinary glue tools.
 type Manager struct {
-	clients []*Client
+	servers []managedServer
 	tools   []glue.Tool
+}
+
+type managedServer struct {
+	name   string
+	cfg    ServerConfig
+	client *Client
 }
 
 // NewManager initializes each configured MCP server, discovers its tools, and
@@ -48,14 +54,16 @@ func NewManager(ctx context.Context, configs []ServerConfig, _ Options) (*Manage
 			_ = m.Close()
 			return nil, fmt.Errorf("mcp: server %q: %w", serverName, err)
 		}
-		m.clients = append(m.clients, client)
+		m.servers = append(m.servers, managedServer{name: serverName, cfg: cfg, client: client})
 
-		tools, err := listGlueTools(ctx, client, cfg, serverName, serverPart, seen)
-		if err != nil {
-			_ = m.Close()
-			return nil, fmt.Errorf("mcp: server %q: %w", serverName, err)
+		if shouldListTools(client.InitializeResult()) {
+			tools, err := listGlueTools(ctx, client, cfg, serverName, serverPart, seen)
+			if err != nil {
+				_ = m.Close()
+				return nil, fmt.Errorf("mcp: server %q: %w", serverName, err)
+			}
+			m.tools = append(m.tools, tools...)
 		}
-		m.tools = append(m.tools, tools...)
 	}
 	return m, nil
 }
@@ -68,14 +76,46 @@ func (m *Manager) Tools() []glue.Tool {
 	return append([]glue.Tool(nil), m.tools...)
 }
 
+// Resource describes an MCP resource exposed by one configured server.
+type Resource struct {
+	Server      string         `json:"server"`
+	URI         string         `json:"uri"`
+	Name        string         `json:"name"`
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	MIMEType    string         `json:"mime_type,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+	Size        *int64         `json:"size,omitempty"`
+}
+
+// Resources lists resource metadata from servers that advertise MCP resource
+// support. It does not read resource contents.
+func (m *Manager) Resources(ctx context.Context) ([]Resource, error) {
+	if m == nil {
+		return nil, nil
+	}
+	var out []Resource
+	for _, server := range m.servers {
+		if !hasCapability(server.client.InitializeResult(), "resources") {
+			continue
+		}
+		resources, err := listResources(ctx, server.client, server.cfg, server.name)
+		if err != nil {
+			return nil, fmt.Errorf("mcp: server %q: %w", server.name, err)
+		}
+		out = append(out, resources...)
+	}
+	return out, nil
+}
+
 // Close releases all MCP client transports owned by the manager.
 func (m *Manager) Close() error {
 	if m == nil {
 		return nil
 	}
 	var errs []error
-	for _, client := range m.clients {
-		if err := client.Close(); err != nil {
+	for _, server := range m.servers {
+		if err := server.client.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -86,6 +126,11 @@ type listToolsResult struct {
 	Tools []toolDefinition `json:"tools"`
 }
 
+type listResourcesResult struct {
+	Resources  []resourceDefinition `json:"resources"`
+	NextCursor string               `json:"nextCursor,omitempty"`
+}
+
 type toolDefinition struct {
 	Name         string          `json:"name"`
 	Title        string          `json:"title,omitempty"`
@@ -93,6 +138,16 @@ type toolDefinition struct {
 	InputSchema  json.RawMessage `json:"inputSchema,omitempty"`
 	OutputSchema json.RawMessage `json:"outputSchema,omitempty"`
 	Annotations  map[string]any  `json:"annotations,omitempty"`
+}
+
+type resourceDefinition struct {
+	URI         string         `json:"uri"`
+	Name        string         `json:"name"`
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	MIMEType    string         `json:"mimeType,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+	Size        *int64         `json:"size,omitempty"`
 }
 
 type callToolResult struct {
@@ -124,6 +179,56 @@ func listGlueTools(ctx context.Context, client *Client, cfg ServerConfig, server
 		out = append(out, tool)
 	}
 	return out, nil
+}
+
+func listResources(ctx context.Context, client *Client, cfg ServerConfig, serverName string) ([]Resource, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeoutFor(cfg))
+	defer cancel()
+
+	var out []Resource
+	var cursor string
+	for {
+		var params any
+		if cursor != "" {
+			params = map[string]string{"cursor": cursor}
+		}
+		var listed listResourcesResult
+		if err := client.Request(reqCtx, "resources/list", params, &listed); err != nil {
+			return nil, err
+		}
+		for _, def := range listed.Resources {
+			resource, err := mapResource(serverName, def)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, resource)
+		}
+		if listed.NextCursor == "" {
+			return out, nil
+		}
+		cursor = listed.NextCursor
+	}
+}
+
+func mapResource(serverName string, def resourceDefinition) (Resource, error) {
+	uri := strings.TrimSpace(def.URI)
+	name := strings.TrimSpace(def.Name)
+	if uri == "" {
+		return Resource{}, errors.New("mcp: resource uri is required")
+	}
+	if name == "" {
+		return Resource{}, fmt.Errorf("mcp: resource %q name is required", uri)
+	}
+	return Resource{
+		Server:      serverName,
+		URI:         uri,
+		Name:        name,
+		Title:       strings.TrimSpace(def.Title),
+		Description: strings.TrimSpace(def.Description),
+		MIMEType:    strings.TrimSpace(def.MIMEType),
+		Annotations: cloneMap(def.Annotations),
+		Size:        cloneInt64(def.Size),
+	}, nil
 }
 
 func mapTool(client *Client, cfg ServerConfig, serverName, serverPart string, def toolDefinition, seen map[string]struct{}) (glue.Tool, error) {
@@ -261,6 +366,21 @@ func (t remoteTool) mapResult(result callToolResult) glue.ToolResult {
 	}
 }
 
+func shouldListTools(init InitializeResult) bool {
+	if hasCapability(init, "tools") {
+		return true
+	}
+	return len(init.Capabilities) == 0
+}
+
+func hasCapability(init InitializeResult, name string) bool {
+	if len(init.Capabilities) == 0 {
+		return false
+	}
+	_, ok := init.Capabilities[name]
+	return ok
+}
+
 func timeoutFor(cfg ServerConfig) time.Duration {
 	if cfg.Timeout > 0 {
 		return cfg.Timeout
@@ -370,4 +490,12 @@ func cloneMap(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func cloneInt64(in *int64) *int64 {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }

--- a/tools/mcp/tools_test.go
+++ b/tools/mcp/tools_test.go
@@ -144,6 +144,72 @@ func TestManagerRejectsToolNameCollision(t *testing.T) {
 	}
 }
 
+func TestManagerListsMCPResources(t *testing.T) {
+	cfg := helperConfig("resources")
+	cfg.Name = "fake-server"
+	mgr, err := NewManager(context.Background(), []ServerConfig{cfg}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	resources, err := mgr.Resources(context.Background())
+	if err != nil {
+		t.Fatalf("Resources: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources = %d, want 1: %+v", len(resources), resources)
+	}
+	resource := resources[0]
+	if resource.Server != "fake-server" || resource.URI != "file:///workspace/README.md" || resource.Name != "readme" {
+		t.Fatalf("resource identity = %+v", resource)
+	}
+	if resource.Title != "Project README" || resource.Description != "repository overview" || resource.MIMEType != "text/markdown" {
+		t.Fatalf("resource metadata = %+v", resource)
+	}
+	if resource.Size == nil || *resource.Size != 1234 {
+		t.Fatalf("resource size = %+v", resource.Size)
+	}
+	if resource.Annotations["priority"].(float64) != 0.8 {
+		t.Fatalf("annotations = %+v", resource.Annotations)
+	}
+}
+
+func TestManagerSkipsServersWithoutResources(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("tools")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	resources, err := mgr.Resources(context.Background())
+	if err != nil {
+		t.Fatalf("Resources: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("resources = %+v, want none", resources)
+	}
+}
+
+func TestManagerSupportsResourceOnlyServers(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("resources_only")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+	if len(mgr.Tools()) != 0 {
+		t.Fatalf("tools = %+v, want none", mgr.Tools())
+	}
+
+	resources, err := mgr.Resources(context.Background())
+	if err != nil {
+		t.Fatalf("Resources: %v", err)
+	}
+	if len(resources) != 1 || resources[0].URI != "file:///workspace/README.md" {
+		t.Fatalf("resources = %+v", resources)
+	}
+}
+
 func requireTool(t *testing.T, tools []glue.Tool, name string) glue.Tool {
 	t.Helper()
 	for _, tool := range tools {


### PR DESCRIPTION
Closes #204.

## Summary
- Add read-only MCP resource metadata discovery through `tools/mcp.Manager.Resources`.
- Add `peggy mcp resources` with human and JSON output for configured Peggy MCP servers.
- Accept resource-only MCP servers and skip servers that do not advertise resource support.
- Update Peggy MCP docs.

## Validation
- `go test ./tools/mcp -run 'TestManager(Exposes|Uses|Maps|Rejects|ListsMCPResources|SkipsServersWithoutResources|SupportsResourceOnlyServers)' -count=1`
- `go test ./agents/peggy -run 'TestRunMCP(Resources|Tools|Usage)|TestPeggyMCP|TestMCPServerConfigs' -count=1`
- `git diff --check -- tools/mcp/tools.go tools/mcp/tools_test.go tools/mcp/client_test.go tools/mcp/doc.go agents/peggy/mcp.go agents/peggy/mcp_test.go agents/peggy/runner.go agents/peggy/runner_test.go agents/peggy/README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`