### PR TITLE
agents/peggy: inspect MCP prompts

### DIFF
--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -21,7 +21,7 @@ A long-running personal-assistant agent built on the
 - per-call permission prompts for side-effecting coding tools in the
   CLI, Telegram, and daemon clients
 - per-channel permission tiers (`prompt`, `read_only`, `trusted`)
-- opt-in MCP tools plus resource listing and resource reads
+- opt-in MCP tools plus resource and prompt inspection
 - four model backends: Codex (ChatGPT subscription), Gemini,
   OpenRouter, NVIDIA build
 
@@ -149,6 +149,8 @@ defaults above and emits a stderr diagnostic.
 
 ```
 peggy [flags] "<prompt text>"
+peggy mcp prompt [flags]
+peggy mcp prompts [flags]
 peggy mcp read [flags]
 peggy mcp resources [flags]
 peggy mcp tools [flags]
@@ -356,6 +358,8 @@ provider or running a prompt:
 ```sh
 peggy mcp read --config ~/.config/peggy/settings.json --server filesystem --uri file:///workspace/README.md
 peggy mcp read --config ~/.config/peggy/settings.json --server filesystem --uri file:///workspace/README.md --json
+peggy mcp prompts --config ~/.config/peggy/settings.json
+peggy mcp prompt --config ~/.config/peggy/settings.json --server linear --name summarize_issue --arg issue=GLUE-123
 peggy mcp resources --config ~/.config/peggy/settings.json
 peggy mcp resources --config ~/.config/peggy/settings.json --json
 peggy mcp tools --config ~/.config/peggy/settings.json
