### PR TITLE
agents/peggy: expose workspace roles

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -30,6 +30,12 @@ not formally follow SemVer until v1.0.
   data, `glue connect --skill <name> --arg key=value` runs a skill
   over the existing SSE stream, and `glue connect --inspect` includes
   skills when the daemon advertises them.
+- **Workspace roles for Peggy.** `peggy roles` lists role files from
+  `context.work_dir`, local `peggy --role <name>` and
+  `peggy skill --role <name>` apply a workspace role to a run, and
+  daemon clients can inspect roles with `glue connect --roles` /
+  `--roles-json`. `glue connect --inspect` includes roles when the
+  daemon advertises them.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -158,6 +158,7 @@ defaults above and emits a stderr diagnostic.
 peggy [flags] "<prompt text>"
 peggy skill [flags] <name>
 peggy skills [flags]
+peggy roles [flags]
 peggy mcp prompt [flags]
 peggy mcp prompts [flags]
 peggy mcp read [flags]
@@ -237,6 +238,28 @@ glue connect --skills-json
 glue connect --skill triage --arg issue=GLUE-123 --id cli:triage --usage
 ```
 
+Roles live under `roles/*.md` with the same simple frontmatter style:
+
+```markdown
+---
+name: reviewer
+description: Review diffs carefully
+model: gpt-5-codex
+---
+
+Focus on correctness, regressions, and missing tests.
+```
+
+List roles and apply one to a prompt or skill run:
+
+```sh
+peggy roles --config ~/.config/peggy/settings.json
+peggy --role reviewer --config ~/.config/peggy/settings.json "review this branch"
+peggy skill --role reviewer --config ~/.config/peggy/settings.json triage
+glue connect --roles
+glue connect --role reviewer --prompt "review this branch"
+```
+
 `peggy status` prints a local readiness summary without constructing a
 provider, starting a prompt, or connecting to MCP servers:
 
@@ -258,6 +281,7 @@ session history and memory store.
 peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
 glue connect --skills
+glue connect --roles
 glue connect --skill triage --arg issue=GLUE-123 --id cli:triage
 glue connect --mcp-resources
 glue connect --mcp-prompts
@@ -282,12 +306,13 @@ Useful `serve` flags:
 
 Startup output prints the `base_url` and metadata path, never the
 bearer token. `glue connect --inspect` includes status, tools,
-daemon-advertised skills, and any daemon-advertised MCP
-resource/prompt catalogs. Use `--skills-json`, `--mcp-resources-json`,
-`--mcp-prompts-json`, `--mcp-read-json`, or `--mcp-prompt-json` when
-another client needs the payload as data. Add `--usage` to prompt or
-skill-mode `glue connect` when you want provider-reported token usage
-on stderr. Stop the daemon with SIGINT/SIGTERM.
+daemon-advertised skills, daemon-advertised roles, and any
+daemon-advertised MCP resource/prompt catalogs. Use `--skills-json`,
+`--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
+`--mcp-read-json`, or `--mcp-prompt-json` when another client needs the
+payload as data. Add `--usage` to prompt or skill-mode `glue connect`
+when you want provider-reported token usage on stderr. Stop the daemon
+with SIGINT/SIGTERM.
 
 Telegram can attach to the same daemon:
 
@@ -574,7 +599,7 @@ near-term follow-up.
   per-call permission prompts for side effects.
 - **Workspace file skills**: `context.work_dir` loads `AGENTS.md`,
   `.agents/skills`, and roles; local and daemon clients can list the
-  catalog and run one skill through Peggy.
+  catalogs, apply roles, and run one skill through Peggy.
 - **Permission tiers** by channel/client: prompt, read-only, or trusted.
 - All four shipped providers: `codex` (ChatGPT subscription),
   `gemini`, `openrouter`, `nvidia`. Codex is the default and uses

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -188,6 +188,44 @@ func TestPeggyDaemonListsAndRunsWorkspaceSkills(t *testing.T) {
 	}
 }
 
+func TestPeggyDaemonListsWorkspaceRoles(t *testing.T) {
+	workDir := t.TempDir()
+	roleDir := filepath.Join(workDir, "roles")
+	if err := os.MkdirAll(roleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(roleDir, "reviewer.md"), []byte("---\nname: reviewer\ndescription: Reviews diffs\nmodel: role-model\n---\nReview carefully."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := New(Options{
+		Settings: Settings{Context: ContextSettings{WorkDir: workDir}},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	var roles struct {
+		Roles []daemon.RoleCatalogEntry `json:"roles"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/roles", &roles)
+	if len(roles.Roles) != 1 || roles.Roles[0].Name != "reviewer" || roles.Roles[0].Model != "role-model" {
+		t.Fatalf("roles = %+v", roles.Roles)
+	}
+}
+
 func TestPeggyDaemonExposesMCPCatalogs(t *testing.T) {
 	p, err := New(Options{
 		Settings: Settings{

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -232,6 +232,32 @@ func (p *Peggy) SkillCatalog(ctx context.Context) ([]daemon.SkillCatalogEntry, e
 	return out, nil
 }
 
+// RoleCatalog implements daemon.RoleCatalogHost.
+func (p *Peggy) RoleCatalog(ctx context.Context) ([]daemon.RoleCatalogEntry, error) {
+	if p == nil {
+		return nil, nil
+	}
+	workDir := strings.TrimSpace(p.settings.Context.WorkDir)
+	if workDir == "" {
+		return nil, nil
+	}
+	projectContext, err := glue.LoadContext(workDir)
+	if err != nil {
+		return nil, err
+	}
+	names := sortedMapKeys(projectContext.Roles)
+	out := make([]daemon.RoleCatalogEntry, 0, len(names))
+	for _, name := range names {
+		role := projectContext.Roles[name]
+		out = append(out, daemon.RoleCatalogEntry{
+			Name:        role.Name,
+			Description: role.Description,
+			Model:       role.Model,
+		})
+	}
+	return out, nil
+}
+
 // MCPResourceCatalog implements daemon.MCPResourceCatalogHost.
 func (p *Peggy) MCPResourceCatalog(ctx context.Context) ([]daemon.MCPResourceCatalogEntry, error) {
 	if p == nil || p.mcpManager == nil {
@@ -369,6 +395,11 @@ func (p *Peggy) Close() error {
 //
 // An empty sessionID resolves to "default".
 func (p *Peggy) Prompt(ctx context.Context, sessionID, text string, stdout io.Writer) (string, error) {
+	return p.PromptWithOptions(ctx, sessionID, text, stdout)
+}
+
+// PromptWithOptions runs one turn with additional Glue prompt options.
+func (p *Peggy) PromptWithOptions(ctx context.Context, sessionID, text string, stdout io.Writer, options ...glue.PromptOption) (string, error) {
 	if p == nil || p.agent == nil {
 		return "", errors.New("peggy: not initialised")
 	}
@@ -379,7 +410,7 @@ func (p *Peggy) Prompt(ctx context.Context, sessionID, text string, stdout io.Wr
 	if err != nil {
 		return "", err
 	}
-	opts := []glue.PromptOption{}
+	opts := append([]glue.PromptOption{}, options...)
 	if stdout != nil {
 		opts = append(opts, glue.WithStreamWriter(stdout))
 	}
@@ -393,6 +424,11 @@ func (p *Peggy) Prompt(ctx context.Context, sessionID, text string, stdout io.Wr
 // Skill runs one named Glue skill against the given session id. Args are
 // appended to the skill prompt as formatted JSON by the Glue session layer.
 func (p *Peggy) Skill(ctx context.Context, sessionID, name string, args any, stdout io.Writer) (string, error) {
+	return p.SkillWithOptions(ctx, sessionID, name, args, stdout)
+}
+
+// SkillWithOptions runs one named Glue skill with additional prompt options.
+func (p *Peggy) SkillWithOptions(ctx context.Context, sessionID, name string, args any, stdout io.Writer, options ...glue.PromptOption) (string, error) {
 	if p == nil || p.agent == nil {
 		return "", errors.New("peggy: not initialised")
 	}
@@ -404,7 +440,7 @@ func (p *Peggy) Skill(ctx context.Context, sessionID, name string, args any, std
 	if err != nil {
 		return "", err
 	}
-	opts := []glue.PromptOption{}
+	opts := append([]glue.PromptOption{}, options...)
 	if stdout != nil {
 		opts = append(opts, glue.WithStreamWriter(stdout))
 	}

--- a/agents/peggy/peggy_test.go
+++ b/agents/peggy/peggy_test.go
@@ -146,6 +146,38 @@ func TestPeggy_SkillUsesWorkspaceSkill(t *testing.T) {
 	}
 }
 
+func TestPeggy_PromptWithOptionsUsesWorkspaceRole(t *testing.T) {
+	workDir := t.TempDir()
+	roleDir := filepath.Join(workDir, "roles")
+	if err := os.MkdirAll(roleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(roleDir, "reviewer.md"), []byte("---\nname: reviewer\ndescription: Reviews diffs\nmodel: role-model\n---\nReview carefully."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fp := &fakeProvider{text: "reviewed"}
+	p, err := New(Options{
+		Settings: Settings{Context: ContextSettings{WorkDir: workDir}},
+		Provider: fp,
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.PromptWithOptions(context.Background(), "default", "check this", nil, glue.WithRole("reviewer")); err != nil {
+		t.Fatalf("PromptWithOptions: %v", err)
+	}
+	if len(fp.requests) != 1 {
+		t.Fatalf("provider requests = %d, want 1", len(fp.requests))
+	}
+	req := fp.requests[0]
+	if req.Model != "role-model" || !strings.Contains(req.SystemPrompt, "Review carefully.") {
+		t.Fatalf("request model=%q system=%q", req.Model, req.SystemPrompt)
+	}
+}
+
 func TestPeggy_PromptPersistsTranscript(t *testing.T) {
 	storeDir := filepath.Join(t.TempDir(), "sessions")
 	fp := &fakeProvider{text: "first"}

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -95,6 +95,12 @@ type skillCatalogEntry struct {
 	Description string `json:"description,omitempty"`
 }
 
+type roleCatalogEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Model       string `json:"model,omitempty"`
+}
+
 // Run is the top-level CLI entry point. It parses args, loads the
 // settings and identity files, constructs a Peggy, and dispatches a
 // single prompt. Returns a process exit code.
@@ -121,6 +127,8 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 			return runSkill(ctx, args[1:], stdin, stdout, stderr)
 		case "skills":
 			return runSkills(args[1:], stdout, stderr)
+		case "roles":
+			return runRoles(args[1:], stdout, stderr)
 		case "status":
 			return runStatus(args[1:], stdout, stderr)
 		case "mcp":
@@ -134,6 +142,7 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 		configPath           = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
 		soulPath             = fs.String("soul", "", "path to identity Markdown (overrides $PEGGY_SOUL / XDG / ~/.config/peggy/SOUL.md)")
 		sessionID            = fs.String("session", "default", "session id (file-backed transcripts key off this)")
+		roleName             = fs.String("role", "", "workspace role name for this prompt")
 		showVersion          = fs.Bool("version", false, "print version and exit")
 		enableCoding         = fs.Bool("coding", false, "enable local coding tools for this prompt")
 		codingWorkDir        = fs.String("workdir", "", "workspace root for --coding (default current directory)")
@@ -146,6 +155,7 @@ Usage:
   peggy [flags] "<prompt text>"
   peggy skill [flags] <name>
   peggy skills [flags]
+  peggy roles [flags]
   peggy status [flags]
   peggy mcp [command]
   peggy serve [flags]
@@ -156,6 +166,7 @@ Examples:
   peggy --config /tmp/peggy.json "what do you know about my Aussie?"
   peggy --coding --workdir . "run the tests and fix the failure"
   peggy skills --config ~/.config/peggy/settings.json
+  peggy roles --config ~/.config/peggy/settings.json
   peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
   peggy status --config ~/.config/peggy/settings.json
   peggy mcp tools --config ~/.config/peggy/settings.json
@@ -230,7 +241,8 @@ Identity (SOUL.md) resolution: --soul > $PEGGY_SOUL > $XDG_CONFIG_HOME/peggy/SOU
 	}
 	defer p.Close()
 
-	if _, err := p.Prompt(ctx, *sessionID, prompt, stdout); err != nil {
+	promptOptions := promptOptionsForRole(*roleName)
+	if _, err := p.PromptWithOptions(ctx, *sessionID, prompt, stdout, promptOptions...); err != nil {
 		fmt.Fprintf(stderr, "\npeggy: prompt: %v\n", err)
 		return 1
 	}
@@ -247,6 +259,14 @@ func cliPermissionForSettings(settings Settings, stdin io.Reader, stderr io.Writ
 		PermissionTierForChannel(settings.Permissions, PermissionChannelCLI),
 		PermissionChannelCLI,
 	)
+}
+
+func promptOptionsForRole(roleName string) []glue.PromptOption {
+	roleName = strings.TrimSpace(roleName)
+	if roleName == "" {
+		return nil
+	}
+	return []glue.PromptOption{glue.WithRole(roleName)}
 }
 
 func runSkills(args []string, stdout, stderr io.Writer) int {
@@ -307,6 +327,64 @@ Flags:
 	return 0
 }
 
+func runRoles(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy roles", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy roles — list roles discovered from Peggy's configured workspace.
+
+Usage:
+  peggy roles [flags]
+
+Examples:
+  peggy roles --config ~/.config/peggy/settings.json
+  peggy roles --json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy roles: positional args not supported")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy roles: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy roles: no settings.json found; using built-in defaults")
+	}
+	catalog, err := loadRoleCatalog(settings.Context.WorkDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy roles: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(catalog); err != nil {
+			fmt.Fprintf(stderr, "peggy roles: encode catalog: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeRoleCatalog(stdout, catalog)
+	return 0
+}
+
 func runSkill(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("peggy skill", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -314,6 +392,7 @@ func runSkill(ctx context.Context, args []string, stdin io.Reader, stdout, stder
 		configPath           = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
 		soulPath             = fs.String("soul", "", "path to identity Markdown (overrides $PEGGY_SOUL / XDG / ~/.config/peggy/SOUL.md)")
 		sessionID            = fs.String("session", "default", "session id (file-backed transcripts key off this)")
+		roleName             = fs.String("role", "", "workspace role name for this skill run")
 		enableCoding         = fs.Bool("coding", false, "enable local coding tools for this skill run")
 		codingWorkDir        = fs.String("workdir", "", "workspace root for --coding (default current directory)")
 		codingAllowOverwrite = fs.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
@@ -395,7 +474,8 @@ Flags:
 	}
 	defer p.Close()
 
-	if _, err := p.Skill(ctx, *sessionID, skillName, parsedArgs, stdout); err != nil {
+	promptOptions := promptOptionsForRole(*roleName)
+	if _, err := p.SkillWithOptions(ctx, *sessionID, skillName, parsedArgs, stdout, promptOptions...); err != nil {
 		fmt.Fprintf(stderr, "\npeggy skill: %v\n", err)
 		return 1
 	}
@@ -424,6 +504,28 @@ func loadSkillCatalog(workDir string) ([]skillCatalogEntry, error) {
 	return catalog, nil
 }
 
+func loadRoleCatalog(workDir string) ([]roleCatalogEntry, error) {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return nil, nil
+	}
+	ctx, err := glue.LoadContext(workDir)
+	if err != nil {
+		return nil, err
+	}
+	names := sortedMapKeys(ctx.Roles)
+	catalog := make([]roleCatalogEntry, 0, len(names))
+	for _, name := range names {
+		role := ctx.Roles[name]
+		catalog = append(catalog, roleCatalogEntry{
+			Name:        role.Name,
+			Description: role.Description,
+			Model:       role.Model,
+		})
+	}
+	return catalog, nil
+}
+
 func writeSkillCatalog(w io.Writer, catalog []skillCatalogEntry) {
 	if len(catalog) == 0 {
 		fmt.Fprintln(w, "No Peggy skills configured.")
@@ -436,6 +538,25 @@ func writeSkillCatalog(w io.Writer, catalog []skillCatalogEntry) {
 		fmt.Fprintln(w, entry.Name)
 		if entry.Description != "" {
 			fmt.Fprintf(w, "  description: %s\n", singleLine(entry.Description))
+		}
+	}
+}
+
+func writeRoleCatalog(w io.Writer, catalog []roleCatalogEntry) {
+	if len(catalog) == 0 {
+		fmt.Fprintln(w, "No Peggy roles configured.")
+		return
+	}
+	for i, entry := range catalog {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, entry.Name)
+		if entry.Description != "" {
+			fmt.Fprintf(w, "  description: %s\n", singleLine(entry.Description))
+		}
+		if entry.Model != "" {
+			fmt.Fprintf(w, "  model: %s\n", entry.Model)
 		}
 	}
 }

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -328,6 +328,72 @@ func TestRunSkillsJSON(t *testing.T) {
 	}
 }
 
+func TestRunRolesListsWorkspaceRoles(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	workDir := t.TempDir()
+	roleDir := filepath.Join(workDir, "roles")
+	if err := os.MkdirAll(roleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(roleDir, "reviewer.md"), []byte("---\nname: reviewer\ndescription: Reviews diffs\nmodel: role-model\n---\nReview carefully."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	raw, _ := json.MarshalIndent(map[string]any{
+		"context": map[string]any{"work_dir": workDir},
+	}, "", "  ")
+	_ = os.WriteFile(cfgPath, raw, 0o600)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"roles", "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	for _, want := range []string{"reviewer", "description: Reviews diffs", "model: role-model"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", out.String(), want)
+		}
+	}
+}
+
+func TestRunRolesJSON(t *testing.T) {
+	t.Setenv(EnvConfigPath, "")
+	t.Setenv(EnvSoulPath, "")
+	t.Setenv(XDGConfigEnv, t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	workDir := t.TempDir()
+	roleDir := filepath.Join(workDir, "roles")
+	if err := os.MkdirAll(roleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(roleDir, "reviewer.md"), []byte("---\nname: reviewer\nmodel: role-model\n---\nReview carefully."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "settings.json")
+	raw, _ := json.MarshalIndent(map[string]any{
+		"context": map[string]any{"work_dir": workDir},
+	}, "", "  ")
+	_ = os.WriteFile(cfgPath, raw, 0o600)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"roles", "--config", cfgPath, "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var catalog []roleCatalogEntry
+	if err := json.Unmarshal(out.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, out.String())
+	}
+	if len(catalog) != 1 || catalog[0].Name != "reviewer" || catalog[0].Model != "role-model" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}
+
 func TestRunSkillFlagsParse(t *testing.T) {
 	t.Setenv(EnvConfigPath, "")
 	t.Setenv(EnvSoulPath, "")

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -131,6 +131,10 @@ type daemonSkillCatalog struct {
 	Skills []daemon.SkillCatalogEntry `json:"skills"`
 }
 
+type daemonRoleCatalog struct {
+	Roles []daemon.RoleCatalogEntry `json:"roles"`
+}
+
 type daemonMCPResourceCatalog struct {
 	Resources []daemon.MCPResourceCatalogEntry `json:"resources"`
 }
@@ -160,6 +164,7 @@ type daemonInspect struct {
 	Status       daemonStatus                     `json:"status"`
 	Tools        []daemonToolCatalogEntry         `json:"tools"`
 	Skills       []daemon.SkillCatalogEntry       `json:"skills,omitempty"`
+	Roles        []daemon.RoleCatalogEntry        `json:"roles,omitempty"`
 	MCPResources []daemon.MCPResourceCatalogEntry `json:"mcp_resources,omitempty"`
 	MCPPrompts   []daemon.MCPPromptCatalogEntry   `json:"mcp_prompts,omitempty"`
 }
@@ -371,6 +376,8 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	toolsJSON := flags.Bool("tools-json", false, "print --tools output as JSON")
 	showSkills := flags.Bool("skills", false, "list daemon skills and exit without starting a run")
 	skillsJSON := flags.Bool("skills-json", false, "print --skills output as JSON")
+	showRoles := flags.Bool("roles", false, "list daemon roles and exit without starting a run")
+	rolesJSON := flags.Bool("roles-json", false, "print --roles output as JSON")
 	showMCPResources := flags.Bool("mcp-resources", false, "list daemon MCP resources and exit without starting a run")
 	mcpResourcesJSON := flags.Bool("mcp-resources-json", false, "print --mcp-resources output as JSON")
 	showMCPPrompts := flags.Bool("mcp-prompts", false, "list daemon MCP prompts and exit without starting a run")
@@ -400,6 +407,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *skillsJSON {
 		*showSkills = true
 	}
+	if *rolesJSON {
+		*showRoles = true
+	}
 	if *mcpResourcesJSON {
 		*showMCPResources = true
 	}
@@ -419,13 +429,13 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 		*showInspect = true
 	}
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showSkills, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --skills, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --status, or --inspect")
+		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" && strings.TrimSpace(*skillName) == "" {
 		return errors.New("missing required --prompt or --skill")
@@ -461,6 +471,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showSkills {
 		return runConnectSkills(ctx, cfg, *skillsJSON, stdout, client)
+	}
+	if *showRoles {
+		return runConnectRoles(ctx, cfg, *rolesJSON, stdout, client)
 	}
 	if *showMCPResources {
 		return runConnectMCPResources(ctx, cfg, *mcpResourcesJSON, stdout, client)
@@ -575,6 +588,20 @@ func runConnectSkills(ctx context.Context, cfg connectConfig, jsonOutput bool, s
 	return nil
 }
 
+func runConnectRoles(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	catalog, err := fetchDaemonRoles(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(catalog)
+	}
+	writeDaemonRoleCatalog(stdout, catalog.Roles)
+	return nil
+}
+
 func runConnectMCPResources(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
 	catalog, err := fetchDaemonMCPResources(ctx, cfg, client)
 	if err != nil {
@@ -678,6 +705,13 @@ func runConnectInspect(ctx context.Context, cfg connectConfig, jsonOutput bool, 
 		}
 		inspect.Skills = skills.Skills
 	}
+	if daemonHasCapability(status, "roles") {
+		roles, err := fetchDaemonRoles(ctx, cfg, client)
+		if err != nil {
+			return err
+		}
+		inspect.Roles = roles.Roles
+	}
 	if daemonHasCapability(status, "mcp_resources") {
 		resources, err := fetchDaemonMCPResources(ctx, cfg, client)
 		if err != nil {
@@ -746,6 +780,11 @@ func writeDaemonInspect(w io.Writer, inspect daemonInspect) {
 		fmt.Fprintln(w, "skills:")
 		writeDaemonSkillCatalogIndented(w, inspect.Skills, "  ")
 	}
+	if daemonHasCapability(inspect.Status, "roles") {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "roles:")
+		writeDaemonRoleCatalogIndented(w, inspect.Roles, "  ")
+	}
 	if daemonHasCapability(inspect.Status, "mcp_resources") {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "mcp_resources:")
@@ -802,6 +841,30 @@ func fetchDaemonSkills(ctx context.Context, cfg connectConfig, client httpDoer) 
 	}
 	if catalog.Skills == nil {
 		catalog.Skills = []daemon.SkillCatalogEntry{}
+	}
+	return catalog, nil
+}
+
+func fetchDaemonRoles(ctx context.Context, cfg connectConfig, client httpDoer) (daemonRoleCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/roles", nil)
+	if err != nil {
+		return daemonRoleCatalog{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonRoleCatalog{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonRoleCatalog{}, fmt.Errorf("daemon roles: %s", httpStatusError(resp))
+	}
+	var catalog daemonRoleCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		return daemonRoleCatalog{}, err
+	}
+	if catalog.Roles == nil {
+		catalog.Roles = []daemon.RoleCatalogEntry{}
 	}
 	return catalog, nil
 }
@@ -956,6 +1019,29 @@ func writeDaemonSkillCatalogIndented(w io.Writer, skills []daemon.SkillCatalogEn
 		fmt.Fprintf(w, "%s%s\n", indent, skill.Name)
 		if skill.Description != "" {
 			fmt.Fprintf(w, "%s  description: %s\n", indent, oneLine(skill.Description))
+		}
+	}
+}
+
+func writeDaemonRoleCatalog(w io.Writer, roles []daemon.RoleCatalogEntry) {
+	writeDaemonRoleCatalogIndented(w, roles, "")
+}
+
+func writeDaemonRoleCatalogIndented(w io.Writer, roles []daemon.RoleCatalogEntry, indent string) {
+	if len(roles) == 0 {
+		fmt.Fprintf(w, "%sNo daemon roles reported.\n", indent)
+		return
+	}
+	for i, role := range roles {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s%s\n", indent, role.Name)
+		if role.Description != "" {
+			fmt.Fprintf(w, "%s  description: %s\n", indent, oneLine(role.Description))
+		}
+		if role.Model != "" {
+			fmt.Fprintf(w, "%s  model: %s\n", indent, role.Model)
 		}
 	}
 }
@@ -1487,6 +1573,7 @@ func printUsage(w io.Writer) {
   glue connect --status [--status-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --tools [--tools-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --skills [--skills-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --roles [--roles-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-resources [--mcp-resources-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-prompts [--mcp-prompts-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-read --server <name> --uri <uri> [--mcp-read-json] [--metadata <path>] [--base-url <url>] [--token <token>]
@@ -1495,7 +1582,7 @@ func printUsage(w io.Writer) {
 Commands:
   run      Run the local Gemini-backed agent.
   serve    Start a local HTTP+SSE daemon for Glue sessions.
-  connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/MCP catalogs.
+  connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP catalogs.
 
 Flags:
   --id       Session id. Defaults to "default".
@@ -1523,6 +1610,9 @@ Flags:
   --skills   Connect mode: list daemon skills and exit without starting a run.
   --skills-json
              Connect --skills mode: print JSON.
+  --roles    Connect mode: list daemon roles and exit without starting a run.
+  --roles-json
+             Connect --roles mode: print JSON.
   --mcp-resources
              Connect mode: list daemon MCP resources and exit without starting a run.
   --mcp-resources-json

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -871,6 +871,81 @@ func TestRunCLIConnectListsSkillsJSON(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectListsRoles(t *testing.T) {
+	var sawRoles bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/roles":
+			sawRoles = true
+			writeJSONResponse(t, w, http.StatusOK, daemonRoleCatalog{Roles: []daemon.RoleCatalogEntry{{
+				Name:        "reviewer",
+				Description: "Reviews diffs",
+				Model:       "fast-model",
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--roles",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawRoles || sawRun {
+		t.Fatalf("sawRoles=%v sawRun=%v", sawRoles, sawRun)
+	}
+	for _, want := range []string{"reviewer", "description: Reviews diffs", "model: fast-model"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectListsRolesJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/roles" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemonRoleCatalog{Roles: []daemon.RoleCatalogEntry{{
+			Name:  "reviewer",
+			Model: "fast-model",
+		}}})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--roles-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var catalog daemonRoleCatalog
+	if err := json.Unmarshal(stdout.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if len(catalog.Roles) != 1 || catalog.Roles[0].Name != "reviewer" || catalog.Roles[0].Model != "fast-model" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}
+
 func TestRunCLIConnectRunsSkill(t *testing.T) {
 	var payload startRunPayload
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1527,6 +1602,7 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 
 func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 	var sawSkills bool
+	var sawRoles bool
 	var sawResources bool
 	var sawPrompts bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1535,7 +1611,7 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
 				OK:           true,
 				Version:      1,
-				Capabilities: []string{"status", "tools", "skills", "mcp_resources", "mcp_prompts"},
+				Capabilities: []string{"status", "tools", "skills", "roles", "mcp_resources", "mcp_prompts"},
 			})
 		case "/v1/tools":
 			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{})
@@ -1544,6 +1620,12 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemonSkillCatalog{Skills: []daemon.SkillCatalogEntry{{
 				Name:        "triage",
 				Description: "Triage one issue",
+			}}})
+		case "/v1/roles":
+			sawRoles = true
+			writeJSONResponse(t, w, http.StatusOK, daemonRoleCatalog{Roles: []daemon.RoleCatalogEntry{{
+				Name:  "reviewer",
+				Model: "fast-model",
 			}}})
 		case "/v1/mcp/resources":
 			sawResources = true
@@ -1575,12 +1657,15 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%q", code, stderr.String())
 	}
-	if !sawSkills || !sawResources || !sawPrompts {
-		t.Fatalf("sawSkills=%v sawResources=%v sawPrompts=%v", sawSkills, sawResources, sawPrompts)
+	if !sawSkills || !sawRoles || !sawResources || !sawPrompts {
+		t.Fatalf("sawSkills=%v sawRoles=%v sawResources=%v sawPrompts=%v", sawSkills, sawRoles, sawResources, sawPrompts)
 	}
 	for _, want := range []string{
 		"skills:",
 		"triage",
+		"roles:",
+		"reviewer",
+		"model: fast-model",
 		"mcp_resources:",
 		"file:///workspace/README.md",
 		"mcp_prompts:",

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -40,6 +40,12 @@ type SkillCatalogHost interface {
 	SkillCatalog(context.Context) ([]SkillCatalogEntry, error)
 }
 
+// RoleCatalogHost is optionally implemented by hosts that can expose
+// reusable roles without starting a run.
+type RoleCatalogHost interface {
+	RoleCatalog(context.Context) ([]RoleCatalogEntry, error)
+}
+
 // MCPResourceCatalogHost is optionally implemented by hosts that can expose
 // MCP resource metadata without starting a run.
 type MCPResourceCatalogHost interface {
@@ -68,6 +74,13 @@ type MCPPromptRendererHost interface {
 type SkillCatalogEntry struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+}
+
+// RoleCatalogEntry describes one reusable role advertised by a host.
+type RoleCatalogEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Model       string `json:"model,omitempty"`
 }
 
 // MCPResourceCatalogEntry describes one MCP resource advertised by a host.
@@ -304,6 +317,10 @@ type skillCatalogResponse struct {
 	Skills []SkillCatalogEntry `json:"skills"`
 }
 
+type roleCatalogResponse struct {
+	Roles []RoleCatalogEntry `json:"roles"`
+}
+
 type mcpResourceCatalogResponse struct {
 	Resources []MCPResourceCatalogEntry `json:"resources"`
 }
@@ -395,6 +412,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleSkills(w, r)
+		return
+	}
+
+	if r.URL.Path == "/v1/roles" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleRoles(w, r)
 		return
 	}
 
@@ -506,6 +532,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	if _, ok := s.host.(SkillCatalogHost); ok {
 		capabilities = append(capabilities, "skills")
 	}
+	if _, ok := s.host.(RoleCatalogHost); ok {
+		capabilities = append(capabilities, "roles")
+	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:           true,
 		Version:      protocolVersion,
@@ -587,6 +616,23 @@ func (s *Server) handleSkills(w http.ResponseWriter, r *http.Request) {
 		skills = []SkillCatalogEntry{}
 	}
 	writeJSON(w, http.StatusOK, skillCatalogResponse{Skills: skills})
+}
+
+func (s *Server) handleRoles(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.host.(RoleCatalogHost)
+	if !ok {
+		writeJSON(w, http.StatusOK, roleCatalogResponse{Roles: []RoleCatalogEntry{}})
+		return
+	}
+	roles, err := host.RoleCatalog(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if roles == nil {
+		roles = []RoleCatalogEntry{}
+	}
+	writeJSON(w, http.StatusOK, roleCatalogResponse{Roles: roles})
 }
 
 func (s *Server) handleMCPResources(w http.ResponseWriter, r *http.Request) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -109,6 +109,18 @@ func (h skillCatalogHost) SkillCatalog(context.Context) ([]SkillCatalogEntry, er
 	return h.skills, nil
 }
 
+type roleCatalogHost struct {
+	roles []RoleCatalogEntry
+}
+
+func (roleCatalogHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
+func (h roleCatalogHost) RoleCatalog(context.Context) ([]RoleCatalogEntry, error) {
+	return h.roles, nil
+}
+
 type mcpCatalogHost struct {
 	resources []MCPResourceCatalogEntry
 	prompts   []MCPPromptCatalogEntry
@@ -314,6 +326,64 @@ func TestServerSkillsCatalogUnsupportedHost(t *testing.T) {
 	}
 	if len(catalog.Skills) != 0 {
 		t.Fatalf("catalog = %+v, want empty", catalog.Skills)
+	}
+}
+
+func TestServerRolesCatalog(t *testing.T) {
+	srv := newTestServer(t, roleCatalogHost{roles: []RoleCatalogEntry{{
+		Name:        "reviewer",
+		Description: "Reviews diffs",
+		Model:       "fast-model",
+	}}})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/roles", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/roles", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("roles status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var catalog roleCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Roles) != 1 || catalog.Roles[0].Name != "reviewer" || catalog.Roles[0].Model != "fast-model" {
+		t.Fatalf("catalog = %+v", catalog.Roles)
+	}
+
+	var status statusResponse
+	resp = getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(status.Capabilities, "roles") {
+		t.Fatalf("capabilities = %v, missing roles", status.Capabilities)
+	}
+}
+
+func TestServerRolesCatalogUnsupportedHost(t *testing.T) {
+	srv := newTestServer(t, sessionOnlyHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/roles", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("roles status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var catalog roleCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Roles) != 0 {
+		t.Fatalf("catalog = %+v, want empty", catalog.Roles)
 	}
 }
 

--- a/docs/adr/0010-daemon-protocol.md
+++ b/docs/adr/0010-daemon-protocol.md
@@ -145,7 +145,7 @@ Response:
   "version": 1,
   "active_runs": 0,
   "tools_count": 4,
-  "capabilities": ["runs", "events", "permissions", "tools", "skills", "status"]
+  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "status"]
 }
 ```
 
@@ -201,6 +201,31 @@ Response:
 Hosts that do not expose a skill catalog return an empty `skills`
 array. A host that does expose a catalog advertises the `skills`
 capability in `/v1/status`.
+
+Daemon clients can inspect reusable host roles:
+
+```http
+GET /v1/roles
+```
+
+Response:
+
+```json
+{
+  "roles": [
+    {
+      "name": "reviewer",
+      "description": "Review diffs carefully",
+      "model": "gpt-5-codex"
+    }
+  ]
+}
+```
+
+Hosts that do not expose a role catalog return an empty `roles` array.
+A host that exposes a catalog advertises the `roles` capability in
+`/v1/status`. Runs apply roles through the existing `role` field on
+the run-start request.
 
 ### 5. Runs and sessions
 


### PR DESCRIPTION
## Summary

- add daemon role catalog support via authenticated `GET /v1/roles` and status capability advertising
- add `glue connect --roles`, `--roles-json`, and inspect role sections while preserving existing `--role` run selection
- add Peggy local `peggy roles` / `--json`, `peggy --role`, and `peggy skill --role`
- wire Peggy daemon role catalogs from `context.work_dir`
- document workspace role files and daemon role inspection

Closes #222.

## Validation

- `go test ./daemon ./cmd/glue ./agents/peggy -run 'TestServerRoles|TestRunCLIConnectListsRoles|TestRunCLIConnectInspectIncludesMCPCatalogs|TestPeggy_PromptWithOptionsUsesWorkspaceRole|TestRunRoles|TestPeggyDaemonListsWorkspaceRoles' -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`