### PR TITLE
agents/peggy: expose daemon mcp catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,10 +641,11 @@ go run ./cmd/glue connect --prompt "Say hi" --id local-dev
 By default, `connect` reads the same metadata file written by `serve`.
 Use `--base-url`, `--token`, or `--metadata` when connecting to an
 explicit daemon endpoint. Use `--inspect` for a compact authenticated
-status-and-tools preflight, or `--status` / `--tools` to render each
-view separately. Each inspect mode also has a `-json` form for scripts.
-Add `--usage` to `run` or prompt-mode `connect` to print provider-reported
-token usage on stderr without changing streamed stdout.
+status-and-catalog preflight, or `--status`, `--tools`,
+`--mcp-resources`, or `--mcp-prompts` to render each view separately.
+Each inspect mode also has a `-json` form for scripts. Add `--usage`
+to `run` or prompt-mode `connect` to print provider-reported token
+usage on stderr without changing streamed stdout.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:
@@ -652,6 +653,8 @@ agent, settings, memory store, and coding tools loaded once:
 ```sh
 go run ./agents/peggy/cmd/peggy serve --coding --workdir .
 go run ./cmd/glue connect --inspect
+go run ./cmd/glue connect --mcp-resources
+go run ./cmd/glue connect --mcp-prompts
 go run ./cmd/glue connect --prompt "Say hi to Peggy" --id cli:daily
 ```
 

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the `peggy` agent. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com); this project does
 not formally follow SemVer until v1.0.
 
+## Unreleased
+
+### Added
+
+- **Daemon MCP catalogs.** `peggy serve` now exposes authenticated MCP
+  resource and prompt catalog endpoints through the daemon host, and
+  `glue connect --mcp-resources`, `--mcp-prompts`, plus JSON variants
+  render those catalogs for remote clients. `glue connect --inspect`
+  includes MCP catalog sections when the daemon advertises them.
+
 ## v0.4.0 — 2026-05-24
 
 Peggy now has an ecosystem surface for external tools and operator
@@ -58,8 +68,8 @@ before a run starts.
   and dynamic discovery remain deferred.
 - `peggy status` is intentionally config-only. It does not prove that
   provider credentials or MCP endpoints are live.
-- Daemon inspection exposes status and tool catalogs; resource/prompt
-  catalogs are still local CLI inspection surfaces.
+- MCP resource reads and prompt rendering through daemon clients remain
+  deferred.
 
 ## v0.3.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -196,6 +196,8 @@ session history and memory store.
 ```sh
 peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
+glue connect --mcp-resources
+glue connect --mcp-prompts
 glue connect --prompt "summarize today's plan" --id cli:daily --usage
 ```
 
@@ -214,8 +216,11 @@ Useful `serve` flags:
   over the daemon protocol for the connected client to answer.
 
 Startup output prints the `base_url` and metadata path, never the
-bearer token. Add `--usage` to prompt-mode `glue connect` when you want
-provider-reported token usage on stderr. Stop the daemon with
+bearer token. `glue connect --inspect` includes status, tools, and any
+daemon-advertised MCP resource/prompt catalogs. Use
+`--mcp-resources-json` or `--mcp-prompts-json` when another client needs
+the catalog as data. Add `--usage` to prompt-mode `glue connect` when
+you want provider-reported token usage on stderr. Stop the daemon with
 SIGINT/SIGTERM.
 
 Telegram can attach to the same daemon:
@@ -382,6 +387,16 @@ lists prompt templates and `peggy mcp prompt` renders one prompt with
 repeatable `--arg key=value` values. Servers that do not advertise the
 requested MCP capability are skipped for listing and cannot serve that
 request.
+
+When Peggy is already running as a daemon, remote clients can inspect
+the same initialized MCP catalog through the daemon protocol:
+
+```sh
+glue connect --mcp-resources
+glue connect --mcp-resources-json
+glue connect --mcp-prompts
+glue connect --mcp-prompts-json
+```
 
 The permission choices are intentionally small:
 

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -126,9 +126,82 @@ func TestPeggyV03ReleaseSmoke(t *testing.T) {
 	}
 }
 
