### PR TITLE
agents/peggy: read MCP resources

### DIFF
--- a/agents/glue-review/fixture_test.go
+++ b/agents/glue-review/fixture_test.go
@@ -183,6 +183,9 @@ func TestFixtureReplayRetryClassifiers(t *testing.T) {
 	if !isRetryableFixtureReplayError(fmt.Errorf("rc=1 stderr=[failover] openrouter failed: context deadline exceeded")) {
 		t.Fatal("context deadline from live upstream should be retryable")
 	}
+	if !isRetryableFixtureReplayError(fmt.Errorf("rc=1 stderr=openrouter: http 404: Model not found provider_name=OpenInference")) {
+		t.Fatal("OpenRouter free-router model miss should be retryable")
+	}
 	if !isUpstreamRateLimit(fmt.Errorf("openrouter http 429: Rate limit exceeded")) {
 		t.Fatal("429 rate limit should be classified as upstream rate limit")
 	}
@@ -245,7 +248,15 @@ func isRetryableFixtureReplayError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "invalid JSON arguments") ||
 		(strings.Contains(msg, "tool call") && strings.Contains(msg, "invalid JSON")) ||
-		strings.Contains(msg, "context deadline exceeded")
+		strings.Contains(msg, "context deadline exceeded") ||
+		isOpenRouterModelRoutingMiss(msg)
+}
+
+func isOpenRouterModelRoutingMiss(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "openrouter") &&
+		strings.Contains(msg, "model not found") &&
+		strings.Contains(msg, "openinference")
 }
 
 func isRetryableFixtureReplayReview(review string) bool {

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -21,6 +21,7 @@ A long-running personal-assistant agent built on the
 - per-call permission prompts for side-effecting coding tools in the
   CLI, Telegram, and daemon clients
 - per-channel permission tiers (`prompt`, `read_only`, `trusted`)
+- opt-in MCP tools plus resource listing and resource reads
 - four model backends: Codex (ChatGPT subscription), Gemini,
   OpenRouter, NVIDIA build
 
@@ -137,7 +138,7 @@ and emits a stderr diagnostic.
 | `mcp.servers.<name>.work_dir` | current process dir | Working directory for the stdio server. `~` and `$HOME` expand. |
 | `mcp.servers.<name>.url` | none | Streamable HTTP MCP endpoint URL. Required for `transport: "http"`. |
 | `mcp.servers.<name>.headers_env` | `{}` | Map HTTP header names to env var names. Peggy resolves the env vars at startup and does not write secret values back to settings. |
-| `mcp.servers.<name>.timeout_seconds` | `30` | Timeout for initialize, `tools/list`, and individual `tools/call` requests. |
+| `mcp.servers.<name>.timeout_seconds` | `30` | Timeout for initialize, `tools/list`, `tools/call`, `resources/list`, and `resources/read` requests. |
 | `permissions.default_tier` | `prompt` | Permission tier for side-effecting tools when a channel has no override. One of `prompt`, `read_only`, or `trusted`. |
 | `permissions.channels.<name>` | inherited | Channel override keyed by `cli`, `telegram`, or a future daemon client prefix. |
 
@@ -148,6 +149,7 @@ defaults above and emits a stderr diagnostic.
 
 ```
 peggy [flags] "<prompt text>"
+peggy mcp read [flags]
 peggy mcp resources [flags]
 peggy mcp tools [flags]
 peggy serve [flags]
@@ -341,24 +343,29 @@ For HTTP servers, keep tokens in environment variables and point
 ```
 
 Discovered MCP tools are exposed to the model as namespaced tools such
-as `mcp_filesystem_read_file`. Permission prompts use the existing
-channel tier settings: `prompt` asks the owning client, `read_only`
-denies before execution, and `trusted` allows the call subject to the
-server configuration and timeout.
+as `mcp_filesystem_read_file`. Resource-capable servers also expose a
+permission-gated `mcp_<server>_read_resource` tool that reads a URI
+from that server. Permission prompts use the existing channel tier
+settings: `prompt` asks the owning client, `read_only` denies before
+execution, and `trusted` allows the call subject to the server
+configuration and timeout.
 
 Inspect the configured MCP surface without constructing a model
 provider or running a prompt:
 
 ```sh
+peggy mcp read --config ~/.config/peggy/settings.json --server filesystem --uri file:///workspace/README.md
+peggy mcp read --config ~/.config/peggy/settings.json --server filesystem --uri file:///workspace/README.md --json
 peggy mcp resources --config ~/.config/peggy/settings.json
 peggy mcp resources --config ~/.config/peggy/settings.json --json
 peggy mcp tools --config ~/.config/peggy/settings.json
 peggy mcp tools --config ~/.config/peggy/settings.json --json
 ```
 
-`peggy mcp resources` lists resource metadata only; it does not fetch
-resource contents. Servers that do not advertise resource support are
-skipped.
+`peggy mcp resources` lists resource metadata only. `peggy mcp read`
+fetches one resource URI for operator inspection. Servers that do not
+advertise resource support are skipped for listing and cannot serve
+resource reads.
 
 The permission choices are intentionally small:
 

--- a/agents/peggy/mcp.go
+++ b/agents/peggy/mcp.go
@@ -63,6 +63,25 @@ func MCPResources(ctx context.Context, settings MCPSettings) ([]toolsmcp.Resourc
 	return resources, manager, normalized, nil
 }
 
+// MCPReadResource initializes Peggy's configured MCP servers and reads one
+// resource URI from the named server.
+func MCPReadResource(ctx context.Context, settings MCPSettings, serverName, uri string) (toolsmcp.ResourceRead, *toolsmcp.Manager, MCPSettings, error) {
+	configs, normalized, err := MCPServerConfigs(settings)
+	if err != nil {
+		return toolsmcp.ResourceRead{}, nil, normalized, err
+	}
+	manager, err := toolsmcp.NewManager(ctx, configs, toolsmcp.Options{})
+	if err != nil {
+		return toolsmcp.ResourceRead{}, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	read, err := manager.ReadResource(ctx, serverName, uri)
+	if err != nil {
+		_ = manager.Close()
+		return toolsmcp.ResourceRead{}, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	return read, manager, normalized, nil
+}
+
 // MCPServerConfigs converts Peggy settings into tools/mcp server configs.
 func MCPServerConfigs(settings MCPSettings) ([]toolsmcp.ServerConfig, MCPSettings, error) {
 	normalized, err := expandMCPSettings(settings)

--- a/agents/peggy/mcp_test.go
+++ b/agents/peggy/mcp_test.go
@@ -160,6 +160,48 @@ func TestPeggyMCPToolUsesPermissionPath(t *testing.T) {
 	}
 }
 
+func TestPeggyRegistersMCPResourceReadToolWhenEnabled(t *testing.T) {
+	provider := &fakeProvider{text: "ok"}
+	p := newMCPTestPeggy(t, provider, glue.AllowAll{}, mcpTestServer("resources_only", ""))
+
+	if _, err := p.Prompt(context.Background(), "s", "what resources are available?", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(provider.requests) == 0 {
+		t.Fatal("provider not called")
+	}
+	var names []string
+	for _, tool := range provider.requests[0].Tools {
+		names = append(names, tool.Name)
+	}
+	if !containsString(names, "mcp_fake_read_resource") {
+		t.Fatalf("tools = %v, missing mcp_fake_read_resource", names)
+	}
+}
+
+func TestPeggyMCPResourceReadUsesPermissionPath(t *testing.T) {
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("call_1", "mcp_fake_read_resource", `{"uri":"file:///workspace/README.md"}`),
+		peggyTextTurn("done"),
+	}}
+	perm := &recordingPermission{decision: glue.PermissionDecision{Allow: true}}
+	p := newMCPTestPeggy(t, provider, perm, mcpTestServer("resources_only", ""))
+
+	if _, err := p.Prompt(context.Background(), "s", "read resource", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(perm.requests) != 1 {
+		t.Fatalf("permission requests = %d, want 1", len(perm.requests))
+	}
+	req := perm.requests[0]
+	if req.Tool != "mcp_fake_read_resource" || req.Action != "mcp_read_resource" || req.Target != "fake:file:///workspace/README.md" {
+		t.Fatalf("permission request = %+v", req)
+	}
+	if string(req.Args) != `{"uri":"file:///workspace/README.md"}` {
+		t.Fatalf("permission args = %s", req.Args)
+	}
+}
+
 func TestPeggyMCPReadOnlyTierDeniesBeforeExecution(t *testing.T) {
 	callFile := filepath.Join(t.TempDir(), "called")
 	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
@@ -348,8 +390,30 @@ func runPeggyMCPHelper() error {
 			}); err != nil {
 				return err
 			}
+		case "resources/read":
+			if scenario != "resources" && scenario != "resources_only" {
+				return fmt.Errorf("method = %q, want tools/list, tools/call, or resources/list", req.Method)
+			}
+			var params struct {
+				URI string `json:"uri"`
+			}
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				return err
+			}
+			if params.URI != "file:///workspace/README.md" {
+				return fmt.Errorf("resource uri = %q, want file:///workspace/README.md", params.URI)
+			}
+			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
+				"contents": []map[string]any{{
+					"uri":      params.URI,
+					"mimeType": "text/markdown",
+					"text":     "# Project README\n\nHello from Peggy MCP resource.",
+				}},
+			}); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("method = %q, want tools/list, tools/call, or resources/list", req.Method)
+			return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, or resources/read", req.Method)
 		}
 	}
 }

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -201,12 +201,14 @@ func runMCP(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, `peggy mcp — inspect Peggy's configured MCP surface.
 
 Usage:
+  peggy mcp read [flags]
   peggy mcp resources [flags]
   peggy mcp tools [flags]
 
 Commands:
+  read       Read one resource URI from an enabled MCP server.
   resources  List resources discovered from enabled MCP servers.
-  tools    List tools discovered from enabled MCP servers.
+  tools      List tools discovered from enabled MCP servers.
 `)
 	}
 	if len(args) == 0 {
@@ -217,6 +219,8 @@ Commands:
 	case "-h", "--help", "help":
 		usage()
 		return 0
+	case "read":
+		return runMCPRead(ctx, args[1:], stdout, stderr)
 	case "resources":
 		return runMCPResources(ctx, args[1:], stdout, stderr)
 	case "tools":
@@ -226,6 +230,81 @@ Commands:
 		usage()
 		return 2
 	}
