### PR TITLE
agents/peggy: load and run file skills

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -18,6 +18,12 @@ not formally follow SemVer until v1.0.
   or render one MCP prompt with
   `glue connect --mcp-prompt --server <name> --name <prompt> --arg key=value`;
   both modes have JSON variants.
+- **Workspace file skills.** Peggy settings now support
+  `context.work_dir` for loading Glue workspace context, including
+  `.agents/skills/<name>/SKILL.md`. `peggy skills` lists discovered
+  skills without constructing a provider. `peggy skill` runs one
+  skill through a Peggy session with repeatable `--arg key=value`
+  values, and library callers can use `Peggy.Skill`.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -4,7 +4,7 @@
 > remembers you across sessions, and curates facts on her own.
 
 A long-running personal-assistant agent built on the
-[glue](../..) framework. **v0.4** ships:
+[glue](../..) framework. Current builds include:
 
 - a single-prompt **CLI** (`peggy`)
 - a **Telegram bot** binary (`peggy-telegram`) with a chat-id allowlist
@@ -22,7 +22,9 @@ A long-running personal-assistant agent built on the
   CLI, Telegram, and daemon clients
 - per-channel permission tiers (`prompt`, `read_only`, `trusted`)
 - opt-in MCP stdio/HTTP tools plus resource and prompt inspection
-- local readiness status for config, identity, memory, coding, and MCP setup
+- workspace file skills loaded from `.agents/skills/<name>/SKILL.md`
+- local readiness status for config, identity, memory, context,
+  coding, and MCP setup
 - four model backends: Codex (ChatGPT subscription), Gemini,
   OpenRouter, NVIDIA build
 
@@ -108,6 +110,9 @@ and emits a stderr diagnostic.
     "target_tokens": 8000,
     "keep_recent": 8
   },