+func TestPeggyDaemonExposesMCPCatalogs(t *testing.T) {
+	p, err := New(Options{
+		Settings: Settings{
+			MCP: MCPSettings{Servers: map[string]MCPServerSettings{
+				"filesystem": mcpTestServer("resources_only", ""),
+				"briefs":     mcpTestServer("prompts_only", ""),
+			}},
+		},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	var resources struct {
+		Resources []daemon.MCPResourceCatalogEntry `json:"resources"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/mcp/resources", &resources)
+	if len(resources.Resources) != 1 || resources.Resources[0].Server != "filesystem" || resources.Resources[0].URI != "file:///workspace/README.md" {
+		t.Fatalf("resources = %+v", resources.Resources)
+	}
+
+	var prompts struct {
+		Prompts []daemon.MCPPromptCatalogEntry `json:"prompts"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/mcp/prompts", &prompts)
+	if len(prompts.Prompts) != 1 || prompts.Prompts[0].Server != "briefs" || prompts.Prompts[0].Name != "daily_brief" {
+		t.Fatalf("prompts = %+v", prompts.Prompts)
+	}
+
+	var status struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/status", &status)
+	for _, want := range []string{"mcp_resources", "mcp_prompts"} {
+		if !containsString(status.Capabilities, want) {
+			t.Fatalf("capabilities = %v, missing %q", status.Capabilities, want)
+		}
+	}
+}
+
 type startRunResponse struct {
 	RunID     string `json:"run_id"`
 	EventsURL string `json:"events_url"`
+}
+
+func getPeggyDaemonJSON(t *testing.T, url string, out any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d, want %d", url, resp.StatusCode, http.StatusOK)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func startPeggyDaemonRun(t *testing.T, baseURL string) startRunResponse {

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
 	"github.com/erain/glue/providers"
 	"github.com/erain/glue/providers/codex"
 	"github.com/erain/glue/providers/gemini"
@@ -17,6 +18,7 @@ import (
 	"github.com/erain/glue/providers/openrouter"
 	filestore "github.com/erain/glue/stores/file"
 	sqlitestore "github.com/erain/glue/stores/sqlite"
+	toolsmcp "github.com/erain/glue/tools/mcp"
 )
 
 // Options configures New. Most fields are optional.
@@ -77,7 +79,7 @@ type Peggy struct {
 	soul     string
 	stderr   io.Writer
 
-	mcpManager io.Closer
+	mcpManager *toolsmcp.Manager
 }
 
 // New builds a Peggy from the supplied Options. Settings defaults
@@ -186,6 +188,78 @@ func (p *Peggy) Settings() Settings { return p.settings }
 // Agent returns the underlying glue agent. Exposed for cross-session
 // queries (Agent.SearchSessions) and for advanced integrations.
 func (p *Peggy) Agent() *glue.Agent { return p.agent }
+
+// Session implements daemon.Host by delegating to Peggy's underlying agent.
+func (p *Peggy) Session(ctx context.Context, id string, options ...glue.SessionOption) (*glue.Session, error) {
+	if p == nil || p.agent == nil {
+		return nil, errors.New("peggy: not initialised")
+	}
+	return p.agent.Session(ctx, id, options...)
+}
+
+// ToolCatalog implements daemon.ToolCatalogHost.
+func (p *Peggy) ToolCatalog() []glue.ToolSpec {
+	if p == nil || p.agent == nil {
+		return nil
+	}
+	return p.agent.ToolCatalog()
+}
+
+// MCPResourceCatalog implements daemon.MCPResourceCatalogHost.
+func (p *Peggy) MCPResourceCatalog(ctx context.Context) ([]daemon.MCPResourceCatalogEntry, error) {
+	if p == nil || p.mcpManager == nil {
+		return nil, nil
+	}
+	resources, err := p.mcpManager.Resources(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]daemon.MCPResourceCatalogEntry, 0, len(resources))
+	for _, resource := range resources {
+		out = append(out, daemon.MCPResourceCatalogEntry{
+			Server:      resource.Server,
+			URI:         resource.URI,
+			Name:        resource.Name,
+			Title:       resource.Title,
+			Description: resource.Description,
+			MIMEType:    resource.MIMEType,
+			Annotations: cloneResourceAnnotations(resource.Annotations),
+			Size:        cloneResourceSize(resource.Size),
+		})
+	}
+	return out, nil
+}
+
+// MCPPromptCatalog implements daemon.MCPPromptCatalogHost.
+func (p *Peggy) MCPPromptCatalog(ctx context.Context) ([]daemon.MCPPromptCatalogEntry, error) {
+	if p == nil || p.mcpManager == nil {
+		return nil, nil
+	}
+	prompts, err := p.mcpManager.Prompts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]daemon.MCPPromptCatalogEntry, 0, len(prompts))
+	for _, prompt := range prompts {
+		entry := daemon.MCPPromptCatalogEntry{
+			Server:      prompt.Server,
+			Name:        prompt.Name,
+			Title:       prompt.Title,
+			Description: prompt.Description,
+			Arguments:   make([]daemon.MCPPromptCatalogArgument, 0, len(prompt.Arguments)),
+		}
+		for _, arg := range prompt.Arguments {
+			entry.Arguments = append(entry.Arguments, daemon.MCPPromptCatalogArgument{
+				Name:        arg.Name,
+				Title:       arg.Title,
+				Description: arg.Description,
+				Required:    arg.Required,
+			})
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
 
 // Close releases resources held by the Peggy. Safe to call multiple
 // times; safe on a nil receiver. When the store implements io.Closer

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -1222,7 +1222,7 @@ Flags:
 	defer p.Close()
 
 	handler, err := daemon.New(daemon.Options{
-		Host:              p.Agent(),
+		Host:              p,
 		Token:             token,
 		PermissionPolicy:  NewDaemonPermissionPolicy(settings.Permissions),
 		PermissionTimeout: *permissionTimeout,

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -114,6 +114,14 @@ type daemonToolCatalog struct {
 	Tools []daemonToolCatalogEntry `json:"tools"`
 }
 
+type daemonMCPResourceCatalog struct {
+	Resources []daemon.MCPResourceCatalogEntry `json:"resources"`
+}
+
+type daemonMCPPromptCatalog struct {
+	Prompts []daemon.MCPPromptCatalogEntry `json:"prompts"`
+}
+
 type daemonToolCatalogEntry struct {
 	Name                    string          `json:"name"`
 	Description             string          `json:"description,omitempty"`
@@ -132,8 +140,10 @@ type daemonStatus struct {
 }
 
 type daemonInspect struct {
-	Status daemonStatus             `json:"status"`
-	Tools  []daemonToolCatalogEntry `json:"tools"`
+	Status       daemonStatus                     `json:"status"`
+	Tools        []daemonToolCatalogEntry         `json:"tools"`
+	MCPResources []daemon.MCPResourceCatalogEntry `json:"mcp_resources,omitempty"`
+	MCPPrompts   []daemon.MCPPromptCatalogEntry   `json:"mcp_prompts,omitempty"`
 }
 
 type connectPermissionPayload struct {
@@ -340,6 +350,10 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
 	showTools := flags.Bool("tools", false, "list daemon tools and exit without starting a run")
 	toolsJSON := flags.Bool("tools-json", false, "print --tools output as JSON")
+	showMCPResources := flags.Bool("mcp-resources", false, "list daemon MCP resources and exit without starting a run")
+	mcpResourcesJSON := flags.Bool("mcp-resources-json", false, "print --mcp-resources output as JSON")
+	showMCPPrompts := flags.Bool("mcp-prompts", false, "list daemon MCP prompts and exit without starting a run")
+	mcpPromptsJSON := flags.Bool("mcp-prompts-json", false, "print --mcp-prompts output as JSON")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
@@ -353,6 +367,12 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *toolsJSON {
 		*showTools = true
 	}
+	if *mcpResourcesJSON {
+		*showMCPResources = true
+	}
+	if *mcpPromptsJSON {
+		*showMCPPrompts = true
+	}
 	if *statusJSON {
 		*showStatus = true
 	}
@@ -360,13 +380,13 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 		*showInspect = true
 	}
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showMCPResources, *showMCPPrompts, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --status, or --inspect")
+		return errors.New("choose only one of --tools, --mcp-resources, --mcp-prompts, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" {
 		return errors.New("missing required --prompt")
@@ -390,6 +410,12 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showTools {
 		return runConnectTools(ctx, cfg, *toolsJSON, stdout, client)
+	}
+	if *showMCPResources {
+		return runConnectMCPResources(ctx, cfg, *mcpResourcesJSON, stdout, client)
+	}
+	if *showMCPPrompts {
+		return runConnectMCPPrompts(ctx, cfg, *mcpPromptsJSON, stdout, client)
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
@@ -476,6 +502,34 @@ func runConnectTools(ctx context.Context, cfg connectConfig, jsonOutput bool, st
 	return nil
 }
 
+func runConnectMCPResources(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	catalog, err := fetchDaemonMCPResources(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(catalog)
+	}
+	writeDaemonMCPResourceCatalog(stdout, catalog.Resources)
+	return nil
+}
+
+func runConnectMCPPrompts(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	catalog, err := fetchDaemonMCPPrompts(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(catalog)
+	}
+	writeDaemonMCPPromptCatalog(stdout, catalog.Prompts)
+	return nil
+}
+
 func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
 	status, err := fetchDaemonStatus(ctx, cfg, client)
 	if err != nil {
@@ -500,6 +554,20 @@ func runConnectInspect(ctx context.Context, cfg connectConfig, jsonOutput bool, 
 		return err
 	}
 	inspect := daemonInspect{Status: status, Tools: catalog.Tools}
+	if daemonHasCapability(status, "mcp_resources") {
+		resources, err := fetchDaemonMCPResources(ctx, cfg, client)
+		if err != nil {
+			return err
+		}
+		inspect.MCPResources = resources.Resources
+	}
+	if daemonHasCapability(status, "mcp_prompts") {
+		prompts, err := fetchDaemonMCPPrompts(ctx, cfg, client)
+		if err != nil {
+			return err
+		}
+		inspect.MCPPrompts = prompts.Prompts
+	}
 	if jsonOutput {
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
@@ -549,6 +617,16 @@ func writeDaemonInspect(w io.Writer, inspect daemonInspect) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "tools:")
 	writeDaemonToolCatalogIndented(w, inspect.Tools, "  ")
+	if daemonHasCapability(inspect.Status, "mcp_resources") {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "mcp_resources:")
+		writeDaemonMCPResourceCatalogIndented(w, inspect.MCPResources, "  ")
+	}
+	if daemonHasCapability(inspect.Status, "mcp_prompts") {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "mcp_prompts:")
+		writeDaemonMCPPromptCatalogIndented(w, inspect.MCPPrompts, "  ")
+	}
 }
 
 func fetchDaemonTools(ctx context.Context, cfg connectConfig, client httpDoer) (daemonToolCatalog, error) {
@@ -571,6 +649,54 @@ func fetchDaemonTools(ctx context.Context, cfg connectConfig, client httpDoer) (
 	}
 	if catalog.Tools == nil {
 		catalog.Tools = []daemonToolCatalogEntry{}
+	}
+	return catalog, nil
+}
+
+func fetchDaemonMCPResources(ctx context.Context, cfg connectConfig, client httpDoer) (daemonMCPResourceCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/mcp/resources", nil)
+	if err != nil {
+		return daemonMCPResourceCatalog{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonMCPResourceCatalog{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonMCPResourceCatalog{}, fmt.Errorf("daemon MCP resources: %s", httpStatusError(resp))
+	}
+	var catalog daemonMCPResourceCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		return daemonMCPResourceCatalog{}, err
+	}
+	if catalog.Resources == nil {
+		catalog.Resources = []daemon.MCPResourceCatalogEntry{}
+	}
+	return catalog, nil
+}
+
+func fetchDaemonMCPPrompts(ctx context.Context, cfg connectConfig, client httpDoer) (daemonMCPPromptCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/mcp/prompts", nil)
+	if err != nil {
+		return daemonMCPPromptCatalog{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonMCPPromptCatalog{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonMCPPromptCatalog{}, fmt.Errorf("daemon MCP prompts: %s", httpStatusError(resp))
+	}
+	var catalog daemonMCPPromptCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		return daemonMCPPromptCatalog{}, err
+	}
+	if catalog.Prompts == nil {
+		catalog.Prompts = []daemon.MCPPromptCatalogEntry{}
 	}
 	return catalog, nil
 }
@@ -599,6 +725,90 @@ func writeDaemonToolCatalogIndented(w io.Writer, tools []daemonToolCatalogEntry,
 			fmt.Fprintf(w, "%s  parameters: %s\n", indent, compactJSON(tool.Parameters))
 		}
 	}
+}
+
+func writeDaemonMCPResourceCatalog(w io.Writer, resources []daemon.MCPResourceCatalogEntry) {
+	writeDaemonMCPResourceCatalogIndented(w, resources, "")
+}
+
+func writeDaemonMCPResourceCatalogIndented(w io.Writer, resources []daemon.MCPResourceCatalogEntry, indent string) {
+	if len(resources) == 0 {
+		fmt.Fprintf(w, "%sNo daemon MCP resources reported.\n", indent)
+		return
+	}
+	for i, resource := range resources {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s%s\n", indent, resource.URI)
+		fmt.Fprintf(w, "%s  server: %s\n", indent, resource.Server)
+		fmt.Fprintf(w, "%s  name: %s\n", indent, resource.Name)
+		if resource.Title != "" {
+			fmt.Fprintf(w, "%s  title: %s\n", indent, oneLine(resource.Title))
+		}
+		if resource.Description != "" {
+			fmt.Fprintf(w, "%s  description: %s\n", indent, oneLine(resource.Description))
+		}
+		if resource.MIMEType != "" {
+			fmt.Fprintf(w, "%s  mime_type: %s\n", indent, resource.MIMEType)
+		}
+		if resource.Size != nil {
+			fmt.Fprintf(w, "%s  size: %d\n", indent, *resource.Size)
+		}
+		if len(resource.Annotations) > 0 {
+			raw, err := json.Marshal(resource.Annotations)
+			if err == nil {
+				fmt.Fprintf(w, "%s  annotations: %s\n", indent, compactJSON(raw))
+			}
+		}
+	}
+}
+
+func writeDaemonMCPPromptCatalog(w io.Writer, prompts []daemon.MCPPromptCatalogEntry) {
+	writeDaemonMCPPromptCatalogIndented(w, prompts, "")
+}
+
+func writeDaemonMCPPromptCatalogIndented(w io.Writer, prompts []daemon.MCPPromptCatalogEntry, indent string) {
+	if len(prompts) == 0 {
+		fmt.Fprintf(w, "%sNo daemon MCP prompts reported.\n", indent)
+		return
+	}
+	for i, prompt := range prompts {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s%s\n", indent, prompt.Name)
+		fmt.Fprintf(w, "%s  server: %s\n", indent, prompt.Server)
+		if prompt.Title != "" {
+			fmt.Fprintf(w, "%s  title: %s\n", indent, oneLine(prompt.Title))
+		}
+		if prompt.Description != "" {
+			fmt.Fprintf(w, "%s  description: %s\n", indent, oneLine(prompt.Description))
+		}
+		if len(prompt.Arguments) > 0 {
+			fmt.Fprintf(w, "%s  arguments:\n", indent)
+			for _, arg := range prompt.Arguments {
+				required := ""
+				if arg.Required {
+					required = " required"
+				}
+				line := arg.Name + required
+				if arg.Description != "" {
+					line += " - " + oneLine(arg.Description)
+				}
+				fmt.Fprintf(w, "%s    %s\n", indent, line)
+			}
+		}
+	}
+}
+
+func daemonHasCapability(status daemonStatus, capability string) bool {
+	for _, existing := range status.Capabilities {
+		if existing == capability {
+			return true
+		}
+	}
+	return false
 }
 
 func oneLine(s string) string {
@@ -953,15 +1163,17 @@ func printUsage(w io.Writer) {
   glue connect --inspect [--inspect-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --status [--status-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --tools [--tools-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --mcp-resources [--mcp-resources-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --mcp-prompts [--mcp-prompts-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
   serve    Start a local HTTP+SSE daemon for Glue sessions.
-  connect  Start a daemon run, or inspect daemon status/tools.
+  connect  Start a daemon run, or inspect daemon status/tools/MCP catalogs.
 
 Flags:
   --id       Session id. Defaults to "default".
-  --prompt   Prompt text. Required unless connect --inspect/--status/--tools is set.
+  --prompt   Prompt text. Required unless connect is in an inspection mode.
   --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
   --store    File session store directory. Defaults to .glue/sessions.
   --work     Working directory for serve mode. Defaults to ".".
@@ -981,6 +1193,14 @@ Flags:
   --tools    Connect mode: list daemon tools and exit without starting a run.
   --tools-json
              Connect --tools mode: print JSON.
+  --mcp-resources
+             Connect mode: list daemon MCP resources and exit without starting a run.
+  --mcp-resources-json
+             Connect --mcp-resources mode: print JSON.
+  --mcp-prompts
+             Connect mode: list daemon MCP prompts and exit without starting a run.
+  --mcp-prompts-json
+             Connect --mcp-prompts mode: print JSON.
   --env      Load env vars from a .env file. Repeatable; shell env wins.
 `)
 }

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -791,6 +791,197 @@ func TestRunCLIConnectListsToolsJSON(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectListsMCPResources(t *testing.T) {
+	size := int64(1234)
+	var sawResources bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/mcp/resources":
+			sawResources = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("resources method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("resources auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemonMCPResourceCatalog{Resources: []daemon.MCPResourceCatalogEntry{{
+				Server:      "filesystem",
+				URI:         "file:///workspace/README.md",
+				Name:        "readme",
+				Title:       "Project README",
+				Description: "repository overview",
+				MIMEType:    "text/markdown",
+				Annotations: map[string]any{"audience": []string{"assistant"}},
+				Size:        &size,
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-resources",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawResources || sawRun {
+		t.Fatalf("sawResources=%v sawRun=%v", sawResources, sawRun)
+	}
+	for _, want := range []string{
+		"file:///workspace/README.md",
+		"server: filesystem",
+		"name: readme",
+		"title: Project README",
+		"description: repository overview",
+		"mime_type: text/markdown",
+		"size: 1234",
+		`annotations: {"audience":["assistant"]}`,
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectListsMCPResourcesJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/mcp/resources" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemonMCPResourceCatalog{Resources: []daemon.MCPResourceCatalogEntry{{
+			Server: "filesystem",
+			URI:    "file:///workspace/README.md",
+			Name:   "readme",
+		}}})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-resources-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var catalog daemonMCPResourceCatalog
+	if err := json.Unmarshal(stdout.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if len(catalog.Resources) != 1 || catalog.Resources[0].URI != "file:///workspace/README.md" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}
+
+func TestRunCLIConnectListsMCPPrompts(t *testing.T) {
+	var sawPrompts bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/mcp/prompts":
+			sawPrompts = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("prompts method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("prompts auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemonMCPPromptCatalog{Prompts: []daemon.MCPPromptCatalogEntry{{
+				Server:      "linear",
+				Name:        "daily_brief",
+				Title:       "Daily Brief",
+				Description: "Draft a concise daily briefing",
+				Arguments: []daemon.MCPPromptCatalogArgument{{
+					Name:        "topic",
+					Description: "Subject to brief",
+					Required:    true,
+				}},
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-prompts",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawPrompts || sawRun {
+		t.Fatalf("sawPrompts=%v sawRun=%v", sawPrompts, sawRun)
+	}
+	for _, want := range []string{
+		"daily_brief",
+		"server: linear",
+		"title: Daily Brief",
+		"description: Draft a concise daily briefing",
+		"arguments:",
+		"topic required - Subject to brief",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectListsMCPPromptsJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/mcp/prompts" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemonMCPPromptCatalog{Prompts: []daemon.MCPPromptCatalogEntry{{
+			Server: "linear",
+			Name:   "daily_brief",
+		}}})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-prompts-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var catalog daemonMCPPromptCatalog
+	if err := json.Unmarshal(stdout.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if len(catalog.Prompts) != 1 || catalog.Prompts[0].Name != "daily_brief" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}
+
 func TestRunCLIConnectShowsStatus(t *testing.T) {
 	var sawStatus bool
 	var sawRun bool
@@ -996,6 +1187,64 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 	}
 	if len(inspect.Tools) != 1 || inspect.Tools[0].Name != "shell_exec" || inspect.Tools[0].PermissionAction != "exec" {
 		t.Fatalf("tools = %+v", inspect.Tools)
+	}
+}
+
+func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
+	var sawResources bool
+	var sawPrompts bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/status":
+			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
+				OK:           true,
+				Version:      1,
+				Capabilities: []string{"status", "tools", "mcp_resources", "mcp_prompts"},
+			})
+		case "/v1/tools":
+			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{})
+		case "/v1/mcp/resources":
+			sawResources = true
+			writeJSONResponse(t, w, http.StatusOK, daemonMCPResourceCatalog{Resources: []daemon.MCPResourceCatalogEntry{{
+				Server: "filesystem",
+				URI:    "file:///workspace/README.md",
+				Name:   "readme",
+			}}})
+		case "/v1/mcp/prompts":
+			sawPrompts = true
+			writeJSONResponse(t, w, http.StatusOK, daemonMCPPromptCatalog{Prompts: []daemon.MCPPromptCatalogEntry{{
+				Server: "linear",
+				Name:   "daily_brief",
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--inspect",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawResources || !sawPrompts {
+		t.Fatalf("sawResources=%v sawPrompts=%v", sawResources, sawPrompts)
+	}
+	for _, want := range []string{
+		"mcp_resources:",
+		"file:///workspace/README.md",
+		"mcp_prompts:",
+		"daily_brief",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
 	}
 }
 

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -34,6 +34,47 @@ type ToolCatalogHost interface {
 	ToolCatalog() []glue.ToolSpec
 }
 
+// MCPResourceCatalogHost is optionally implemented by hosts that can expose
+// MCP resource metadata without starting a run.
+type MCPResourceCatalogHost interface {
+	MCPResourceCatalog(context.Context) ([]MCPResourceCatalogEntry, error)
+}
+
+// MCPPromptCatalogHost is optionally implemented by hosts that can expose MCP
+// prompt metadata without starting a run.
+type MCPPromptCatalogHost interface {
+	MCPPromptCatalog(context.Context) ([]MCPPromptCatalogEntry, error)
+}
+
+// MCPResourceCatalogEntry describes one MCP resource advertised by a host.
+type MCPResourceCatalogEntry struct {
+	Server      string         `json:"server"`
+	URI         string         `json:"uri"`
+	Name        string         `json:"name"`
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	MIMEType    string         `json:"mime_type,omitempty"`
+	Annotations map[string]any `json:"annotations,omitempty"`
+	Size        *int64         `json:"size,omitempty"`
+}
+
+// MCPPromptCatalogEntry describes one MCP prompt advertised by a host.
+type MCPPromptCatalogEntry struct {
+	Server      string                     `json:"server"`
+	Name        string                     `json:"name"`
+	Title       string                     `json:"title,omitempty"`
+	Description string                     `json:"description,omitempty"`
+	Arguments   []MCPPromptCatalogArgument `json:"arguments,omitempty"`
+}
+
+// MCPPromptCatalogArgument describes one argument accepted by an MCP prompt.
+type MCPPromptCatalogArgument struct {
+	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
 // Options configures [New].
 type Options struct {
 	// Host is required. A *glue.Agent satisfies this interface.
@@ -188,6 +229,14 @@ type toolCatalogResponse struct {
 	Tools []toolCatalogEntry `json:"tools"`
 }
 
+type mcpResourceCatalogResponse struct {
+	Resources []MCPResourceCatalogEntry `json:"resources"`
+}
+
+type mcpPromptCatalogResponse struct {
+	Prompts []MCPPromptCatalogEntry `json:"prompts"`
+}
+
 type toolCatalogEntry struct {
 	Name                    string          `json:"name"`
 	Description             string          `json:"description,omitempty"`
@@ -265,6 +314,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/v1/mcp/resources" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleMCPResources(w, r)
+		return
+	}
+
+	if r.URL.Path == "/v1/mcp/prompts" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleMCPPrompts(w, r)
+		return
+	}
+
 	if sessionID, ok := parseStartRunPath(r.URL.Path); ok {
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
@@ -315,18 +382,25 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	if host, ok := s.host.(ToolCatalogHost); ok {
 		toolsCount = len(host.ToolCatalog())
 	}
+	capabilities := []string{
+		"runs",
+		"events",
+		"permissions",
+		"tools",
+		"status",
+	}
+	if _, ok := s.host.(MCPResourceCatalogHost); ok {
+		capabilities = append(capabilities, "mcp_resources")
+	}
+	if _, ok := s.host.(MCPPromptCatalogHost); ok {
+		capabilities = append(capabilities, "mcp_prompts")
+	}
 	writeJSON(w, http.StatusOK, statusResponse{
-		OK:         true,
-		Version:    protocolVersion,
-		ActiveRuns: s.activeRunCount(),
-		ToolsCount: toolsCount,
-		Capabilities: []string{
-			"runs",
-			"events",
-			"permissions",
-			"tools",
-			"status",
-		},
+		OK:           true,
+		Version:      protocolVersion,
+		ActiveRuns:   s.activeRunCount(),
+		ToolsCount:   toolsCount,
+		Capabilities: capabilities,
 	})
 }
 
@@ -379,6 +453,40 @@ func (s *Server) handleTools(w http.ResponseWriter, _ *http.Request) {
 		tools = append(tools, entry)
 	}
 	writeJSON(w, http.StatusOK, toolCatalogResponse{Tools: tools})
+}
+
+func (s *Server) handleMCPResources(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.host.(MCPResourceCatalogHost)
+	if !ok {
+		writeJSON(w, http.StatusOK, mcpResourceCatalogResponse{Resources: []MCPResourceCatalogEntry{}})
+		return
+	}
+	resources, err := host.MCPResourceCatalog(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if resources == nil {
+		resources = []MCPResourceCatalogEntry{}
+	}
+	writeJSON(w, http.StatusOK, mcpResourceCatalogResponse{Resources: resources})
+}
+
+func (s *Server) handleMCPPrompts(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.host.(MCPPromptCatalogHost)
+	if !ok {
+		writeJSON(w, http.StatusOK, mcpPromptCatalogResponse{Prompts: []MCPPromptCatalogEntry{}})
+		return
+	}
+	prompts, err := host.MCPPromptCatalog(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if prompts == nil {
+		prompts = []MCPPromptCatalogEntry{}
+	}
+	writeJSON(w, http.StatusOK, mcpPromptCatalogResponse{Prompts: prompts})
 }
 
 func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, req startRunRequest) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -77,6 +77,23 @@ func (sessionOnlyHost) Session(context.Context, string, ...glue.SessionOption) (
 	return nil, errors.New("unused")
 }
 
+type mcpCatalogHost struct {
+	resources []MCPResourceCatalogEntry
+	prompts   []MCPPromptCatalogEntry
+}
+
+func (mcpCatalogHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
+func (h mcpCatalogHost) MCPResourceCatalog(context.Context) ([]MCPResourceCatalogEntry, error) {
+	return h.resources, nil
+}
+
+func (h mcpCatalogHost) MCPPromptCatalog(context.Context) ([]MCPPromptCatalogEntry, error) {
+	return h.prompts, nil
+}
+
 func TestServerAuthAndHealth(t *testing.T) {
 	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
 	ts := httptest.NewServer(srv)
@@ -170,6 +187,111 @@ func TestServerToolsCatalogUnsupportedHost(t *testing.T) {
 	}
 	if len(catalog.Tools) != 0 {
 		t.Fatalf("catalog = %+v, want empty", catalog.Tools)
+	}
+}
+
+func TestServerMCPCatalogs(t *testing.T) {
+	size := int64(1234)
+	srv := newTestServer(t, mcpCatalogHost{
+		resources: []MCPResourceCatalogEntry{{
+			Server:      "filesystem",
+			URI:         "file:///workspace/README.md",
+			Name:        "readme",
+			Title:       "Project README",
+			Description: "repository overview",
+			MIMEType:    "text/markdown",
+			Annotations: map[string]any{"audience": []any{"assistant"}},
+			Size:        &size,
+		}},
+		prompts: []MCPPromptCatalogEntry{{
+			Server:      "linear",
+			Name:        "daily_brief",
+			Title:       "Daily Brief",
+			Description: "Draft a concise daily briefing",
+			Arguments: []MCPPromptCatalogArgument{{
+				Name:        "topic",
+				Description: "Subject to brief",
+				Required:    true,
+			}},
+		}},
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/mcp/resources", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated resources status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/mcp/resources", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("resources status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var resources mcpResourceCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resources); err != nil {
+		t.Fatal(err)
+	}
+	if len(resources.Resources) != 1 || resources.Resources[0].URI != "file:///workspace/README.md" || resources.Resources[0].MIMEType != "text/markdown" {
+		t.Fatalf("resources = %+v", resources.Resources)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/mcp/prompts", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("prompts status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var prompts mcpPromptCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&prompts); err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts.Prompts) != 1 || prompts.Prompts[0].Name != "daily_brief" || len(prompts.Prompts[0].Arguments) != 1 {
+		t.Fatalf("prompts = %+v", prompts.Prompts)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	var status statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"mcp_resources", "mcp_prompts"} {
+		if !contains(status.Capabilities, want) {
+			t.Fatalf("capabilities = %v, missing %q", status.Capabilities, want)
+		}
+	}
+}
+
+func TestServerMCPCatalogsUnsupportedHost(t *testing.T) {
+	srv := newTestServer(t, sessionOnlyHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/mcp/resources", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("resources status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var resources mcpResourceCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resources); err != nil {
+		t.Fatal(err)
+	}
+	if len(resources.Resources) != 0 {
+		t.Fatalf("resources = %+v, want empty", resources.Resources)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/mcp/prompts", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("prompts status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var prompts mcpPromptCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&prompts); err != nil {
+		t.Fatal(err)
+	}
+	if len(prompts.Prompts) != 0 {
+		t.Fatalf("prompts = %+v, want empty", prompts.Prompts)
 	}
 }
 


### PR DESCRIPTION
Closes #214.

## Summary
- Add authenticated daemon endpoints for MCP resource and prompt catalogs.
- Let Peggy serve as the daemon host so `peggy serve` exposes tools plus initialized MCP catalogs.
- Add `glue connect --mcp-resources`, `--mcp-prompts`, and JSON variants.
- Extend `glue connect --inspect` with MCP catalog sections when the daemon advertises those capabilities.
- Document the remote MCP catalog workflow in Peggy and root docs.

## Validation
- `go test ./daemon -run 'TestServerMCP|TestServerStatus|TestServerToolsCatalog' -count=1`
- `go test ./agents/peggy -run 'TestPeggyDaemonExposesMCPCatalogs|TestRunServe|TestPeggyDaemonCodingPermissionViaDaemon' -count=1`
- `go test ./cmd/glue -run 'TestRunCLIConnect(ListsMCP|InspectIncludesMCP|InspectsDaemon|RequiresPrompt|RejectsMultiple)' -count=1`
- `go test ./daemon ./cmd/glue ./agents/peggy -count=1`
- `git diff --check -- daemon/server.go daemon/server_test.go agents/peggy/peggy.go agents/peggy/runner.go agents/peggy/daemon_test.go cmd/glue/main.go cmd/glue/main_test.go agents/peggy/README.md agents/peggy/CHANGELOG.md README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`