+}
+
+func runMCPRead(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy mcp read", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		serverName = fs.String("server", "", "configured MCP server name")
+		uri        = fs.String("uri", "", "MCP resource URI to read")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy mcp read — read one resource from an enabled MCP server.
+
+Usage:
+  peggy mcp read --server <name> --uri <uri> [flags]
+
+Examples:
+  peggy mcp read --config ~/.config/peggy/settings.json --server filesystem --uri file:///workspace/README.md
+  peggy mcp read --server filesystem --uri file:///workspace/README.md --json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy mcp read: positional args not supported")
+		return 2
+	}
+	if strings.TrimSpace(*serverName) == "" {
+		fmt.Fprintln(stderr, "peggy mcp read: --server is required")
+		return 2
+	}
+	if strings.TrimSpace(*uri) == "" {
+		fmt.Fprintln(stderr, "peggy mcp read: --uri is required")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp read: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy mcp read: no settings.json found; using built-in defaults")
+	}
+
+	read, manager, _, err := MCPReadResource(ctx, settings.MCP, *serverName, *uri)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp read: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := manager.Close(); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp read: close: %v\n", err)
+		}
+	}()
+
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(read); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp read: encode resource: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeMCPResourceRead(stdout, read)
+	return 0
 }
 
 func runMCPResources(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -446,6 +525,39 @@ func writeMCPResourceCatalog(w io.Writer, catalog []mcpResourceCatalogEntry) {
 			if err == nil {
 				fmt.Fprintf(w, "  annotations: %s\n", compactJSONLine(raw))
 			}
+		}
+	}
+}
+
+func writeMCPResourceRead(w io.Writer, read toolsmcp.ResourceRead) {
+	if len(read.Contents) == 0 {
+		fmt.Fprintln(w, "No MCP resource contents returned.")
+		return
+	}
+	for i, item := range read.Contents {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, item.URI)
+		fmt.Fprintf(w, "  server: %s\n", read.Server)
+		fmt.Fprintf(w, "  requested_uri: %s\n", read.URI)
+		if item.MIMEType != "" {
+			fmt.Fprintf(w, "  mime_type: %s\n", item.MIMEType)
+		}
+		if len(item.Meta) > 0 {
+			raw, err := json.Marshal(item.Meta)
+			if err == nil {
+				fmt.Fprintf(w, "  meta: %s\n", compactJSONLine(raw))
+			}
+		}
+		switch {
+		case item.Text != nil:
+			fmt.Fprintln(w, "  text:")
+			for _, line := range strings.Split(*item.Text, "\n") {
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+		case item.Blob != nil:
+			fmt.Fprintf(w, "  blob: %s\n", *item.Blob)
 		}
 	}
 }

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	toolsmcp "github.com/erain/glue/tools/mcp"
 )
 
 func TestRun_Version(t *testing.T) {
@@ -299,6 +301,67 @@ func TestRunMCPResourcesJSON(t *testing.T) {
 	}
 	if entry.Size == nil || *entry.Size != 1234 {
 		t.Fatalf("size = %+v", entry.Size)
+	}
+}
+
+func TestRunMCPReadRequiresFlags(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "read"}, &out, &errOut)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut.String(), "--server is required") {
+		t.Fatalf("stderr = %q, want server diagnostic", errOut.String())
+	}
+}
+
+func TestRunMCPReadResource(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("resources_only", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "read", "--config", cfgPath, "--server", "fake", "--uri", "file:///workspace/README.md"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"file:///workspace/README.md",
+		"server: fake",
+		"requested_uri: file:///workspace/README.md",
+		"mime_type: text/markdown",
+		"Hello from Peggy MCP resource.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stdout = %q, missing %q", text, want)
+		}
+	}
+}
+
+func TestRunMCPReadJSON(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("resources_only", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "read", "--config", cfgPath, "--server", "fake", "--uri", "file:///workspace/README.md", "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var read toolsmcp.ResourceRead
+	if err := json.Unmarshal(out.Bytes(), &read); err != nil {
+		t.Fatalf("decode read: %v\nstdout=%s", err, out.String())
+	}
+	if read.Server != "fake" || read.URI != "file:///workspace/README.md" || len(read.Contents) != 1 {
+		t.Fatalf("read = %+v", read)
+	}
+	if read.Contents[0].Text == nil || !strings.Contains(*read.Contents[0].Text, "Peggy MCP resource") {
+		t.Fatalf("contents = %+v", read.Contents)
 	}
 }
 

--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -206,8 +206,15 @@ func runMCPToolScenario(dec *json.Decoder, enc *json.Encoder, scenario string) e
 			if err := writeHelperResult(enc, req.ID, helperResourcesList()); err != nil {
 				return err
 			}
+		case "resources/read":
+			if scenario != "resources" && scenario != "resources_only" {
+				return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			}
+			if err := handleHelperResourceRead(enc, req); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("method = %q, want tools/list, tools/call, or resources/list", req.Method)
+			return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, or resources/read", req.Method)
 		}
 	}
 }