+  "context": {
+    "work_dir": "~/workspace"
+  },
   "permissions": {
     "default_tier": "prompt",
     "channels": {
@@ -127,6 +132,7 @@ and emits a stderr diagnostic.
 | `compaction.threshold` | `200` | Message-count gate. Compaction only runs when the in-memory transcript exceeds this. |
 | `compaction.target_tokens` | `8000` | Soft cap on transcript size before summarization. Word-count heuristic; not a real tokenizer. |
 | `compaction.keep_recent` | `8` | Most-recent messages retained verbatim through compaction. |
+| `context.work_dir` | empty | Workspace root for `AGENTS.md`, `.agents/skills`, and roles. `~` and `$HOME` expand. |
 | `coding.enabled` | `false` | Register local coding tools. Enable only for trusted local workspaces. |
 | `coding.work_dir` | current directory | Workspace root for `read_file`, `write_file`, `shell_exec`, and git helpers. `~` and `$HOME` expand. |
 | `coding.allowed_binaries` | `go`, `git`, `make`, `node`, `npm`, `python`, `python3` | Basename allowlist for `shell_exec`; model calls cannot run arbitrary paths. |
@@ -150,6 +156,8 @@ defaults above and emits a stderr diagnostic.
 
 ```
 peggy [flags] "<prompt text>"
+peggy skill [flags] <name>
+peggy skills [flags]
 peggy mcp prompt [flags]
 peggy mcp prompts [flags]
 peggy mcp read [flags]
@@ -175,6 +183,50 @@ peggy status [flags]
 
 The prompt is whatever non-flag args you pass — quoting is your
 shell's job. Multi-word prompts work without quoting too.
+
+## File Skills
+
+Point `context.work_dir` at a workspace to let Peggy discover reusable
+project context:
+
+```json
+{
+  "context": {
+    "work_dir": "/path/to/workspace"
+  }
+}
+```
+
+Peggy loads `AGENTS.md` into the system prompt and scans skills under
+`.agents/skills/<name>/SKILL.md`. A skill file is Markdown with
+optional frontmatter:
+
+```markdown
+---
+name: triage
+description: Triage one issue and propose next actions
+---
+
+Read the issue context, identify missing information, and return a
+short implementation plan with risks.
+```
+
+List discovered skills without constructing a model provider:
+
+```sh
+peggy skills --config ~/.config/peggy/settings.json
+peggy skills --config ~/.config/peggy/settings.json --json
+```
+
+Run one skill through a normal Peggy session:
+
+```sh
+peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
+```
+
+Repeat `--arg key=value` to pass small structured inputs. Skill runs
+use the same provider, identity, memory, session store, MCP setup, and
+optional `--coding` controls as normal Peggy prompts.
 
 `peggy status` prints a local readiness summary without constructing a
 provider, starting a prompt, or connecting to MCP servers:
@@ -509,13 +561,16 @@ near-term follow-up.
 - Opt-in **local coding mode** for CLI and Telegram: read files, write
   files, run allowlisted commands, and inspect git branch context with
   per-call permission prompts for side effects.
+- **Workspace file skills**: `context.work_dir` loads `AGENTS.md`,
+  `.agents/skills`, and roles; `peggy skills` lists the catalog and
+  `peggy skill --arg key=value <name>` runs one skill through Peggy.
 - **Permission tiers** by channel/client: prompt, read-only, or trusted.
 - All four shipped providers: `codex` (ChatGPT subscription),
   `gemini`, `openrouter`, `nvidia`. Codex is the default and uses
   your existing ChatGPT subscription via `codex login` — no per-token
   bill.
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.3 summary and
+See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.4 summary and
 known limitations.
 
 ## Channels
@@ -543,13 +598,15 @@ external transports. The pattern is designed in
 Per tracker [#110](https://github.com/erain/glue/issues/110), in
 priority order:
 
-- **M4 — ecosystem.** MCP client (stdio + HTTP), cost tracking,
+- **M5 — file skills and workspace context.** Make Peggy a richer
+  operator over glue project context: file-backed skills, role-aware
+  runs, and daemon/client discovery for reusable workflows.
+- **Later ecosystem polish.** Cost tracking and
   `providers/anthropic` when budget allows.
 
-Near-term follow-ups that may slip into v0.3.x patches: a `peggy
-memories` subcommand (list / export / forget), edit-in-place
-Telegram streaming, FTS5 prefix-match on session ids for
-channel-scoped recall.
+Near-term follow-ups that may ship as patches: a `peggy memories`
+subcommand (list / export / forget), edit-in-place Telegram
+streaming, FTS5 prefix-match on session ids for channel-scoped recall.
 
 ## As a library
 
@@ -567,6 +624,9 @@ if err != nil { /* … */ }
 defer p.Close()
 
 text, err := p.Prompt(ctx, "session-id", "hello", os.Stdout)
+
+text, err = p.Skill(ctx, "session-id", "triage",
+    map[string]string{"issue": "GLUE-123"}, os.Stdout)
 ```
 
 See [`peggy.go`](peggy.go) for the full API.

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -174,6 +174,7 @@ func New(opts Options) (*Peggy, error) {
 		SystemPrompt:        finalSystem,
 		Tools:               tools,
 		Store:               store,
+		WorkDir:             settings.Context.WorkDir,
 		Permission:          opts.Permission,
 		Compactor:           compactor,
 		CompactionThreshold: settings.Compaction.Threshold,
@@ -358,6 +359,31 @@ func (p *Peggy) Prompt(ctx context.Context, sessionID, text string, stdout io.Wr
 		opts = append(opts, glue.WithStreamWriter(stdout))
 	}
 	res, err := session.Prompt(ctx, text, opts...)
+	if err != nil {
+		return "", err
+	}
+	return res.Text, nil
+}
+
+// Skill runs one named Glue skill against the given session id. Args are
+// appended to the skill prompt as formatted JSON by the Glue session layer.
+func (p *Peggy) Skill(ctx context.Context, sessionID, name string, args any, stdout io.Writer) (string, error) {
+	if p == nil || p.agent == nil {
+		return "", errors.New("peggy: not initialised")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", errors.New("peggy: empty skill name")
+	}
+	session, err := p.agent.Session(ctx, sessionID)
+	if err != nil {
+		return "", err
+	}
+	opts := []glue.PromptOption{}
+	if stdout != nil {
+		opts = append(opts, glue.WithStreamWriter(stdout))
+	}
+	res, err := session.Skill(ctx, name, args, opts...)
 	if err != nil {
 		return "", err
 	}

--- a/agents/peggy/peggy_test.go
+++ b/agents/peggy/peggy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -96,6 +97,52 @@ func TestPeggy_SoulFlowsIntoSystemPrompt(t *testing.T) {
 	sys := fp.requests[0].SystemPrompt
 	if !strings.Contains(sys, "Australian Shepherds") {
 		t.Errorf("system prompt missing SOUL content: %q", sys)
+	}
+}
+
+func TestPeggy_SkillUsesWorkspaceSkill(t *testing.T) {
+	workDir := t.TempDir()
+	skillDir := filepath.Join(workDir, ".agents", "skills", "triage")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: triage\ndescription: Triage one issue\n---\nInvestigate the issue and propose next steps."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fp := &fakeProvider{text: "triaged"}
+	p, err := New(Options{
+		Settings: Settings{Context: ContextSettings{WorkDir: workDir}},
+		Provider: fp,
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	var stdout bytes.Buffer
+	text, err := p.Skill(context.Background(), "default", "triage", map[string]string{"issue": "GLUE-123"}, &stdout)
+	if err != nil {
+		t.Fatalf("Skill: %v", err)
+	}
+	if text != "triaged" || !strings.Contains(stdout.String(), "triaged") {
+		t.Fatalf("skill output text=%q stdout=%q", text, stdout.String())
+	}
+	if len(fp.requests) != 1 {
+		t.Fatalf("provider requests = %d, want 1", len(fp.requests))
+	}
+	req := fp.requests[0]
+	if !strings.Contains(req.SystemPrompt, "triage") || !strings.Contains(req.SystemPrompt, "Triage one issue") {
+		t.Fatalf("system prompt missing skill catalog: %q", req.SystemPrompt)
+	}
+	if len(req.Messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(req.Messages))
+	}
+	prompt := req.Messages[0].Content[0].Text
+	for _, want := range []string{"Investigate the issue", `"issue": "GLUE-123"`} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("skill prompt = %q, missing %q", prompt, want)
+		}
 	}
 }
 

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -46,6 +46,7 @@ type statusReport struct {
 	Provider    statusProvider     `json:"provider"`
 	Store       StoreSettings      `json:"store"`
 	Compaction  CompactionSettings `json:"compaction"`
+	Context     statusContext      `json:"context"`
 	Coding      statusCoding       `json:"coding"`
 	Permissions PermissionSettings `json:"permissions"`
 	Channels    []string           `json:"channels,omitempty"`
@@ -70,6 +71,11 @@ type statusCoding struct {
 	AllowOverwrite  bool     `json:"allow_overwrite"`
 }
 
+type statusContext struct {
+	Enabled bool   `json:"enabled"`
+	WorkDir string `json:"work_dir,omitempty"`
+}
+
 type statusMCP struct {
 	Configured int               `json:"configured"`
 	Enabled    int               `json:"enabled"`
@@ -82,6 +88,11 @@ type statusMCPServer struct {
 	Transport string `json:"transport"`
 	Command   string `json:"command,omitempty"`
 	URL       string `json:"url,omitempty"`
+}
+
+type skillCatalogEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 // Run is the top-level CLI entry point. It parses args, loads the
@@ -106,6 +117,10 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 		switch args[0] {
 		case "serve":
 			return runServe(ctx, args[1:], stdout, stderr, serve)
+		case "skill":
+			return runSkill(ctx, args[1:], stdin, stdout, stderr)
+		case "skills":
+			return runSkills(args[1:], stdout, stderr)
 		case "status":
 			return runStatus(args[1:], stdout, stderr)
 		case "mcp":
@@ -129,6 +144,8 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 
 Usage:
   peggy [flags] "<prompt text>"
+  peggy skill [flags] <name>
+  peggy skills [flags]
   peggy status [flags]
   peggy mcp [command]
   peggy serve [flags]
@@ -138,6 +155,8 @@ Examples:
   peggy --session work "remind me about the migration plan"
   peggy --config /tmp/peggy.json "what do you know about my Aussie?"
   peggy --coding --workdir . "run the tests and fix the failure"
+  peggy skills --config ~/.config/peggy/settings.json
+  peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
   peggy status --config ~/.config/peggy/settings.json
   peggy mcp tools --config ~/.config/peggy/settings.json
   peggy serve --config ~/.config/peggy/settings.json
@@ -190,14 +209,7 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 		fmt.Fprintf(stderr, "peggy: identity loaded from %s (%d bytes)\n", soulPathUsed, len(soul))
 	}
 
-	var permission glue.Permission
-	if settings.Coding.Enabled || MCPEnabled(settings.MCP) {
-		permission = NewTieredPermission(
-			NewCLIPermission(CLIPermissionOptions{Stdin: stdin, Stderr: stderr}),
-			PermissionTierForChannel(settings.Permissions, PermissionChannelCLI),
-			PermissionChannelCLI,
-		)
-	}
+	permission := cliPermissionForSettings(settings, stdin, stderr)
 	if settings.Coding.Enabled {
 		workDir := settings.Coding.WorkDir
 		if strings.TrimSpace(workDir) == "" {
@@ -224,6 +236,208 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 	}
 	fmt.Fprintln(stdout) // trailing newline so shell prompts don't run on
 	return 0
+}
+
+func cliPermissionForSettings(settings Settings, stdin io.Reader, stderr io.Writer) glue.Permission {
+	if !settings.Coding.Enabled && !MCPEnabled(settings.MCP) {
+		return nil
+	}
+	return NewTieredPermission(
+		NewCLIPermission(CLIPermissionOptions{Stdin: stdin, Stderr: stderr}),
+		PermissionTierForChannel(settings.Permissions, PermissionChannelCLI),
+		PermissionChannelCLI,
+	)
+}
+
+func runSkills(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy skills", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy skills — list skills discovered from Peggy's configured workspace.
+
+Usage:
+  peggy skills [flags]
+
+Examples:
+  peggy skills --config ~/.config/peggy/settings.json
+  peggy skills --json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy skills: positional args not supported")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy skills: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy skills: no settings.json found; using built-in defaults")
+	}
+	catalog, err := loadSkillCatalog(settings.Context.WorkDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy skills: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(catalog); err != nil {
+			fmt.Fprintf(stderr, "peggy skills: encode catalog: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeSkillCatalog(stdout, catalog)
+	return 0
+}
+
+func runSkill(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy skill", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath           = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		soulPath             = fs.String("soul", "", "path to identity Markdown (overrides $PEGGY_SOUL / XDG / ~/.config/peggy/SOUL.md)")
+		sessionID            = fs.String("session", "default", "session id (file-backed transcripts key off this)")
+		enableCoding         = fs.Bool("coding", false, "enable local coding tools for this skill run")
+		codingWorkDir        = fs.String("workdir", "", "workspace root for --coding (default current directory)")
+		codingAllowOverwrite = fs.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
+		skillArgs            stringListFlag
+	)
+	fs.Var(&skillArgs, "arg", "skill argument as key=value (repeatable)")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy skill — run one skill discovered from Peggy's configured workspace.
+
+Usage:
+  peggy skill [flags] <name>
+
+Examples:
+  peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
+  peggy skill --session work daily_plan
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "peggy skill: exactly one skill name is required")
+		return 2
+	}
+	skillName := strings.TrimSpace(fs.Arg(0))
+	if skillName == "" {
+		fmt.Fprintln(stderr, "peggy skill: skill name is required")
+		return 2
+	}
+	parsedArgs, err := parsePromptArgs(skillArgs)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy skill: %v\n", err)
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy skill: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy skill: no settings.json found; using built-in defaults")
+	}
+	applyCodingFlags(&settings, *enableCoding, *codingWorkDir, *codingAllowOverwrite)
+
+	soul, soulPathUsed, err := LoadSoul(*soulPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy skill: %v\n", err)
+		return 1
+	}
+	if soul == "" {
+		fmt.Fprintln(stderr, "peggy skill: no SOUL.md found; running without identity context")
+	} else {
+		fmt.Fprintf(stderr, "peggy skill: identity loaded from %s (%d bytes)\n", soulPathUsed, len(soul))
+	}
+	if settings.Coding.Enabled {
+		workDir := settings.Coding.WorkDir
+		if strings.TrimSpace(workDir) == "" {
+			workDir = "."
+		}
+		fmt.Fprintf(stderr, "peggy skill: coding tools enabled for %s\n", workDir)
+	}
+
+	p, err := New(Options{
+		Settings:   settings,
+		Soul:       soul,
+		Stderr:     stderr,
+		Permission: cliPermissionForSettings(settings, stdin, stderr),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy skill: setup: %v\n", err)
+		return 1
+	}
+	defer p.Close()
+
+	if _, err := p.Skill(ctx, *sessionID, skillName, parsedArgs, stdout); err != nil {
+		fmt.Fprintf(stderr, "\npeggy skill: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout)
+	return 0
+}
+
+func loadSkillCatalog(workDir string) ([]skillCatalogEntry, error) {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return nil, nil
+	}
+	ctx, err := glue.LoadContext(workDir)
+	if err != nil {
+		return nil, err
+	}
+	names := sortedMapKeys(ctx.Skills)
+	catalog := make([]skillCatalogEntry, 0, len(names))
+	for _, name := range names {
+		skill := ctx.Skills[name]
+		catalog = append(catalog, skillCatalogEntry{
+			Name:        skill.Name,
+			Description: skill.Description,
+		})
+	}
+	return catalog, nil
+}
+
+func writeSkillCatalog(w io.Writer, catalog []skillCatalogEntry) {
+	if len(catalog) == 0 {
+		fmt.Fprintln(w, "No Peggy skills configured.")
+		return
+	}
+	for i, entry := range catalog {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, entry.Name)
+		if entry.Description != "" {
+			fmt.Fprintf(w, "  description: %s\n", singleLine(entry.Description))
+		}
+	}
 }
 
 func runStatus(args []string, stdout, stderr io.Writer) int {
@@ -305,10 +519,19 @@ func buildStatusReport(settings Settings, settingsPath, soul, soulPath string) s
 		},
 		Store:       settings.Store,
 		Compaction:  settings.Compaction,
+		Context:     buildStatusContext(settings.Context),
 		Coding:      buildStatusCoding(settings.Coding),
 		Permissions: settings.Permissions,
 		Channels:    channels,
 		MCP:         mcpServers,
+	}
+}
+
+func buildStatusContext(contextSettings ContextSettings) statusContext {
+	workDir := strings.TrimSpace(contextSettings.WorkDir)
+	return statusContext{
+		Enabled: workDir != "",
+		WorkDir: workDir,
 	}
 }
 
