### PR TITLE
agents/peggy: add daemon mcp read and prompt actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,9 +643,11 @@ Use `--base-url`, `--token`, or `--metadata` when connecting to an
 explicit daemon endpoint. Use `--inspect` for a compact authenticated
 status-and-catalog preflight, or `--status`, `--tools`,
 `--mcp-resources`, or `--mcp-prompts` to render each view separately.
-Each inspect mode also has a `-json` form for scripts. Add `--usage`
-to `run` or prompt-mode `connect` to print provider-reported token
-usage on stderr without changing streamed stdout.
+Peggy daemons also support `--mcp-read` and `--mcp-prompt` for direct
+resource reads and prompt rendering. Each inspect/action mode also has a
+`-json` form for scripts. Add `--usage` to `run` or prompt-mode
+`connect` to print provider-reported token usage on stderr without
+changing streamed stdout.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:
@@ -655,6 +657,8 @@ go run ./agents/peggy/cmd/peggy serve --coding --workdir .
 go run ./cmd/glue connect --inspect
 go run ./cmd/glue connect --mcp-resources
 go run ./cmd/glue connect --mcp-prompts
+go run ./cmd/glue connect --mcp-read --server filesystem --uri file:///workspace/README.md
+go run ./cmd/glue connect --mcp-prompt --server linear --name summarize_issue --arg issue=GLUE-123
 go run ./cmd/glue connect --prompt "Say hi to Peggy" --id cli:daily
 ```
 

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -13,6 +13,11 @@ not formally follow SemVer until v1.0.
   `glue connect --mcp-resources`, `--mcp-prompts`, plus JSON variants
   render those catalogs for remote clients. `glue connect --inspect`
   includes MCP catalog sections when the daemon advertises them.
+- **Daemon MCP read/render actions.** Remote clients can read one MCP
+  resource with `glue connect --mcp-read --server <name> --uri <uri>`
+  or render one MCP prompt with
+  `glue connect --mcp-prompt --server <name> --name <prompt> --arg key=value`;
+  both modes have JSON variants.
 
 ## v0.4.0 — 2026-05-24
 
@@ -68,8 +73,8 @@ before a run starts.
   and dynamic discovery remain deferred.
 - `peggy status` is intentionally config-only. It does not prove that
   provider credentials or MCP endpoints are live.
-- MCP resource reads and prompt rendering through daemon clients remain
-  deferred.
+- MCP subscriptions, prompt auto-use policy, OAuth, elicitation,
+  sampling, and dynamic discovery remain deferred.
 
 ## v0.3.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -198,6 +198,8 @@ peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
 glue connect --mcp-resources
 glue connect --mcp-prompts
+glue connect --mcp-read --server filesystem --uri file:///workspace/README.md
+glue connect --mcp-prompt --server linear --name summarize_issue --arg issue=GLUE-123
 glue connect --prompt "summarize today's plan" --id cli:daily --usage
 ```
 
@@ -218,9 +220,10 @@ Useful `serve` flags:
 Startup output prints the `base_url` and metadata path, never the
 bearer token. `glue connect --inspect` includes status, tools, and any
 daemon-advertised MCP resource/prompt catalogs. Use
-`--mcp-resources-json` or `--mcp-prompts-json` when another client needs
-the catalog as data. Add `--usage` to prompt-mode `glue connect` when
-you want provider-reported token usage on stderr. Stop the daemon with
+`--mcp-resources-json`, `--mcp-prompts-json`, `--mcp-read-json`, or
+`--mcp-prompt-json` when another client needs the MCP payload as data.
+Add `--usage` to prompt-mode `glue connect` when you want
+provider-reported token usage on stderr. Stop the daemon with
 SIGINT/SIGTERM.
 
 Telegram can attach to the same daemon:
@@ -396,6 +399,10 @@ glue connect --mcp-resources
 glue connect --mcp-resources-json
 glue connect --mcp-prompts
 glue connect --mcp-prompts-json