@@ -261,6 +268,33 @@ func helperResourcesList() map[string]any {
 			"size":        1234,
 		}},
 	}
+}
+
+func handleHelperResourceRead(enc *json.Encoder, req helperRequest) error {
+	var params struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return err
+	}
+	if params.URI != "file:///workspace/README.md" {
+		return fmt.Errorf("resource uri = %q, want file:///workspace/README.md", params.URI)
+	}
+	return writeHelperResult(enc, req.ID, map[string]any{
+		"contents": []map[string]any{
+			{
+				"uri":      params.URI,
+				"mimeType": "text/markdown",
+				"text":     "# Project README\n\nHello from MCP resource.",
+				"_meta":    map[string]any{"etag": "abc123"},
+			},
+			{
+				"uri":      "file:///workspace/logo.png",
+				"mimeType": "image/png",
+				"blob":     "aW1hZ2U=",
+			},
+		},
+	})
 }
 
 func handleHelperToolCall(enc *json.Encoder, req helperRequest) error {

--- a/tools/mcp/doc.go
+++ b/tools/mcp/doc.go
@@ -3,7 +3,7 @@
 //
 // This package follows ADR-0011. It supports JSON-RPC lifecycle negotiation
 // over stdio and Streamable HTTP, discovery of MCP server tools, mapping
-// those tools to permission-gated glue.Tool values, and read-only resource
-// metadata inspection. Prompts, resource reads, sampling, elicitation, OAuth,
-// and dynamic discovery are deferred follow-up surfaces.
+// those tools to permission-gated glue.Tool values, read-only resource
+// metadata inspection, and permission-gated resource reads. Prompts, sampling,
+// elicitation, OAuth, and dynamic discovery are deferred follow-up surfaces.
 package mcp

--- a/tools/mcp/tools.go
+++ b/tools/mcp/tools.go
@@ -14,6 +14,7 @@ import (
 )
 
 var emptyObjectSchema = json.RawMessage(`{"type":"object","additionalProperties":false}`)
+var readResourceSchema = json.RawMessage(`{"type":"object","properties":{"uri":{"type":"string","description":"MCP resource URI to read from this server."}},"required":["uri"],"additionalProperties":false}`)
 
 // Options configures an MCP manager. It is intentionally empty for the first
 // stdio/tool-mapping slice so future compatibility options have a stable home.
@@ -64,6 +65,9 @@ func NewManager(ctx context.Context, configs []ServerConfig, _ Options) (*Manage
 			}
 			m.tools = append(m.tools, tools...)
 		}