@@ -363,9 +367,11 @@ peggy mcp tools --config ~/.config/peggy/settings.json --json
 ```
 
 `peggy mcp resources` lists resource metadata only. `peggy mcp read`
-fetches one resource URI for operator inspection. Servers that do not
-advertise resource support are skipped for listing and cannot serve
-resource reads.
+fetches one resource URI for operator inspection. `peggy mcp prompts`
+lists prompt templates and `peggy mcp prompt` renders one prompt with
+repeatable `--arg key=value` values. Servers that do not advertise the
+requested MCP capability are skipped for listing and cannot serve that
+request.
 
 The permission choices are intentionally small:
 

--- a/agents/peggy/mcp.go
+++ b/agents/peggy/mcp.go
@@ -82,6 +82,47 @@ func MCPReadResource(ctx context.Context, settings MCPSettings, serverName, uri 
 	return read, manager, normalized, nil
 }
 
+// MCPPrompts initializes Peggy's configured MCP servers and returns
+// discovered prompt metadata plus the manager that owns server lifecycles.
+func MCPPrompts(ctx context.Context, settings MCPSettings) ([]toolsmcp.Prompt, *toolsmcp.Manager, MCPSettings, error) {
+	configs, normalized, err := MCPServerConfigs(settings)
+	if err != nil {
+		return nil, nil, normalized, err
+	}
+	if len(configs) == 0 {
+		return nil, nil, normalized, nil
+	}
+	manager, err := toolsmcp.NewManager(ctx, configs, toolsmcp.Options{})
+	if err != nil {
+		return nil, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	prompts, err := manager.Prompts(ctx)
+	if err != nil {
+		_ = manager.Close()
+		return nil, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	return prompts, manager, normalized, nil
+}
+
+// MCPGetPrompt initializes Peggy's configured MCP servers and renders one
+// prompt by name from the named server.
+func MCPGetPrompt(ctx context.Context, settings MCPSettings, serverName, name string, args map[string]string) (toolsmcp.PromptGet, *toolsmcp.Manager, MCPSettings, error) {
+	configs, normalized, err := MCPServerConfigs(settings)
+	if err != nil {
+		return toolsmcp.PromptGet{}, nil, normalized, err
+	}
+	manager, err := toolsmcp.NewManager(ctx, configs, toolsmcp.Options{})
+	if err != nil {
+		return toolsmcp.PromptGet{}, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	prompt, err := manager.GetPrompt(ctx, serverName, name, args)
+	if err != nil {
+		_ = manager.Close()
+		return toolsmcp.PromptGet{}, nil, normalized, fmt.Errorf("peggy: mcp: %w", err)
+	}
+	return prompt, manager, normalized, nil
+}
+
 // MCPServerConfigs converts Peggy settings into tools/mcp server configs.
 func MCPServerConfigs(settings MCPSettings) ([]toolsmcp.ServerConfig, MCPSettings, error) {
 	normalized, err := expandMCPSettings(settings)

--- a/agents/peggy/mcp_test.go
+++ b/agents/peggy/mcp_test.go
@@ -341,8 +341,8 @@ func runPeggyMCPHelper() error {
 		}
 		switch req.Method {
 		case "tools/list":
-			if scenario == "resources_only" {
-				return fmt.Errorf("resources_only server received tools/list")
+			if scenario == "resources_only" || scenario == "prompts_only" {
+				return fmt.Errorf("%s server received tools/list", scenario)
 			}
 			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
 				"tools": []map[string]any{{
@@ -412,8 +412,56 @@ func runPeggyMCPHelper() error {
 			}); err != nil {
 				return err
 			}
+		case "prompts/list":
+			if scenario != "prompts" && scenario != "prompts_only" {
+				return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, or resources/read", req.Method)
+			}
+			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
+				"prompts": []map[string]any{{
+					"name":        "daily_brief",
+					"title":       "Daily Brief",
+					"description": "Draft a concise daily briefing",
+					"arguments": []map[string]any{{
+						"name":        "topic",
+						"description": "Subject to brief",
+						"required":    true,
+					}},
+				}},
+			}); err != nil {
+				return err
+			}
+		case "prompts/get":
+			if scenario != "prompts" && scenario != "prompts_only" {
+				return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, resources/read, or prompts/list", req.Method)
+			}
+			var params struct {
+				Name      string            `json:"name"`
+				Arguments map[string]string `json:"arguments,omitempty"`
+			}
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				return err
+			}
+			if params.Name != "daily_brief" {
+				return fmt.Errorf("prompt name = %q, want daily_brief", params.Name)
+			}
+			topic := params.Arguments["topic"]
+			if topic == "" {
+				topic = "today"
+			}
+			if err := writePeggyMCPResult(enc, req.ID, map[string]any{
+				"description": "Rendered daily briefing prompt",
+				"messages": []map[string]any{{
+					"role": "user",
+					"content": map[string]any{
+						"type": "text",
+						"text": "Brief me on " + topic + ".",
+					},
+				}},
+			}); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, or resources/read", req.Method)
+			return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, resources/read, prompts/list, or prompts/get", req.Method)
 		}
 	}
 }
@@ -429,6 +477,15 @@ func peggyMCPInitializeResult(scenario string) map[string]any {
 	case "resources_only":
 		capabilities = map[string]any{
 			"resources": map[string]any{},
+		}
+	case "prompts":
+		capabilities = map[string]any{
+			"tools":   map[string]any{},
+			"prompts": map[string]any{},
+		}
+	case "prompts_only":
+		capabilities = map[string]any{
+			"prompts": map[string]any{},
 		}
 	}
 	return map[string]any{

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -196,16 +196,31 @@ type mcpResourceCatalogEntry struct {
 	Size        *int64         `json:"size,omitempty"`
 }
 
+type stringListFlag []string
+
+func (v *stringListFlag) String() string {
+	return strings.Join(*v, ",")
+}
+
+func (v *stringListFlag) Set(s string) error {
+	*v = append(*v, s)
+	return nil
+}
+
 func runMCP(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	usage := func() {
 		fmt.Fprintf(stderr, `peggy mcp — inspect Peggy's configured MCP surface.
 
 Usage:
+  peggy mcp prompt [flags]
+  peggy mcp prompts [flags]
   peggy mcp read [flags]
   peggy mcp resources [flags]
   peggy mcp tools [flags]
 
 Commands:
+  prompt     Render one prompt from an enabled MCP server.
+  prompts    List prompts discovered from enabled MCP servers.
   read       Read one resource URI from an enabled MCP server.
   resources  List resources discovered from enabled MCP servers.
   tools      List tools discovered from enabled MCP servers.
@@ -219,6 +234,10 @@ Commands:
 	case "-h", "--help", "help":
 		usage()
 		return 0
+	case "prompt":
+		return runMCPPrompt(ctx, args[1:], stdout, stderr)
+	case "prompts":
+		return runMCPPrompts(ctx, args[1:], stdout, stderr)
 	case "read":
 		return runMCPRead(ctx, args[1:], stdout, stderr)
 	case "resources":
@@ -230,6 +249,153 @@ Commands:
 		usage()
 		return 2
 	}