+glue connect --mcp-read --server filesystem --uri file:///workspace/README.md
+glue connect --mcp-read-json --server filesystem --uri file:///workspace/README.md
+glue connect --mcp-prompt --server linear --name summarize_issue --arg issue=GLUE-123
+glue connect --mcp-prompt-json --server linear --name summarize_issue --arg issue=GLUE-123
 ```
 
 The permission choices are intentionally small:

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -179,6 +179,45 @@ func TestPeggyDaemonExposesMCPCatalogs(t *testing.T) {
 	}
 }
 
+func TestPeggyDaemonReadsMCPResourceAndRendersPrompt(t *testing.T) {
+	p, err := New(Options{
+		Settings: Settings{
+			MCP: MCPSettings{Servers: map[string]MCPServerSettings{
+				"filesystem": mcpTestServer("resources_only", ""),
+				"briefs":     mcpTestServer("prompts_only", ""),
+			}},
+		},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	var read daemon.MCPResourceReadResponse
+	postPeggyDaemonJSON(t, ts.URL+"/v1/mcp/resources/read", `{"server":"filesystem","uri":"file:///workspace/README.md"}`, &read)
+	if read.Server != "filesystem" || len(read.Contents) != 1 || read.Contents[0].Text == nil || !strings.Contains(*read.Contents[0].Text, "Hello from Peggy MCP resource") {
+		t.Fatalf("read = %+v", read)
+	}
+
+	var rendered daemon.MCPPromptRenderResponse
+	postPeggyDaemonJSON(t, ts.URL+"/v1/mcp/prompts/get", `{"server":"briefs","name":"daily_brief","arguments":{"topic":"Go"}}`, &rendered)
+	if rendered.Server != "briefs" || rendered.Name != "daily_brief" || len(rendered.Messages) != 1 || !strings.Contains(string(rendered.Messages[0].Content), "Brief me on Go.") {
+		t.Fatalf("rendered = %+v", rendered)
+	}
+}
+
 type startRunResponse struct {
 	RunID     string `json:"run_id"`
 	EventsURL string `json:"events_url"`
@@ -198,6 +237,27 @@ func getPeggyDaemonJSON(t *testing.T, url string, out any) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET %s status = %d, want %d", url, resp.StatusCode, http.StatusOK)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func postPeggyDaemonJSON(t *testing.T, url, body string, out any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s status = %d, want %d", url, resp.StatusCode, http.StatusOK)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		t.Fatal(err)

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -2,6 +2,7 @@ package peggy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -259,6 +260,64 @@ func (p *Peggy) MCPPromptCatalog(ctx context.Context) ([]daemon.MCPPromptCatalog
 		out = append(out, entry)
 	}
 	return out, nil
+}
+
+// MCPReadResource implements daemon.MCPResourceReaderHost.
+func (p *Peggy) MCPReadResource(ctx context.Context, req daemon.MCPReadResourceRequest) (daemon.MCPResourceReadResponse, error) {
+	if p == nil || p.mcpManager == nil {
+		return daemon.MCPResourceReadResponse{}, errors.New("peggy: MCP is not initialised")
+	}
+	read, err := p.mcpManager.ReadResource(ctx, req.Server, req.URI)
+	if err != nil {
+		return daemon.MCPResourceReadResponse{}, err
+	}
+	contents := make([]daemon.MCPResourceContent, 0, len(read.Contents))
+	for _, content := range read.Contents {
+		contents = append(contents, daemon.MCPResourceContent{
+			URI:      content.URI,
+			MIMEType: content.MIMEType,
+			Text:     cloneStringPointer(content.Text),
+			Blob:     cloneStringPointer(content.Blob),
+			Meta:     cloneResourceAnnotations(content.Meta),
+		})
+	}
+	return daemon.MCPResourceReadResponse{
+		Server:   read.Server,
+		URI:      read.URI,
+		Contents: contents,
+	}, nil
+}
+
+// MCPRenderPrompt implements daemon.MCPPromptRendererHost.
+func (p *Peggy) MCPRenderPrompt(ctx context.Context, req daemon.MCPPromptRenderRequest) (daemon.MCPPromptRenderResponse, error) {
+	if p == nil || p.mcpManager == nil {
+		return daemon.MCPPromptRenderResponse{}, errors.New("peggy: MCP is not initialised")
+	}
+	rendered, err := p.mcpManager.GetPrompt(ctx, req.Server, req.Name, req.Arguments)
+	if err != nil {
+		return daemon.MCPPromptRenderResponse{}, err
+	}
+	messages := make([]daemon.MCPPromptMessage, 0, len(rendered.Messages))
+	for _, message := range rendered.Messages {
+		messages = append(messages, daemon.MCPPromptMessage{
+			Role:    message.Role,
+			Content: append(json.RawMessage(nil), message.Content...),
+		})
+	}
+	return daemon.MCPPromptRenderResponse{
+		Server:      rendered.Server,
+		Name:        rendered.Name,
+		Description: rendered.Description,
+		Messages:    messages,
+	}, nil
+}
+
+func cloneStringPointer(in *string) *string {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 // Close releases resources held by the Peggy. Safe to call multiple

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -49,6 +49,15 @@ func (e *envFiles) Set(value string) error {
 	return nil
 }
 
+type repeatedStrings []string
+
+func (r *repeatedStrings) String() string { return strings.Join(*r, ",") }
+
+func (r *repeatedStrings) Set(value string) error {
+	*r = append(*r, value)
+	return nil
+}
+
 type serveFunc func(context.Context, serveConfig, http.Handler, io.Writer) error
 
 type serveConfig struct {
@@ -354,12 +363,21 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	mcpResourcesJSON := flags.Bool("mcp-resources-json", false, "print --mcp-resources output as JSON")
 	showMCPPrompts := flags.Bool("mcp-prompts", false, "list daemon MCP prompts and exit without starting a run")
 	mcpPromptsJSON := flags.Bool("mcp-prompts-json", false, "print --mcp-prompts output as JSON")
+	showMCPRead := flags.Bool("mcp-read", false, "read one daemon MCP resource and exit without starting a run")
+	mcpReadJSON := flags.Bool("mcp-read-json", false, "print --mcp-read output as JSON")
+	showMCPPrompt := flags.Bool("mcp-prompt", false, "render one daemon MCP prompt and exit without starting a run")
+	mcpPromptJSON := flags.Bool("mcp-prompt-json", false, "print --mcp-prompt output as JSON")
+	mcpServer := flags.String("server", "", "MCP server name for --mcp-read or --mcp-prompt")
+	mcpURI := flags.String("uri", "", "MCP resource URI for --mcp-read")
+	mcpName := flags.String("name", "", "MCP prompt name for --mcp-prompt")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
 	inspectJSON := flags.Bool("inspect-json", false, "print --inspect output as JSON")
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
+	var mcpArgs repeatedStrings
+	flags.Var(&mcpArgs, "arg", "MCP prompt argument key=value; repeatable")
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -373,6 +391,12 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *mcpPromptsJSON {
 		*showMCPPrompts = true
 	}
+	if *mcpReadJSON {
+		*showMCPRead = true
+	}
+	if *mcpPromptJSON {
+		*showMCPPrompt = true
+	}
 	if *statusJSON {
 		*showStatus = true
 	}
@@ -380,13 +404,13 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 		*showInspect = true
 	}
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showMCPResources, *showMCPPrompts, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --mcp-resources, --mcp-prompts, --status, or --inspect")
+		return errors.New("choose only one of --tools, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" {
 		return errors.New("missing required --prompt")
@@ -416,6 +440,16 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showMCPPrompts {
 		return runConnectMCPPrompts(ctx, cfg, *mcpPromptsJSON, stdout, client)
+	}
+	if *showMCPRead {
+		return runConnectMCPRead(ctx, cfg, *mcpServer, *mcpURI, *mcpReadJSON, stdout, client)
+	}
+	if *showMCPPrompt {
+		argsMap, err := parseConnectMCPArgs(mcpArgs)
+		if err != nil {
+			return err
+		}
+		return runConnectMCPPrompt(ctx, cfg, *mcpServer, *mcpName, argsMap, *mcpPromptJSON, stdout, client)
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
@@ -527,6 +561,50 @@ func runConnectMCPPrompts(ctx context.Context, cfg connectConfig, jsonOutput boo
 		return enc.Encode(catalog)
 	}
 	writeDaemonMCPPromptCatalog(stdout, catalog.Prompts)
+	return nil
+}
+
+func runConnectMCPRead(ctx context.Context, cfg connectConfig, server, uri string, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	server = strings.TrimSpace(server)
+	uri = strings.TrimSpace(uri)
+	if server == "" {
+		return errors.New("--server is required for --mcp-read")
+	}
+	if uri == "" {
+		return errors.New("--uri is required for --mcp-read")
+	}
+	read, err := requestDaemonMCPResourceRead(ctx, cfg, server, uri, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(read)
+	}
+	writeDaemonMCPResourceRead(stdout, read)
+	return nil
+}
+
+func runConnectMCPPrompt(ctx context.Context, cfg connectConfig, server, name string, args map[string]string, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	server = strings.TrimSpace(server)
+	name = strings.TrimSpace(name)
+	if server == "" {
+		return errors.New("--server is required for --mcp-prompt")
+	}
+	if name == "" {
+		return errors.New("--name is required for --mcp-prompt")
+	}
+	rendered, err := requestDaemonMCPPrompt(ctx, cfg, server, name, args, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rendered)
+	}
+	writeDaemonMCPPrompt(stdout, rendered)
 	return nil
 }
 
@@ -701,6 +779,66 @@ func fetchDaemonMCPPrompts(ctx context.Context, cfg connectConfig, client httpDo
 	return catalog, nil
 }
 
+func requestDaemonMCPResourceRead(ctx context.Context, cfg connectConfig, server, uri string, client httpDoer) (daemon.MCPResourceReadResponse, error) {
+	payload := daemon.MCPReadResourceRequest{Server: server, URI: uri}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return daemon.MCPResourceReadResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.BaseURL+"/v1/mcp/resources/read", &body)
+	if err != nil {
+		return daemon.MCPResourceReadResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemon.MCPResourceReadResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.MCPResourceReadResponse{}, fmt.Errorf("daemon MCP resource read: %s", httpStatusError(resp))
+	}
+	var read daemon.MCPResourceReadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&read); err != nil {
+		return daemon.MCPResourceReadResponse{}, err
+	}
+	if read.Contents == nil {
+		read.Contents = []daemon.MCPResourceContent{}
+	}
+	return read, nil
+}
+
+func requestDaemonMCPPrompt(ctx context.Context, cfg connectConfig, server, name string, args map[string]string, client httpDoer) (daemon.MCPPromptRenderResponse, error) {
+	payload := daemon.MCPPromptRenderRequest{Server: server, Name: name, Arguments: args}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return daemon.MCPPromptRenderResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.BaseURL+"/v1/mcp/prompts/get", &body)
+	if err != nil {
+		return daemon.MCPPromptRenderResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemon.MCPPromptRenderResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.MCPPromptRenderResponse{}, fmt.Errorf("daemon MCP prompt: %s", httpStatusError(resp))
+	}
+	var rendered daemon.MCPPromptRenderResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rendered); err != nil {
+		return daemon.MCPPromptRenderResponse{}, err
+	}
+	if rendered.Messages == nil {
+		rendered.Messages = []daemon.MCPPromptMessage{}
+	}
+	return rendered, nil
+}
+
 func writeDaemonToolCatalog(w io.Writer, tools []daemonToolCatalogEntry) {
 	writeDaemonToolCatalogIndented(w, tools, "")
 }
@@ -802,6 +940,77 @@ func writeDaemonMCPPromptCatalogIndented(w io.Writer, prompts []daemon.MCPPrompt
 	}
 }
 
+func writeDaemonMCPResourceRead(w io.Writer, read daemon.MCPResourceReadResponse) {
+	if len(read.Contents) == 0 {
+		fmt.Fprintln(w, "No daemon MCP resource contents returned.")
+		return
+	}
+	for i, item := range read.Contents {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, item.URI)
+		fmt.Fprintf(w, "  server: %s\n", read.Server)
+		fmt.Fprintf(w, "  requested_uri: %s\n", read.URI)
+		if item.MIMEType != "" {
+			fmt.Fprintf(w, "  mime_type: %s\n", item.MIMEType)
+		}
+		if len(item.Meta) > 0 {
+			raw, err := json.Marshal(item.Meta)
+			if err == nil {
+				fmt.Fprintf(w, "  meta: %s\n", compactJSON(raw))
+			}
+		}
+		switch {
+		case item.Text != nil:
+			fmt.Fprintln(w, "  text:")
+			for _, line := range strings.Split(*item.Text, "\n") {
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+		case item.Blob != nil:
+			fmt.Fprintf(w, "  blob: %s\n", *item.Blob)
+		}
+	}
+}
+
+func writeDaemonMCPPrompt(w io.Writer, rendered daemon.MCPPromptRenderResponse) {
+	fmt.Fprintln(w, rendered.Name)
+	fmt.Fprintf(w, "  server: %s\n", rendered.Server)
+	if rendered.Description != "" {
+		fmt.Fprintf(w, "  description: %s\n", oneLine(rendered.Description))
+	}
+	if len(rendered.Messages) == 0 {
+		fmt.Fprintln(w, "  messages: []")
+		return
+	}
+	fmt.Fprintln(w, "  messages:")
+	for _, message := range rendered.Messages {
+		fmt.Fprintf(w, "    - role: %s\n", message.Role)
+		if text, ok := daemonPromptTextContent(message.Content); ok {
+			fmt.Fprintln(w, "      text:")
+			for _, line := range strings.Split(text, "\n") {
+				fmt.Fprintf(w, "        %s\n", line)
+			}
+			continue
+		}
+		fmt.Fprintf(w, "      content: %s\n", compactJSON(message.Content))
+	}
+}
+
+func daemonPromptTextContent(raw json.RawMessage) (string, bool) {
+	var content struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return "", false
+	}
+	if content.Type != "text" {
+		return "", false
+	}
+	return content.Text, true
+}
+
 func daemonHasCapability(status daemonStatus, capability string) bool {
 	for _, existing := range status.Capabilities {
 		if existing == capability {
@@ -809,6 +1018,22 @@ func daemonHasCapability(status daemonStatus, capability string) bool {
 		}
 	}
 	return false
+}
+
+func parseConnectMCPArgs(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	args := make(map[string]string, len(values))
+	for _, raw := range values {
+		key, value, ok := strings.Cut(raw, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("--arg must be key=value")
+		}
+		args[key] = value
+	}
+	return args, nil
 }
 
 func oneLine(s string) string {
@@ -1165,6 +1390,8 @@ func printUsage(w io.Writer) {
   glue connect --tools [--tools-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-resources [--mcp-resources-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-prompts [--mcp-prompts-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --mcp-read --server <name> --uri <uri> [--mcp-read-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --mcp-prompt --server <name> --name <prompt> [--arg key=value] [--mcp-prompt-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
@@ -1201,6 +1428,18 @@ Flags:
              Connect mode: list daemon MCP prompts and exit without starting a run.
   --mcp-prompts-json
              Connect --mcp-prompts mode: print JSON.
+  --mcp-read
+             Connect mode: read one daemon MCP resource and exit without starting a run.
+  --mcp-read-json
+             Connect --mcp-read mode: print JSON.
+  --mcp-prompt
+             Connect mode: render one daemon MCP prompt and exit without starting a run.
+  --mcp-prompt-json
+             Connect --mcp-prompt mode: print JSON.
+  --server   MCP server name for --mcp-read or --mcp-prompt.
+  --uri      MCP resource URI for --mcp-read.
+  --name     MCP prompt name for --mcp-prompt.
+  --arg      MCP prompt argument key=value. Repeatable.
   --env      Load env vars from a .env file. Repeatable; shell env wins.
 `)
 }

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -982,6 +982,223 @@ func TestRunCLIConnectListsMCPPromptsJSON(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectReadsMCPResource(t *testing.T) {
+	var sawRead bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/mcp/resources/read":
+			sawRead = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("read method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("read auth = %q", auth)
+			}
+			var req daemon.MCPReadResourceRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if req.Server != "filesystem" || req.URI != "file:///workspace/README.md" {
+				t.Fatalf("read request = %+v", req)
+			}
+			text := "# Project README\n\nHello from daemon."
+			writeJSONResponse(t, w, http.StatusOK, daemon.MCPResourceReadResponse{
+				Server: req.Server,
+				URI:    req.URI,
+				Contents: []daemon.MCPResourceContent{{
+					URI:      req.URI,
+					MIMEType: "text/markdown",
+					Text:     &text,
+					Meta:     map[string]any{"source": "test"},
+				}},
+			})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-read",
+		"--server", "filesystem",
+		"--uri", "file:///workspace/README.md",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawRead || sawRun {
+		t.Fatalf("sawRead=%v sawRun=%v", sawRead, sawRun)
+	}
+	for _, want := range []string{
+		"file:///workspace/README.md",
+		"server: filesystem",
+		"requested_uri: file:///workspace/README.md",
+		"mime_type: text/markdown",
+		`meta: {"source":"test"}`,
+		"Hello from daemon.",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectReadsMCPResourceJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/mcp/resources/read" {
+			http.NotFound(w, r)
+			return
+		}
+		text := "hello"
+		writeJSONResponse(t, w, http.StatusOK, daemon.MCPResourceReadResponse{
+			Server: "filesystem",
+			URI:    "file:///workspace/README.md",
+			Contents: []daemon.MCPResourceContent{{
+				URI:  "file:///workspace/README.md",
+				Text: &text,
+			}},
+		})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-read-json",
+		"--server", "filesystem",
+		"--uri", "file:///workspace/README.md",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var read daemon.MCPResourceReadResponse
+	if err := json.Unmarshal(stdout.Bytes(), &read); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if read.Server != "filesystem" || len(read.Contents) != 1 || read.Contents[0].Text == nil {
+		t.Fatalf("read = %+v", read)
+	}
+}
+
+func TestRunCLIConnectRendersMCPPrompt(t *testing.T) {
+	var sawPrompt bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/mcp/prompts/get":
+			sawPrompt = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("prompt method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("prompt auth = %q", auth)
+			}
+			var req daemon.MCPPromptRenderRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if req.Server != "linear" || req.Name != "daily_brief" || req.Arguments["topic"] != "Go" {
+				t.Fatalf("prompt request = %+v", req)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.MCPPromptRenderResponse{
+				Server:      req.Server,
+				Name:        req.Name,
+				Description: "Rendered daily briefing prompt",
+				Messages: []daemon.MCPPromptMessage{{
+					Role:    "user",
+					Content: json.RawMessage(`{"type":"text","text":"Brief me on Go."}`),
+				}},
+			})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-prompt",
+		"--server", "linear",
+		"--name", "daily_brief",
+		"--arg", "topic=Go",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawPrompt || sawRun {
+		t.Fatalf("sawPrompt=%v sawRun=%v", sawPrompt, sawRun)
+	}
+	for _, want := range []string{
+		"daily_brief",
+		"server: linear",
+		"description: Rendered daily briefing prompt",
+		"messages:",
+		"Brief me on Go.",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectRendersMCPPromptJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/mcp/prompts/get" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemon.MCPPromptRenderResponse{
+			Server: "linear",
+			Name:   "daily_brief",
+			Messages: []daemon.MCPPromptMessage{{
+				Role:    "user",
+				Content: json.RawMessage(`{"type":"text","text":"Brief me."}`),
+			}},
+		})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--mcp-prompt-json",
+		"--server", "linear",
+		"--name", "daily_brief",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var rendered daemon.MCPPromptRenderResponse
+	if err := json.Unmarshal(stdout.Bytes(), &rendered); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if rendered.Server != "linear" || rendered.Name != "daily_brief" || len(rendered.Messages) != 1 {
+		t.Fatalf("rendered = %+v", rendered)
+	}
+}
+
 func TestRunCLIConnectShowsStatus(t *testing.T) {
 	var sawStatus bool
 	var sawRun bool

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -46,6 +46,18 @@ type MCPPromptCatalogHost interface {
 	MCPPromptCatalog(context.Context) ([]MCPPromptCatalogEntry, error)
 }
 
+// MCPResourceReaderHost is optionally implemented by hosts that can read one
+// MCP resource without starting a run.
+type MCPResourceReaderHost interface {
+	MCPReadResource(context.Context, MCPReadResourceRequest) (MCPResourceReadResponse, error)
+}
+
+// MCPPromptRendererHost is optionally implemented by hosts that can render one
+// MCP prompt without starting a run.
+type MCPPromptRendererHost interface {
+	MCPRenderPrompt(context.Context, MCPPromptRenderRequest) (MCPPromptRenderResponse, error)
+}
+
 // MCPResourceCatalogEntry describes one MCP resource advertised by a host.
 type MCPResourceCatalogEntry struct {
 	Server      string         `json:"server"`
@@ -73,6 +85,51 @@ type MCPPromptCatalogArgument struct {
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
 	Required    bool   `json:"required,omitempty"`
+}
+
+// MCPReadResourceRequest selects one resource URI from one configured server.
+type MCPReadResourceRequest struct {
+	Server string `json:"server"`
+	URI    string `json:"uri"`
+}
+
+// MCPResourceReadResponse contains the contents returned by an MCP
+// resources/read request.
+type MCPResourceReadResponse struct {
+	Server   string               `json:"server"`
+	URI      string               `json:"uri"`
+	Contents []MCPResourceContent `json:"contents"`
+}
+
+// MCPResourceContent is one text or blob content item returned from a resource.
+type MCPResourceContent struct {
+	URI      string         `json:"uri"`
+	MIMEType string         `json:"mime_type,omitempty"`
+	Text     *string        `json:"text,omitempty"`
+	Blob     *string        `json:"blob,omitempty"`
+	Meta     map[string]any `json:"_meta,omitempty"`
+}
+
+// MCPPromptRenderRequest selects one prompt from one configured server.
+type MCPPromptRenderRequest struct {
+	Server    string            `json:"server"`
+	Name      string            `json:"name"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+// MCPPromptRenderResponse contains the messages returned by an MCP prompts/get
+// request.
+type MCPPromptRenderResponse struct {
+	Server      string             `json:"server"`
+	Name        string             `json:"name"`
+	Description string             `json:"description,omitempty"`
+	Messages    []MCPPromptMessage `json:"messages"`
+}
+
+// MCPPromptMessage is one rendered prompt message.
+type MCPPromptMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
 }
 
 // Options configures [New].
@@ -323,12 +380,30 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/v1/mcp/resources/read" {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleMCPReadResource(w, r)
+		return
+	}
+
 	if r.URL.Path == "/v1/mcp/prompts" {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
 			return
 		}
 		s.handleMCPPrompts(w, r)
+		return
+	}
+
+	if r.URL.Path == "/v1/mcp/prompts/get" {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleMCPRenderPrompt(w, r)
 		return
 	}
 
@@ -394,6 +469,12 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	}
 	if _, ok := s.host.(MCPPromptCatalogHost); ok {
 		capabilities = append(capabilities, "mcp_prompts")
+	}
+	if _, ok := s.host.(MCPResourceReaderHost); ok {
+		capabilities = append(capabilities, "mcp_resource_read")
+	}
+	if _, ok := s.host.(MCPPromptRendererHost); ok {
+		capabilities = append(capabilities, "mcp_prompt_get")
 	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:           true,
@@ -487,6 +568,70 @@ func (s *Server) handleMCPPrompts(w http.ResponseWriter, r *http.Request) {
 		prompts = []MCPPromptCatalogEntry{}
 	}
 	writeJSON(w, http.StatusOK, mcpPromptCatalogResponse{Prompts: prompts})
+}
+
+func (s *Server) handleMCPReadResource(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.host.(MCPResourceReaderHost)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "MCP resource reads are not supported by this host", false)
+		return
+	}
+	var req MCPReadResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body", false)
+		return
+	}
+	req.Server = strings.TrimSpace(req.Server)
+	req.URI = strings.TrimSpace(req.URI)
+	if req.Server == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "server is required", false)
+		return
+	}
+	if req.URI == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "uri is required", false)
+		return
+	}
+	read, err := host.MCPReadResource(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if read.Contents == nil {
+		read.Contents = []MCPResourceContent{}
+	}
+	writeJSON(w, http.StatusOK, read)
+}
+
+func (s *Server) handleMCPRenderPrompt(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.host.(MCPPromptRendererHost)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "MCP prompt rendering is not supported by this host", false)
+		return
+	}
+	var req MCPPromptRenderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body", false)
+		return
+	}
+	req.Server = strings.TrimSpace(req.Server)
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Server == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "server is required", false)
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "name is required", false)
+		return
+	}
+	rendered, err := host.MCPRenderPrompt(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if rendered.Messages == nil {
+		rendered.Messages = []MCPPromptMessage{}
+	}
+	writeJSON(w, http.StatusOK, rendered)
 }
 
 func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, req startRunRequest) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -94,6 +94,44 @@ func (h mcpCatalogHost) MCPPromptCatalog(context.Context) ([]MCPPromptCatalogEnt
 	return h.prompts, nil
 }
 
+type mcpActionHost struct{}
+
+func (mcpActionHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
+func (mcpActionHost) MCPReadResource(_ context.Context, req MCPReadResourceRequest) (MCPResourceReadResponse, error) {
+	if req.Server != "filesystem" || req.URI != "file:///workspace/README.md" {
+		return MCPResourceReadResponse{}, fmt.Errorf("unexpected read request: %+v", req)
+	}
+	text := "# Project README\n\nHello from daemon."
+	return MCPResourceReadResponse{
+		Server: req.Server,
+		URI:    req.URI,
+		Contents: []MCPResourceContent{{
+			URI:      req.URI,
+			MIMEType: "text/markdown",
+			Text:     &text,
+			Meta:     map[string]any{"source": "test"},
+		}},
+	}, nil
+}
+
+func (mcpActionHost) MCPRenderPrompt(_ context.Context, req MCPPromptRenderRequest) (MCPPromptRenderResponse, error) {
+	if req.Server != "linear" || req.Name != "daily_brief" || req.Arguments["topic"] != "Go" {
+		return MCPPromptRenderResponse{}, fmt.Errorf("unexpected prompt request: %+v", req)
+	}
+	return MCPPromptRenderResponse{
+		Server:      req.Server,
+		Name:        req.Name,
+		Description: "Rendered daily briefing prompt",
+		Messages: []MCPPromptMessage{{
+			Role:    "user",
+			Content: json.RawMessage(`{"type":"text","text":"Brief me on Go."}`),
+		}},
+	}, nil
+}
+
 func TestServerAuthAndHealth(t *testing.T) {
 	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
 	ts := httptest.NewServer(srv)
@@ -292,6 +330,74 @@ func TestServerMCPCatalogsUnsupportedHost(t *testing.T) {
 	}
 	if len(prompts.Prompts) != 0 {
 		t.Fatalf("prompts = %+v, want empty", prompts.Prompts)
+	}
+}
+
+func TestServerMCPReadResourceAndRenderPrompt(t *testing.T) {
+	srv := newTestServer(t, mcpActionHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/mcp/resources/read", "", `{"server":"filesystem","uri":"file:///workspace/README.md"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated read status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/mcp/resources/read", "token", `{"server":"filesystem","uri":"file:///workspace/README.md"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("read status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var read MCPResourceReadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&read); err != nil {
+		t.Fatal(err)
+	}
+	if read.Server != "filesystem" || read.URI != "file:///workspace/README.md" || len(read.Contents) != 1 || read.Contents[0].Text == nil {
+		t.Fatalf("read = %+v", read)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/mcp/prompts/get", "token", `{"server":"linear","name":"daily_brief","arguments":{"topic":"Go"}}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("prompt status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var rendered MCPPromptRenderResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rendered); err != nil {
+		t.Fatal(err)
+	}
+	if rendered.Server != "linear" || rendered.Name != "daily_brief" || len(rendered.Messages) != 1 || !strings.Contains(string(rendered.Messages[0].Content), "Brief me on Go.") {
+		t.Fatalf("rendered = %+v", rendered)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	var status statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"mcp_resource_read", "mcp_prompt_get"} {
+		if !contains(status.Capabilities, want) {
+			t.Fatalf("capabilities = %v, missing %q", status.Capabilities, want)
+		}
+	}
+}
+
+func TestServerMCPActionValidation(t *testing.T) {
+	srv := newTestServer(t, mcpActionHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/mcp/resources/read", "token", `{"server":"filesystem"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("read validation status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/mcp/prompts/get", "token", `{"server":"linear"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("prompt validation status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 


### PR DESCRIPTION
Closes #216.

## Summary
- Add authenticated daemon endpoints for MCP resource reads and prompt rendering.
- Let Peggy delegate daemon read/render requests to its initialized MCP manager.
- Add `glue connect --mcp-read`, `--mcp-prompt`, and JSON variants.
- Document the remote MCP action workflow in Peggy and root docs.

## Validation
- `go test ./daemon -run 'TestServerMCP(Read|Action|Catalog)|TestServerStatus' -count=1`
- `go test ./agents/peggy -run 'TestPeggyDaemon(ExposesMCPCatalogs|ReadsMCPResourceAndRendersPrompt)' -count=1`
- `go test ./cmd/glue -run 'TestRunCLIConnect(ReadsMCP|RendersMCP|ListsMCP|InspectIncludesMCP|RejectsMultiple|RequiresPrompt)' -count=1`
- `go test ./daemon ./cmd/glue ./agents/peggy -count=1`
- `git diff --check -- daemon/server.go daemon/server_test.go agents/peggy/peggy.go agents/peggy/daemon_test.go cmd/glue/main.go cmd/glue/main_test.go agents/peggy/README.md agents/peggy/CHANGELOG.md README.md`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`