+		if hasCapability(client.InitializeResult(), "resources") {
+			m.tools = append(m.tools, mapResourceReadTool(client, cfg, serverName, serverPart, seen))
+		}
 	}
 	return m, nil
 }
@@ -88,6 +92,22 @@ type Resource struct {
 	Size        *int64         `json:"size,omitempty"`
 }
 
+// ResourceRead contains the contents returned by an MCP resources/read call.
+type ResourceRead struct {
+	Server   string            `json:"server"`
+	URI      string            `json:"uri"`
+	Contents []ResourceContent `json:"contents"`
+}
+
+// ResourceContent is one text or blob content item returned from a resource.
+type ResourceContent struct {
+	URI      string         `json:"uri"`
+	MIMEType string         `json:"mime_type,omitempty"`
+	Text     *string        `json:"text,omitempty"`
+	Blob     *string        `json:"blob,omitempty"`
+	Meta     map[string]any `json:"_meta,omitempty"`
+}
+
 // Resources lists resource metadata from servers that advertise MCP resource
 // support. It does not read resource contents.
 func (m *Manager) Resources(ctx context.Context) ([]Resource, error) {
@@ -106,6 +126,31 @@ func (m *Manager) Resources(ctx context.Context) ([]Resource, error) {
 		out = append(out, resources...)
 	}
 	return out, nil
+}
+
+// ReadResource reads a resource URI from one named configured MCP server.
+func (m *Manager) ReadResource(ctx context.Context, serverName, uri string) (ResourceRead, error) {
+	if m == nil {
+		return ResourceRead{}, errors.New("mcp: manager is nil")
+	}
+	serverName = strings.TrimSpace(serverName)
+	if serverName == "" {
+		return ResourceRead{}, errors.New("mcp: resource server is required")
+	}
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return ResourceRead{}, errors.New("mcp: resource uri is required")
+	}
+	for _, server := range m.servers {
+		if server.name != serverName {
+			continue
+		}
+		if !hasCapability(server.client.InitializeResult(), "resources") {
+			return ResourceRead{}, fmt.Errorf("mcp: server %q does not support resources", serverName)
+		}
+		return readResource(ctx, server.client, server.cfg, serverName, uri)
+	}
+	return ResourceRead{}, fmt.Errorf("mcp: server %q is not configured", serverName)
 }
 
 // Close releases all MCP client transports owned by the manager.