+}
+
+func runMCPPrompt(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy mcp prompt", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		serverName = fs.String("server", "", "configured MCP server name")
+		promptName = fs.String("name", "", "MCP prompt name to render")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+		promptArgs stringListFlag
+	)
+	fs.Var(&promptArgs, "arg", "prompt argument as key=value (repeatable)")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy mcp prompt — render one prompt from an enabled MCP server.
+
+Usage:
+  peggy mcp prompt --server <name> --name <prompt> [flags]
+
+Examples:
+  peggy mcp prompt --config ~/.config/peggy/settings.json --server linear --name summarize_issue --arg issue=GLUE-123
+  peggy mcp prompt --server linear --name summarize_issue --arg issue=GLUE-123 --json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy mcp prompt: positional args not supported")
+		return 2
+	}
+	if strings.TrimSpace(*serverName) == "" {
+		fmt.Fprintln(stderr, "peggy mcp prompt: --server is required")
+		return 2
+	}
+	if strings.TrimSpace(*promptName) == "" {
+		fmt.Fprintln(stderr, "peggy mcp prompt: --name is required")
+		return 2
+	}
+	parsedArgs, err := parsePromptArgs(promptArgs)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp prompt: %v\n", err)
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp prompt: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy mcp prompt: no settings.json found; using built-in defaults")
+	}
+
+	prompt, manager, _, err := MCPGetPrompt(ctx, settings.MCP, *serverName, *promptName, parsedArgs)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp prompt: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := manager.Close(); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp prompt: close: %v\n", err)
+		}
+	}()
+
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(prompt); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp prompt: encode prompt: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeMCPPrompt(stdout, prompt)
+	return 0
+}
+
+func runMCPPrompts(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy mcp prompts", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy mcp prompts — list prompts from enabled MCP servers.
+
+Usage:
+  peggy mcp prompts [flags]
+
+Examples:
+  peggy mcp prompts --config ~/.config/peggy/settings.json
+  peggy mcp prompts --json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy mcp prompts: positional args not supported")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp prompts: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy mcp prompts: no settings.json found; using built-in defaults")
+	}
+
+	prompts, manager, _, err := MCPPrompts(ctx, settings.MCP)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy mcp prompts: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := manager.Close(); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp prompts: close: %v\n", err)
+		}
+	}()
+
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(prompts); err != nil {
+			fmt.Fprintf(stderr, "peggy mcp prompts: encode catalog: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeMCPPromptCatalog(stdout, prompts)
+	return 0
 }
 
 func runMCPRead(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -496,6 +662,64 @@ func writeMCPToolCatalog(w io.Writer, catalog []mcpToolCatalogEntry) {
 	}
 }
 
+func writeMCPPromptCatalog(w io.Writer, prompts []toolsmcp.Prompt) {
+	if len(prompts) == 0 {
+		fmt.Fprintln(w, "No MCP prompts configured.")
+		return
+	}
+	for i, prompt := range prompts {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, prompt.Name)
+		fmt.Fprintf(w, "  server: %s\n", prompt.Server)
+		if prompt.Title != "" {
+			fmt.Fprintf(w, "  title: %s\n", singleLine(prompt.Title))
+		}
+		if prompt.Description != "" {
+			fmt.Fprintf(w, "  description: %s\n", singleLine(prompt.Description))
+		}
+		if len(prompt.Arguments) > 0 {
+			fmt.Fprintln(w, "  arguments:")
+			for _, arg := range prompt.Arguments {
+				required := ""
+				if arg.Required {
+					required = " required"
+				}
+				line := arg.Name + required
+				if arg.Description != "" {
+					line += " - " + singleLine(arg.Description)
+				}
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+		}
+	}
+}
+
+func writeMCPPrompt(w io.Writer, prompt toolsmcp.PromptGet) {
+	fmt.Fprintln(w, prompt.Name)
+	fmt.Fprintf(w, "  server: %s\n", prompt.Server)
+	if prompt.Description != "" {
+		fmt.Fprintf(w, "  description: %s\n", singleLine(prompt.Description))
+	}
+	if len(prompt.Messages) == 0 {
+		fmt.Fprintln(w, "  messages: []")
+		return
+	}
+	fmt.Fprintln(w, "  messages:")
+	for _, message := range prompt.Messages {
+		fmt.Fprintf(w, "    - role: %s\n", message.Role)
+		if text, ok := promptTextContent(message.Content); ok {
+			fmt.Fprintln(w, "      text:")
+			for _, line := range strings.Split(text, "\n") {
+				fmt.Fprintf(w, "        %s\n", line)
+			}
+			continue
+		}
+		fmt.Fprintf(w, "      content: %s\n", compactJSONLine(message.Content))
+	}
+}
+
 func writeMCPResourceCatalog(w io.Writer, catalog []mcpResourceCatalogEntry) {
 	if len(catalog) == 0 {
 		fmt.Fprintln(w, "No MCP resources configured.")
@@ -579,6 +803,36 @@ func cloneResourceSize(in *int64) *int64 {
 	}
 	out := *in
 	return &out
+}
+
+func parsePromptArgs(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	args := make(map[string]string, len(values))
+	for _, raw := range values {
+		key, value, ok := strings.Cut(raw, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("--arg must be key=value")
+		}
+		args[key] = value
+	}
+	return args, nil
+}
+
+func promptTextContent(raw json.RawMessage) (string, bool) {
+	var content struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return "", false
+	}
+	if content.Type != "text" {
+		return "", false
+	}
+	return content.Text, true
 }
 
 func singleLine(s string) string {

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -365,6 +365,101 @@ func TestRunMCPReadJSON(t *testing.T) {
 	}
 }
 
+func TestRunMCPPromptsNoServers(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "prompts"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "No MCP prompts configured.") {
+		t.Fatalf("stdout = %q, want empty catalog message", out.String())
+	}
+	if !strings.Contains(errOut.String(), "no settings.json found") {
+		t.Fatalf("stderr = %q, want settings diagnostic", errOut.String())
+	}
+}
+
+func TestRunMCPPromptsListsConfiguredPrompts(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("prompts_only", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "prompts", "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"daily_brief",
+		"server: fake",
+		"title: Daily Brief",
+		"description: Draft a concise daily briefing",
+		"topic required",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stdout = %q, missing %q", text, want)
+		}
+	}
+}
+
+func TestRunMCPPromptRendersPrompt(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("prompts_only", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "prompt", "--config", cfgPath, "--server", "fake", "--name", "daily_brief", "--arg", "topic=Go"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"daily_brief",
+		"server: fake",
+		"description: Rendered daily briefing prompt",
+		"role: user",
+		"Brief me on Go.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("stdout = %q, missing %q", text, want)
+		}
+	}
+}
+
+func TestRunMCPPromptJSON(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"mcp": MCPSettings{Servers: map[string]MCPServerSettings{
+			"fake": mcpTestServer("prompts_only", ""),
+		}},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"mcp", "prompt", "--config", cfgPath, "--server", "fake", "--name", "daily_brief", "--arg", "topic=Go", "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var prompt toolsmcp.PromptGet
+	if err := json.Unmarshal(out.Bytes(), &prompt); err != nil {
+		t.Fatalf("decode prompt: %v\nstdout=%s", err, out.String())
+	}
+	if prompt.Server != "fake" || prompt.Name != "daily_brief" || len(prompt.Messages) != 1 {
+		t.Fatalf("prompt = %+v", prompt)
+	}
+	if !strings.Contains(string(prompt.Messages[0].Content), "Brief me on Go.") {
+		t.Fatalf("message = %s", string(prompt.Messages[0].Content))
+	}
+}
+
 func TestRunMCPUsage(t *testing.T) {
 	var out, errOut bytes.Buffer
 	code := Run(context.Background(), []string{"mcp", "bogus"}, &out, &errOut)

--- a/tools/mcp/client_test.go
+++ b/tools/mcp/client_test.go
@@ -157,7 +157,7 @@ func runMCPHelper(scenario string) error {
 	if err := readInitialized(dec); err != nil {
 		return err
 	}
-	if scenario == "tools" || scenario == "bad_schema" || scenario == "collision" || scenario == "resources" || scenario == "resources_only" {
+	if scenario == "tools" || scenario == "bad_schema" || scenario == "collision" || scenario == "resources" || scenario == "resources_only" || scenario == "prompts" || scenario == "prompts_only" {
 		return runMCPToolScenario(dec, enc, scenario)
 	}
 	if scenario != "rpc_error" {
@@ -189,8 +189,8 @@ func runMCPToolScenario(dec *json.Decoder, enc *json.Encoder, scenario string) e
 		}
 		switch req.Method {
 		case "tools/list":
-			if scenario == "resources_only" {
-				return fmt.Errorf("resources_only server received tools/list")
+			if scenario == "resources_only" || scenario == "prompts_only" {
+				return fmt.Errorf("%s server received tools/list", scenario)
 			}
 			if err := writeHelperResult(enc, req.ID, helperToolsList(scenario)); err != nil {
 				return err
@@ -213,8 +213,22 @@ func runMCPToolScenario(dec *json.Decoder, enc *json.Encoder, scenario string) e
 			if err := handleHelperResourceRead(enc, req); err != nil {
 				return err
 			}
+		case "prompts/list":
+			if scenario != "prompts" && scenario != "prompts_only" {
+				return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			}
+			if err := writeHelperResult(enc, req.ID, helperPromptsList()); err != nil {
+				return err
+			}
+		case "prompts/get":
+			if scenario != "prompts" && scenario != "prompts_only" {
+				return fmt.Errorf("method = %q, want tools/list or tools/call", req.Method)
+			}
+			if err := handleHelperPromptGet(enc, req); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, or resources/read", req.Method)
+			return fmt.Errorf("method = %q, want tools/list, tools/call, resources/list, resources/read, prompts/list, or prompts/get", req.Method)
 		}
 	}
 }
@@ -297,6 +311,58 @@ func handleHelperResourceRead(enc *json.Encoder, req helperRequest) error {
 	})
 }
 
+func helperPromptsList() map[string]any {
+	return map[string]any{
+		"prompts": []map[string]any{{
+			"name":        "daily_brief",
+			"title":       "Daily Brief",
+			"description": "Draft a concise daily briefing",
+			"arguments": []map[string]any{{
+				"name":        "topic",
+				"title":       "Topic",
+				"description": "Subject to brief",
+				"required":    true,
+			}},
+		}},
+	}
+}
+
+func handleHelperPromptGet(enc *json.Encoder, req helperRequest) error {
+	var params struct {
+		Name      string            `json:"name"`
+		Arguments map[string]string `json:"arguments,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return err
+	}
+	if params.Name != "daily_brief" {
+		return fmt.Errorf("prompt name = %q, want daily_brief", params.Name)
+	}
+	topic := params.Arguments["topic"]
+	if topic == "" {
+		topic = "today"
+	}
+	return writeHelperResult(enc, req.ID, map[string]any{
+		"description": "Rendered daily briefing prompt",
+		"messages": []map[string]any{
+			{
+				"role": "user",
+				"content": map[string]any{
+					"type": "text",
+					"text": "Brief me on " + topic + ".",
+				},
+			},
+			{
+				"role": "assistant",
+				"content": map[string]any{
+					"type": "text",
+					"text": "Ready.",
+				},
+			},
+		},
+	})
+}
+
 func handleHelperToolCall(enc *json.Encoder, req helperRequest) error {
 	var params struct {
 		Name      string         `json:"name"`
@@ -366,6 +432,15 @@ func initializeResultForScenario(version, scenario string) map[string]any {
 	case "resources_only":
 		return initializeResultWithCapabilities(version, map[string]any{
 			"resources": map[string]any{},
+		})
+	case "prompts":
+		return initializeResultWithCapabilities(version, map[string]any{
+			"tools":   map[string]any{},
+			"prompts": map[string]any{},
+		})
+	case "prompts_only":
+		return initializeResultWithCapabilities(version, map[string]any{
+			"prompts": map[string]any{},
 		})
 	default:
 		return initializeResult(version)

--- a/tools/mcp/doc.go
+++ b/tools/mcp/doc.go
@@ -4,6 +4,7 @@
 // This package follows ADR-0011. It supports JSON-RPC lifecycle negotiation
 // over stdio and Streamable HTTP, discovery of MCP server tools, mapping
 // those tools to permission-gated glue.Tool values, read-only resource
-// metadata inspection, and permission-gated resource reads. Prompts, sampling,
-// elicitation, OAuth, and dynamic discovery are deferred follow-up surfaces.
+// metadata inspection, permission-gated resource reads, and prompt
+// inspection. Sampling, elicitation, OAuth, and dynamic discovery are
+// deferred follow-up surfaces.
 package mcp

--- a/tools/mcp/tools.go
+++ b/tools/mcp/tools.go
@@ -108,6 +108,37 @@ type ResourceContent struct {
 	Meta     map[string]any `json:"_meta,omitempty"`
 }
 
+// Prompt describes an MCP prompt exposed by one configured server.
+type Prompt struct {
+	Server      string           `json:"server"`
+	Name        string           `json:"name"`
+	Title       string           `json:"title,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Arguments   []PromptArgument `json:"arguments,omitempty"`
+}
+
+// PromptArgument describes one named prompt argument.
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+// PromptGet contains messages returned by an MCP prompts/get call.
+type PromptGet struct {
+	Server      string          `json:"server"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Messages    []PromptMessage `json:"messages"`
+}
+
+// PromptMessage is one role/content pair returned by a prompt.
+type PromptMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
 // Resources lists resource metadata from servers that advertise MCP resource
 // support. It does not read resource contents.
 func (m *Manager) Resources(ctx context.Context) ([]Resource, error) {
@@ -153,6 +184,50 @@ func (m *Manager) ReadResource(ctx context.Context, serverName, uri string) (Res
 	return ResourceRead{}, fmt.Errorf("mcp: server %q is not configured", serverName)
 }
 
+// Prompts lists prompt metadata from servers that advertise MCP prompt support.
+func (m *Manager) Prompts(ctx context.Context) ([]Prompt, error) {
+	if m == nil {
+		return nil, nil
+	}
+	var out []Prompt
+	for _, server := range m.servers {
+		if !hasCapability(server.client.InitializeResult(), "prompts") {
+			continue
+		}
+		prompts, err := listPrompts(ctx, server.client, server.cfg, server.name)
+		if err != nil {
+			return nil, fmt.Errorf("mcp: server %q: %w", server.name, err)
+		}
+		out = append(out, prompts...)
+	}
+	return out, nil
+}
+
+// GetPrompt renders a prompt by name from one named configured MCP server.
+func (m *Manager) GetPrompt(ctx context.Context, serverName, name string, args map[string]string) (PromptGet, error) {
+	if m == nil {
+		return PromptGet{}, errors.New("mcp: manager is nil")
+	}
+	serverName = strings.TrimSpace(serverName)
+	if serverName == "" {
+		return PromptGet{}, errors.New("mcp: prompt server is required")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return PromptGet{}, errors.New("mcp: prompt name is required")
+	}
+	for _, server := range m.servers {
+		if server.name != serverName {
+			continue
+		}
+		if !hasCapability(server.client.InitializeResult(), "prompts") {
+			return PromptGet{}, fmt.Errorf("mcp: server %q does not support prompts", serverName)
+		}
+		return getPrompt(ctx, server.client, server.cfg, serverName, name, args)
+	}
+	return PromptGet{}, fmt.Errorf("mcp: server %q is not configured", serverName)
+}
+
 // Close releases all MCP client transports owned by the manager.
 func (m *Manager) Close() error {
 	if m == nil {
@@ -178,6 +253,16 @@ type listResourcesResult struct {
 
 type readResourceResult struct {
 	Contents []resourceContentDefinition `json:"contents"`
+}
+
+type listPromptsResult struct {
+	Prompts    []promptDefinition `json:"prompts"`
+	NextCursor string             `json:"nextCursor,omitempty"`
+}
+
+type getPromptResult struct {
+	Description string                    `json:"description,omitempty"`
+	Messages    []promptMessageDefinition `json:"messages"`
 }
 
 type toolDefinition struct {
@@ -207,6 +292,25 @@ type resourceContentDefinition struct {
 	Meta     map[string]any `json:"_meta,omitempty"`
 }
 
+type promptDefinition struct {
+	Name        string                     `json:"name"`
+	Title       string                     `json:"title,omitempty"`
+	Description string                     `json:"description,omitempty"`
+	Arguments   []promptArgumentDefinition `json:"arguments,omitempty"`
+}
+
+type promptArgumentDefinition struct {
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+type promptMessageDefinition struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
 type callToolResult struct {
 	Content           []json.RawMessage `json:"content,omitempty"`
 	StructuredContent json.RawMessage   `json:"structuredContent,omitempty"`
@@ -220,6 +324,11 @@ type callToolParams struct {
 
 type readResourceParams struct {
 	URI string `json:"uri"`
+}
+
+type getPromptParams struct {
+	Name      string            `json:"name"`
+	Arguments map[string]string `json:"arguments,omitempty"`
 }
 
 func listGlueTools(ctx context.Context, client *Client, cfg ServerConfig, serverName, serverPart string, seen map[string]struct{}) ([]glue.Tool, error) {
@@ -295,6 +404,60 @@ func readResource(ctx context.Context, client *Client, cfg ServerConfig, serverN
 	}, nil
 }
 
+func listPrompts(ctx context.Context, client *Client, cfg ServerConfig, serverName string) ([]Prompt, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeoutFor(cfg))
+	defer cancel()
+
+	var out []Prompt
+	var cursor string
+	for {
+		var params any
+		if cursor != "" {
+			params = map[string]string{"cursor": cursor}
+		}
+		var listed listPromptsResult
+		if err := client.Request(reqCtx, "prompts/list", params, &listed); err != nil {
+			return nil, err
+		}
+		for _, def := range listed.Prompts {
+			prompt, err := mapPrompt(serverName, def)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, prompt)
+		}
+		if listed.NextCursor == "" {
+			return out, nil
+		}
+		cursor = listed.NextCursor
+	}
+}
+
+func getPrompt(ctx context.Context, client *Client, cfg ServerConfig, serverName, name string, args map[string]string) (PromptGet, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeoutFor(cfg))
+	defer cancel()
+
+	var result getPromptResult
+	if err := client.Request(reqCtx, "prompts/get", getPromptParams{Name: name, Arguments: cloneStringMap(args)}, &result); err != nil {
+		return PromptGet{}, err
+	}
+
+	messages := make([]PromptMessage, 0, len(result.Messages))
+	for _, def := range result.Messages {
+		message, err := mapPromptMessage(def)
+		if err != nil {
+			return PromptGet{}, err
+		}
+		messages = append(messages, message)
+	}
+	return PromptGet{
+		Server:      serverName,
+		Name:        name,
+		Description: strings.TrimSpace(result.Description),
+		Messages:    messages,
+	}, nil
+}
+
 func mapResourceContent(def resourceContentDefinition) (ResourceContent, error) {
 	uri := strings.TrimSpace(def.URI)
 	if uri == "" {
@@ -312,6 +475,56 @@ func mapResourceContent(def resourceContentDefinition) (ResourceContent, error) 
 		Text:     cloneString(def.Text),
 		Blob:     cloneString(def.Blob),
 		Meta:     cloneMap(def.Meta),
+	}, nil
+}
+
+func mapPrompt(serverName string, def promptDefinition) (Prompt, error) {
+	name := strings.TrimSpace(def.Name)
+	if name == "" {
+		return Prompt{}, errors.New("mcp: prompt name is required")
+	}
+	args := make([]PromptArgument, 0, len(def.Arguments))
+	for _, defArg := range def.Arguments {
+		arg, err := mapPromptArgument(name, defArg)
+		if err != nil {
+			return Prompt{}, err
+		}
+		args = append(args, arg)
+	}
+	return Prompt{
+		Server:      serverName,
+		Name:        name,
+		Title:       strings.TrimSpace(def.Title),
+		Description: strings.TrimSpace(def.Description),
+		Arguments:   args,
+	}, nil
+}
+
+func mapPromptArgument(promptName string, def promptArgumentDefinition) (PromptArgument, error) {
+	name := strings.TrimSpace(def.Name)
+	if name == "" {
+		return PromptArgument{}, fmt.Errorf("mcp: prompt %q argument name is required", promptName)
+	}
+	return PromptArgument{
+		Name:        name,
+		Title:       strings.TrimSpace(def.Title),
+		Description: strings.TrimSpace(def.Description),
+		Required:    def.Required,
+	}, nil
+}
+
+func mapPromptMessage(def promptMessageDefinition) (PromptMessage, error) {
+	role := strings.TrimSpace(def.Role)
+	if role == "" {
+		return PromptMessage{}, errors.New("mcp: prompt message role is required")
+	}
+	content := compactRaw(def.Content)
+	if len(content) == 0 {
+		return PromptMessage{}, fmt.Errorf("mcp: prompt message %q content is required", role)
+	}
+	return PromptMessage{
+		Role:    role,
+		Content: content,
 	}, nil
 }
 
@@ -746,6 +959,17 @@ func cloneString(in *string) *string {
 	}
 	out := *in
 	return &out
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func cloneInt64(in *int64) *int64 {

--- a/tools/mcp/tools_test.go
+++ b/tools/mcp/tools_test.go
@@ -276,6 +276,90 @@ func TestManagerSupportsResourceOnlyServers(t *testing.T) {
 	}
 }
 
+func TestManagerListsMCPPrompts(t *testing.T) {
+	cfg := helperConfig("prompts")
+	cfg.Name = "fake-server"
+	mgr, err := NewManager(context.Background(), []ServerConfig{cfg}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	prompts, err := mgr.Prompts(context.Background())
+	if err != nil {
+		t.Fatalf("Prompts: %v", err)
+	}
+	if len(prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1: %+v", len(prompts), prompts)
+	}
+	prompt := prompts[0]
+	if prompt.Server != "fake-server" || prompt.Name != "daily_brief" || prompt.Title != "Daily Brief" {
+		t.Fatalf("prompt identity = %+v", prompt)
+	}
+	if len(prompt.Arguments) != 1 || prompt.Arguments[0].Name != "topic" || !prompt.Arguments[0].Required {
+		t.Fatalf("prompt args = %+v", prompt.Arguments)
+	}
+}
+
+func TestManagerGetsMCPPrompt(t *testing.T) {
+	cfg := helperConfig("prompts_only")
+	cfg.Name = "fake-server"
+	mgr, err := NewManager(context.Background(), []ServerConfig{cfg}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	prompt, err := mgr.GetPrompt(context.Background(), "fake-server", "daily_brief", map[string]string{"topic": "Go"})
+	if err != nil {
+		t.Fatalf("GetPrompt: %v", err)
+	}
+	if prompt.Server != "fake-server" || prompt.Name != "daily_brief" || prompt.Description != "Rendered daily briefing prompt" {
+		t.Fatalf("prompt = %+v", prompt)
+	}
+	if len(prompt.Messages) != 2 || prompt.Messages[0].Role != "user" {
+		t.Fatalf("messages = %+v", prompt.Messages)
+	}
+	if !strings.Contains(string(prompt.Messages[0].Content), "Brief me on Go.") {
+		t.Fatalf("message content = %s", string(prompt.Messages[0].Content))
+	}
+}
+
+func TestManagerSkipsServersWithoutPrompts(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("tools")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+
+	prompts, err := mgr.Prompts(context.Background())
+	if err != nil {
+		t.Fatalf("Prompts: %v", err)
+	}
+	if len(prompts) != 0 {
+		t.Fatalf("prompts = %+v, want none", prompts)
+	}
+}
+
+func TestManagerSupportsPromptOnlyServers(t *testing.T) {
+	mgr, err := NewManager(context.Background(), []ServerConfig{helperConfig("prompts_only")}, Options{})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer mgr.Close()
+	if len(mgr.Tools()) != 0 {
+		t.Fatalf("tools = %+v, want none", mgr.Tools())
+	}
+
+	prompts, err := mgr.Prompts(context.Background())
+	if err != nil {
+		t.Fatalf("Prompts: %v", err)
+	}
+	if len(prompts) != 1 || prompts[0].Name != "daily_brief" {
+		t.Fatalf("prompts = %+v", prompts)
+	}
+}
+
 func requireTool(t *testing.T, tools []glue.Tool, name string) glue.Tool {
 	t.Helper()
 	for _, tool := range tools {


### PR DESCRIPTION
Closes #208.

## Summary
- Add `tools/mcp.Manager.Prompts` and `GetPrompt` for MCP `prompts/list` and `prompts/get`.
- Add `peggy mcp prompts` with human and JSON prompt catalogs.
- Add `peggy mcp prompt --server <name> --name <prompt> --arg key=value` with human and JSON rendered prompt output.
- Support prompt-only servers without calling `tools/list`.
- Update Peggy MCP docs and deterministic fake-server coverage.

## Validation
- `go test ./tools/mcp -run 'TestManager(Exposes|Uses|Maps|Rejects|ListsMCPResources|ReadsMCPResource|ExposesResourceReadTool|SkipsServersWithoutResources|SupportsResourceOnlyServers|ListsMCPPrompts|GetsMCPPrompt|SkipsServersWithoutPrompts|SupportsPromptOnlyServers)' -count=1`
- `go test ./agents/peggy -run 'TestRunMCP(Prompt|Prompts|Read|Resources|Tools|Usage)|TestPeggyMCP|TestMCPServerConfigs' -count=1`
- `git diff --check -- tools/mcp/tools.go tools/mcp/tools_test.go tools/mcp/client_test.go tools/mcp/doc.go agents/peggy/mcp.go agents/peggy/mcp_test.go agents/peggy/runner.go agents/peggy/runner_test.go agents/peggy/README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`