@@ -368,6 +591,7 @@ func writeStatusReport(w io.Writer, report statusReport) {
 	fmt.Fprintf(w, "provider: %s %s\n", report.Provider.Name, report.Provider.Model)
 	fmt.Fprintf(w, "store: %s %s\n", report.Store.Type, report.Store.Path)
 	fmt.Fprintf(w, "compaction: threshold=%d target=%d keep=%d\n", report.Compaction.Threshold, report.Compaction.TargetTokens, report.Compaction.KeepRecent)
+	writeStatusContext(w, report.Context)
 	writeStatusCoding(w, report.Coding)
 	writeStatusPermissions(w, report.Permissions)
 	if len(report.Channels) > 0 {
@@ -376,6 +600,14 @@ func writeStatusReport(w io.Writer, report statusReport) {
 		fmt.Fprintln(w, "channels: none")
 	}
 	writeStatusMCP(w, report.MCP)
+}
+
+func writeStatusContext(w io.Writer, contextSettings statusContext) {
+	if !contextSettings.Enabled {
+		fmt.Fprintln(w, "context: disabled")
+		return
+	}
+	fmt.Fprintf(w, "context: enabled work_dir=%s\n", contextSettings.WorkDir)
 }
 
 func writeStatusCoding(w io.Writer, coding statusCoding) {

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -174,6 +174,7 @@ func TestRunStatusDefaults(t *testing.T) {
 		"settings: built-in defaults",
 		"identity: none",
 		"provider: codex (provider default)",
+		"context: disabled",
 		"mcp: 0 configured, 0 enabled",
 	} {
 		if !strings.Contains(text, want) {
@@ -197,6 +198,9 @@ func TestRunStatusJSON(t *testing.T) {
 			"work_dir":         workDir,
 			"allowed_binaries": []string{"git", "go"},
 			"allow_overwrite":  true,
+		},
+		"context": map[string]any{
+			"work_dir": workDir,
 		},
 		"permissions": map[string]any{
 			"default_tier": "prompt",
@@ -246,11 +250,109 @@ func TestRunStatusJSON(t *testing.T) {
 	if !report.Coding.Enabled || report.Coding.WorkDir != workDir || !report.Coding.AllowOverwrite {
 		t.Fatalf("coding = %+v", report.Coding)
 	}
+	if !report.Context.Enabled || report.Context.WorkDir != workDir {
+		t.Fatalf("context = %+v", report.Context)
+	}
 	if report.MCP.Configured != 2 || report.MCP.Enabled != 1 || len(report.MCP.Servers) != 2 {
 		t.Fatalf("mcp = %+v", report.MCP)
 	}
 	if len(report.Channels) != 1 || report.Channels[0] != "telegram" {
 		t.Fatalf("channels = %+v", report.Channels)
+	}
+}
+
+func TestRunSkillsListsWorkspaceSkills(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	workDir := t.TempDir()
+	skillDir := filepath.Join(workDir, ".agents", "skills", "triage")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: triage\ndescription: Triage one issue\n---\nInvestigate the issue."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	cfg := map[string]any{
+		"context": map[string]any{"work_dir": workDir},
+	}
+	raw, _ := json.MarshalIndent(cfg, "", "  ")
+	_ = os.WriteFile(cfgPath, raw, 0o600)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"skills", "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	for _, want := range []string{"triage", "description: Triage one issue"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", out.String(), want)
+		}
+	}
+}
+
+func TestRunSkillsJSON(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	workDir := t.TempDir()
+	skillDir := filepath.Join(workDir, ".agents", "skills", "daily")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: daily\ndescription: Daily plan\n---\nPlan the day."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	raw, _ := json.MarshalIndent(map[string]any{
+		"context": map[string]any{"work_dir": workDir},
+	}, "", "  ")
+	_ = os.WriteFile(cfgPath, raw, 0o600)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"skills", "--config", cfgPath, "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var catalog []skillCatalogEntry
+	if err := json.Unmarshal(out.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, out.String())
+	}
+	if len(catalog) != 1 || catalog[0].Name != "daily" || catalog[0].Description != "Daily plan" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}
+
+func TestRunSkillFlagsParse(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	workDir := t.TempDir()
+	skillDir := filepath.Join(workDir, ".agents", "skills", "triage")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("Investigate the issue."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	raw, _ := json.MarshalIndent(map[string]any{
+		"provider": "bogus-provider",
+		"context":  map[string]any{"work_dir": workDir},
+	}, "", "  ")
+	_ = os.WriteFile(cfgPath, raw, 0o600)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"skill", "--config", cfgPath, "--arg", "issue=GLUE-123", "triage"}, &out, &errOut)
+	if code == 2 {
+		t.Fatalf("exit 2 indicates skill flags were not recognised; stderr=%q", errOut.String())
 	}
 }
 

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -44,6 +44,10 @@ type Settings struct {
 	// discovered tools Peggy can register. Disabled by default.
 	MCP MCPSettings `json:"mcp"`
 
+	// Context configures workspace context discovery for AGENTS.md,
+	// .agents/skills, and roles. Disabled when WorkDir is empty.
+	Context ContextSettings `json:"context"`
+
 	// Permissions configures Peggy's side-effect permission policy.
 	// Defaults to prompt for every channel.
 	Permissions PermissionSettings `json:"permissions"`
@@ -93,6 +97,11 @@ type CodingSettings struct {
 // MCPSettings configures external MCP tool servers.
 type MCPSettings struct {
 	Servers map[string]MCPServerSettings `json:"servers,omitempty"`
+}
+
+// ContextSettings configures Glue project-context discovery for Peggy.
+type ContextSettings struct {
+	WorkDir string `json:"work_dir,omitempty"`
 }
 
 // MCPServerSettings configures one named MCP server. Stdio is the only
@@ -180,6 +189,13 @@ func LoadSettings(path string) (Settings, string, error) {
 			return Settings{}, resolved, err
 		}
 		s.Coding.WorkDir = expanded
+	}
+	if s.Context.WorkDir != "" {
+		expanded, err := expandPath(s.Context.WorkDir)
+		if err != nil {
+			return Settings{}, resolved, err
+		}
+		s.Context.WorkDir = expanded
 	}
 	if len(s.MCP.Servers) > 0 {
 		expanded, err := expandMCPSettings(s.MCP)

--- a/agents/peggy/settings_test.go
+++ b/agents/peggy/settings_test.go
@@ -53,6 +53,22 @@ func TestLoadSettings_HappyPathWithDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadSettings_ContextWorkDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeJSON(t, path, map[string]any{
+		"context": map[string]any{"work_dir": "$HOME/workspace"},
+	})
+	s, _, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got := s.Context.WorkDir; got != filepath.Join(home, "workspace") {
+		t.Fatalf("context.work_dir = %q, want expanded path", got)
+	}
+}
+
 func TestLoadSettings_ExplicitPathMissingIsError(t *testing.T) {
 	t.Setenv(EnvConfigPath, "")
 	_, _, err := LoadSettings(filepath.Join(t.TempDir(), "missing.json"))


### PR DESCRIPTION
## Summary

- add `context.work_dir` settings support so Peggy can load Glue workspace context and file-backed skills
- add `peggy skills` and `peggy skill` CLI flows plus the `Peggy.Skill` library API
- document the M5 file-skill workflow and cover settings, listing, execution, and status behavior in tests

Closes #218.

## Validation

- `go test ./agents/peggy -run 'TestRunStatusDefaults|TestRunStatusJSON|TestRunSkills|TestRunSkillFlagsParse|TestPeggy_SkillUsesWorkspaceSkill|TestLoadSettings_ContextWorkDir' -count=1`\n- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`\n- `go vet ./...`