@@ -131,6 +176,10 @@ type listResourcesResult struct {
 	NextCursor string               `json:"nextCursor,omitempty"`
 }
 
+type readResourceResult struct {
+	Contents []resourceContentDefinition `json:"contents"`
+}
+
 type toolDefinition struct {
 	Name         string          `json:"name"`
 	Title        string          `json:"title,omitempty"`
@@ -150,6 +199,14 @@ type resourceDefinition struct {
 	Size        *int64         `json:"size,omitempty"`
 }
 
+type resourceContentDefinition struct {
+	URI      string         `json:"uri"`
+	MIMEType string         `json:"mimeType,omitempty"`
+	Text     *string        `json:"text,omitempty"`
+	Blob     *string        `json:"blob,omitempty"`
+	Meta     map[string]any `json:"_meta,omitempty"`
+}
+
 type callToolResult struct {
 	Content           []json.RawMessage `json:"content,omitempty"`
 	StructuredContent json.RawMessage   `json:"structuredContent,omitempty"`
@@ -159,6 +216,10 @@ type callToolResult struct {
 type callToolParams struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type readResourceParams struct {
+	URI string `json:"uri"`
 }
 
 func listGlueTools(ctx context.Context, client *Client, cfg ServerConfig, serverName, serverPart string, seen map[string]struct{}) ([]glue.Tool, error) {
@@ -210,6 +271,50 @@ func listResources(ctx context.Context, client *Client, cfg ServerConfig, server
 	}
 }
 
+func readResource(ctx context.Context, client *Client, cfg ServerConfig, serverName, uri string) (ResourceRead, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeoutFor(cfg))
+	defer cancel()
+
+	var result readResourceResult
+	if err := client.Request(reqCtx, "resources/read", readResourceParams{URI: uri}, &result); err != nil {
+		return ResourceRead{}, err
+	}
+
+	contents := make([]ResourceContent, 0, len(result.Contents))
+	for _, def := range result.Contents {
+		content, err := mapResourceContent(def)
+		if err != nil {
+			return ResourceRead{}, err
+		}
+		contents = append(contents, content)
+	}
+	return ResourceRead{
+		Server:   serverName,
+		URI:      uri,
+		Contents: contents,
+	}, nil
+}
+
+func mapResourceContent(def resourceContentDefinition) (ResourceContent, error) {
+	uri := strings.TrimSpace(def.URI)
+	if uri == "" {
+		return ResourceContent{}, errors.New("mcp: resource content uri is required")
+	}
+	if def.Text == nil && def.Blob == nil {
+		return ResourceContent{}, fmt.Errorf("mcp: resource content %q must include text or blob", uri)
+	}
+	if def.Text != nil && def.Blob != nil {
+		return ResourceContent{}, fmt.Errorf("mcp: resource content %q includes both text and blob", uri)
+	}
+	return ResourceContent{
+		URI:      uri,
+		MIMEType: strings.TrimSpace(def.MIMEType),
+		Text:     cloneString(def.Text),
+		Blob:     cloneString(def.Blob),
+		Meta:     cloneMap(def.Meta),
+	}, nil
+}
+
 func mapResource(serverName string, def resourceDefinition) (Resource, error) {
 	uri := strings.TrimSpace(def.URI)
 	name := strings.TrimSpace(def.Name)
@@ -229,6 +334,34 @@ func mapResource(serverName string, def resourceDefinition) (Resource, error) {
 		Annotations: cloneMap(def.Annotations),
 		Size:        cloneInt64(def.Size),
 	}, nil
+}
+
+func mapResourceReadTool(client *Client, cfg ServerConfig, serverName, serverPart string, seen map[string]struct{}) glue.Tool {
+	glueName := reserveGeneratedToolName("mcp_"+serverPart+"_read_resource", seen)
+	remote := resourceReadTool{
+		client:     client,
+		serverName: serverName,
+		glueName:   glueName,
+		timeout:    timeoutFor(cfg),
+	}
+
+	return glue.Tool{
+		ToolSpec: glue.ToolSpec{
+			Name:               glueName,
+			Description:        fmt.Sprintf("Read MCP resource contents from server %s by URI.", serverName),
+			Parameters:         append(json.RawMessage(nil), readResourceSchema...),
+			RequiresPermission: true,
+			PermissionAction:   "mcp_read_resource",
+			PermissionTarget: func(call glue.ToolCall) string {
+				uri := resourceURIFromArgs(call.Arguments)
+				if uri == "" {
+					return serverName
+				}
+				return serverName + ":" + uri
+			},
+		},
+		Execute: remote.execute,
+	}
 }
 
 func mapTool(client *Client, cfg ServerConfig, serverName, serverPart string, def toolDefinition, seen map[string]struct{}) (glue.Tool, error) {
@@ -279,6 +412,56 @@ func mapTool(client *Client, cfg ServerConfig, serverName, serverPart string, de
 		},
 		Execute: remote.execute,
 	}, nil
+}
+
+type resourceReadTool struct {
+	client     *Client
+	serverName string
+	glueName   string
+	timeout    time.Duration
+}
+
+func (t resourceReadTool) execute(ctx context.Context, call glue.ToolCall) (glue.ToolResult, error) {
+	uri := resourceURIFromArgs(call.Arguments)
+	if uri == "" {
+		return glue.ErrorResult(errors.New("mcp: resource uri is required")), nil
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+
+	read, err := readResource(reqCtx, t.client, ServerConfig{Timeout: t.timeout}, t.serverName, uri)
+	if err != nil {
+		var rpcErr *RPCError
+		if errors.As(err, &rpcErr) {
+			return glue.ErrorResult(err), nil
+		}
+		return glue.ToolResult{}, err
+	}
+	return t.mapResult(read), nil
+}
+
+func (t resourceReadTool) mapResult(read ResourceRead) glue.ToolResult {
+	metadata := map[string]any{
+		"mcp_server":        t.serverName,
+		"mcp_resource_uri":  read.URI,
+		"mcp_glue_tool":     t.glueName,
+		"mcp_resource_read": resourceContentsMetadata(read.Contents),
+	}
+
+	content := make([]glue.ContentPart, 0, len(read.Contents))
+	for _, item := range read.Contents {
+		switch {
+		case item.Text != nil:
+			content = append(content, glue.ContentPart{Type: glue.ContentTypeText, Text: *item.Text})
+		case item.Blob != nil:
+			content = append(content, glue.ContentPart{Type: glue.ContentTypeText, Text: resourceBlobContentLine(item)})
+		}
+	}
+	return glue.ToolResult{
+		Content:  content,
+		Metadata: metadata,
+	}
 }
 
 type remoteTool struct {
@@ -381,6 +564,30 @@ func hasCapability(init InitializeResult, name string) bool {
 	return ok
 }
 
+func reserveGeneratedToolName(base string, seen map[string]struct{}) string {
+	if _, ok := seen[base]; !ok {
+		seen[base] = struct{}{}
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d", base, i)
+		if _, ok := seen[candidate]; !ok {
+			seen[candidate] = struct{}{}
+			return candidate
+		}
+	}
+}
+
+func resourceURIFromArgs(raw json.RawMessage) string {
+	var args struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(args.URI)
+}
+
 func timeoutFor(cfg ServerConfig) time.Duration {
 	if cfg.Timeout > 0 {
 		return cfg.Timeout
@@ -481,6 +688,47 @@ func decodeRaw(raw json.RawMessage) any {
 	return v
 }
 
+func resourceContentsMetadata(contents []ResourceContent) []map[string]any {
+	out := make([]map[string]any, 0, len(contents))
+	for _, item := range contents {
+		entry := map[string]any{"uri": item.URI}
+		if item.MIMEType != "" {
+			entry["mime_type"] = item.MIMEType
+		}
+		if item.Text != nil {
+			entry["kind"] = "text"
+			entry["bytes"] = len(*item.Text)
+		}
+		if item.Blob != nil {
+			entry["kind"] = "blob"
+			entry["base64_bytes"] = len(*item.Blob)
+		}
+		if len(item.Meta) > 0 {
+			entry["_meta"] = cloneMap(item.Meta)
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func resourceBlobContentLine(item ResourceContent) string {
+	entry := map[string]any{
+		"uri":  item.URI,
+		"blob": "",
+	}
+	if item.Blob != nil {
+		entry["blob"] = *item.Blob
+	}
+	if item.MIMEType != "" {
+		entry["mime_type"] = item.MIMEType
+	}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
 func cloneMap(in map[string]any) map[string]any {
 	if len(in) == 0 {
 		return nil
@@ -490,6 +738,14 @@ func cloneMap(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func cloneString(in *string) *string {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func cloneInt64(in *int64) *int64 {

--- a/tools/mcp/tools_test.go
+++ b/tools/mcp/tools_test.go
@@ -175,6 +175,74 @@ func TestManagerListsMCPResources(t *testing.T) {
 	}
 }
 
+func TestManagerReadsMCPResource(t *testing.T) {
+	cfg := helperConfig("resources")
+	cfg.Name = "fake-server"
+	mgr, err := NewManager(context.Background(), []ServerConfig{cfg}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	read, err := mgr.ReadResource(context.Background(), "fake-server", "file:///workspace/README.md")
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	if read.Server != "fake-server" || read.URI != "file:///workspace/README.md" {
+		t.Fatalf("read identity = %+v", read)
+	}
+	if len(read.Contents) != 2 {
+		t.Fatalf("contents = %d, want 2: %+v", len(read.Contents), read.Contents)
+	}
+	first := read.Contents[0]
+	if first.Text == nil || !strings.Contains(*first.Text, "Hello from MCP resource") || first.MIMEType != "text/markdown" {
+		t.Fatalf("text content = %+v", first)
+	}
+	if first.Meta["etag"] != "abc123" {
+		t.Fatalf("text meta = %+v", first.Meta)
+	}
+	second := read.Contents[1]
+	if second.Blob == nil || *second.Blob != "aW1hZ2U=" || second.MIMEType != "image/png" {
+		t.Fatalf("blob content = %+v", second)
+	}
+}
+
+func TestManagerExposesResourceReadTool(t *testing.T) {
+	cfg := helperConfig("resources")
+	cfg.Name = "fake-server"
+	mgr, err := NewManager(context.Background(), []ServerConfig{cfg}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	tool := requireTool(t, mgr.Tools(), "mcp_fake_server_read_resource")
+	if !tool.RequiresPermission {
+		t.Fatal("RequiresPermission = false, want true")
+	}
+	if tool.PermissionAction != "mcp_read_resource" {
+		t.Fatalf("PermissionAction = %q, want mcp_read_resource", tool.PermissionAction)
+	}
+	args := json.RawMessage(`{"uri":"file:///workspace/README.md"}`)
+	if got := tool.PermissionTarget(glue.ToolCall{Arguments: args}); got != "fake-server:file:///workspace/README.md" {
+		t.Fatalf("PermissionTarget = %q", got)
+	}
+
+	result, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name, Arguments: args})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("IsError = true")
+	}
+	if len(result.Content) != 2 || !strings.Contains(result.Content[0].Text, "Hello from MCP resource") {
+		t.Fatalf("content = %#v", result.Content)
+	}
+	if result.Metadata["mcp_resource_uri"] != "file:///workspace/README.md" {
+		t.Fatalf("metadata = %#v", result.Metadata)
+	}
+}
+
 func TestManagerSkipsServersWithoutResources(t *testing.T) {
 	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("tools")}, Options{})
 	if err != nil {
@@ -197,9 +265,7 @@ func TestManagerSupportsResourceOnlyServers(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	defer mgr.Close()
-	if len(mgr.Tools()) != 0 {
-		t.Fatalf("tools = %+v, want none", mgr.Tools())
-	}
+	requireTool(t, mgr.Tools(), "mcp_fake_read_resource")
 
 	resources, err := mgr.Resources(context.Background())
 	if err != nil {


### PR DESCRIPTION
Closes #206.

## Summary
- Add `tools/mcp.Manager.ReadResource` for MCP `resources/read` text and blob contents.
- Add a generated permission-gated `mcp_<server>_read_resource` tool for resource-capable MCP servers.
- Add `peggy mcp read --server <name> --uri <uri>` with human and JSON output.
- Update Peggy MCP docs and test helpers for resource reads.
- Harden the live glue-review fixture retry classifier for OpenRouter/OpenInference free-router model misses observed in draft CI.

## Validation
- `go test ./tools/mcp -run 'TestManager(Exposes|Uses|Maps|Rejects|ListsMCPResources|ReadsMCPResource|ExposesResourceReadTool|SkipsServersWithoutResources|SupportsResourceOnlyServers)' -count=1`
- `go test ./agents/peggy -run 'TestPeggyMCP|TestRunMCP(Read|Resources|Tools|Usage)|TestMCPServerConfigs' -count=1`
- `go test ./tools/mcp ./agents/peggy -count=1`
- `go test ./agents/glue-review -run TestFixtureReplayRetryClassifiers -count=1`
- `git diff --check -- agents/glue-review/fixture_test.go tools/mcp/tools.go tools/mcp/tools_test.go tools/mcp/client_test.go tools/mcp/doc.go agents/peggy/mcp.go agents/peggy/mcp_test.go agents/peggy/runner.go agents/peggy/runner_test.go agents/peggy/README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`