### PR TITLE
cmd/glue: add priced usage summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,10 @@ go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
 - `--model` — model id or `gemini/<model>` (default `gemini-2.5-flash`).
 - `--store` — file session store directory (default `.glue/sessions`).
 - `--usage` — print provider-reported token usage to stderr when available.
+- `--usage-input-price`, `--usage-output-price`,
+  `--usage-cache-read-price`, `--usage-cache-write-price` — optional
+  USD-per-1M-token prices used to append `cost_usd=...` to `--usage`
+  output. Glue does not ship provider price tables.
 - `--env` — `.env` file to load before reading `GEMINI_API_KEY`. Repeatable;
   shell environment wins on conflict.
 
@@ -647,7 +651,8 @@ Peggy daemons also support `--mcp-read` and `--mcp-prompt` for direct
 resource reads and prompt rendering. Each inspect/action mode also has a
 `-json` form for scripts. Add `--usage` to `run` or prompt-mode
 `connect` to print provider-reported token usage on stderr without
-changing streamed stdout.
+changing streamed stdout. Add the `--usage-*-price` flags when you
+want a local USD estimate from prices you supply.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -40,6 +40,9 @@ not formally follow SemVer until v1.0.
   creates a safe starter `AGENTS.md`, reviewer/operator roles, and
   triage/daily-plan/implementation-plan skills. Existing files are
   skipped unless `--force` is explicit.
+- **Priced usage estimates.** `glue run --usage` and prompt-mode
+  `glue connect --usage` can append `cost_usd=...` when users supply
+  USD-per-1M-token price flags for input, output, and cache tokens.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -325,8 +325,10 @@ daemon-advertised MCP resource/prompt catalogs. Use `--skills-json`,
 `--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
 `--mcp-read-json`, or `--mcp-prompt-json` when another client needs the
 payload as data. Add `--usage` to prompt or skill-mode `glue connect`
-when you want provider-reported token usage on stderr. Stop the daemon
-with SIGINT/SIGTERM.
+when you want provider-reported token usage on stderr. Add
+`--usage-input-price`, `--usage-output-price`, and optional cache price
+flags to estimate USD cost from prices you supply. Stop the daemon with
+SIGINT/SIGTERM.
 
 Telegram can attach to the same daemon:
 
@@ -652,8 +654,7 @@ priority order:
 - **M5 — file skills and workspace context.** Make Peggy a richer
   operator over glue project context: file-backed skills, role-aware
   runs, and daemon/client discovery for reusable workflows.
-- **Later ecosystem polish.** Cost tracking and
-  `providers/anthropic` when budget allows.
+- **Later ecosystem polish.** `providers/anthropic` when budget allows.
 
 Near-term follow-ups that may ship as patches: a `peggy memories`
 subcommand (list / export / forget), edit-in-place Telegram

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -123,6 +123,14 @@ type usageSummary struct {
 	TotalTokens      int64
 }
 
+type usagePricing struct {
+	Enabled                 bool
+	InputUSDPerMillion      float64
+	OutputUSDPerMillion     float64
+	CacheReadUSDPerMillion  float64
+	CacheWriteUSDPerMillion float64
+}
+
 type daemonToolCatalog struct {
 	Tools []daemonToolCatalogEntry `json:"tools"`
 }
@@ -243,10 +251,15 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 	model := flags.String("model", defaultModel, "model id or gemini/<model>")
 	storeDir := flags.String("store", ".glue/sessions", "session store directory")
 	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
+	usagePricing := registerUsagePricingFlags(flags)
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
 
 	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	markUsagePricingFlagState(flags, usagePricing)
+	if err := validateUsagePricing(*usagePricing); err != nil {
 		return err
 	}
 
@@ -292,7 +305,7 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 		fmt.Fprintln(stdout, response.Text)
 	}
 	if *showUsage {
-		writeUsageSummary(stderr, summarizeUsage(response.NewMessages))
+		writeUsageSummary(stderr, summarizeUsage(response.NewMessages), *usagePricing)
 	}
 	return nil
 }
@@ -372,6 +385,7 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	role := flags.String("role", "", "per-run role override")
 	maxTurns := flags.Int("max-turns", 0, "per-run loop turn budget")
 	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
+	usagePricing := registerUsagePricingFlags(flags)
 	showTools := flags.Bool("tools", false, "list daemon tools and exit without starting a run")
 	toolsJSON := flags.Bool("tools-json", false, "print --tools output as JSON")
 	showSkills := flags.Bool("skills", false, "list daemon skills and exit without starting a run")
@@ -399,6 +413,10 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	flags.Var(&runArgs, "arg", "skill or MCP prompt argument key=value; repeatable")
 
 	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	markUsagePricingFlagState(flags, usagePricing)
+	if err := validateUsagePricing(*usagePricing); err != nil {
 		return err
 	}
 	if *toolsJSON {
@@ -493,7 +511,7 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *showInspect {
 		return runConnectInspect(ctx, cfg, *inspectJSON, stdout, client)
 	}
-	return runConnect(ctx, cfg, *showUsage, stdin, stdout, stderr, client)
+	return runConnect(ctx, cfg, *showUsage, *usagePricing, stdin, stdout, stderr, client)
 }
 
 func resolveConnectConfig(cfg connectConfig) (connectConfig, error) {
@@ -543,7 +561,7 @@ func resolveConnectConfig(cfg connectConfig) (connectConfig, error) {
 	return cfg, nil
 }
 
-func runConnect(ctx context.Context, cfg connectConfig, showUsage bool, stdin io.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
+func runConnect(ctx context.Context, cfg connectConfig, showUsage bool, pricing usagePricing, stdin io.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
 	start, err := startDaemonRun(ctx, cfg, client)
 	if err != nil {
 		return err
@@ -557,7 +575,7 @@ func runConnect(ctx context.Context, cfg connectConfig, showUsage bool, stdin io
 		case <-done:
 		}
 	}()
-	return streamDaemonRun(ctx, cfg, start, showUsage, bufio.NewReader(stdin), stdout, stderr, client)
+	return streamDaemonRun(ctx, cfg, start, showUsage, pricing, bufio.NewReader(stdin), stdout, stderr, client)
 }
 
 func runConnectTools(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
@@ -1267,7 +1285,7 @@ func startDaemonRun(ctx context.Context, cfg connectConfig, client httpDoer) (st
 	return out, nil
 }
 
-func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResult, showUsage bool, input *bufio.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
+func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResult, showUsage bool, pricing usagePricing, input *bufio.Reader, stdout io.Writer, stderr io.Writer, client httpDoer) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+start.EventsURL, nil)
 	if err != nil {
 		return err
@@ -1340,7 +1358,7 @@ func streamDaemonRun(ctx context.Context, cfg connectConfig, start startRunResul
 				if len(messages) == 0 && done.Message != nil {
 					messages = []glue.Message{*done.Message}
 				}
-				writeUsageSummary(stderr, summarizeUsage(messages))
+				writeUsageSummary(stderr, summarizeUsage(messages), pricing)
 			}
 			return nil
 		case "run_error":
@@ -1380,7 +1398,51 @@ func summarizeUsage(messages []glue.Message) usageSummary {
 	return summary
 }
 
-func writeUsageSummary(w io.Writer, summary usageSummary) {
+func registerUsagePricingFlags(flags *flag.FlagSet) *usagePricing {
+	var pricing usagePricing
+	flags.Float64Var(&pricing.InputUSDPerMillion, "usage-input-price", 0, "USD per 1M input tokens for --usage cost estimates")
+	flags.Float64Var(&pricing.OutputUSDPerMillion, "usage-output-price", 0, "USD per 1M output tokens for --usage cost estimates")
+	flags.Float64Var(&pricing.CacheReadUSDPerMillion, "usage-cache-read-price", 0, "USD per 1M cache-read tokens for --usage cost estimates")
+	flags.Float64Var(&pricing.CacheWriteUSDPerMillion, "usage-cache-write-price", 0, "USD per 1M cache-write tokens for --usage cost estimates")
+	return &pricing
+}
+
+func markUsagePricingFlagState(flags *flag.FlagSet, pricing *usagePricing) {
+	flags.Visit(func(flag *flag.Flag) {
+		switch flag.Name {
+		case "usage-input-price", "usage-output-price", "usage-cache-read-price", "usage-cache-write-price":
+			pricing.Enabled = true
+		}
+	})
+}
+
+func validateUsagePricing(pricing usagePricing) error {
+	for name, value := range map[string]float64{
+		"--usage-input-price":       pricing.InputUSDPerMillion,
+		"--usage-output-price":      pricing.OutputUSDPerMillion,
+		"--usage-cache-read-price":  pricing.CacheReadUSDPerMillion,
+		"--usage-cache-write-price": pricing.CacheWriteUSDPerMillion,
+	} {
+		if value < 0 {
+			return fmt.Errorf("%s must be non-negative", name)
+		}
+	}
+	return nil
+}
+
+func usagePricingEnabled(pricing usagePricing) bool {
+	return pricing.Enabled
+}
+
+func estimateUsageCostUSD(summary usageSummary, pricing usagePricing) float64 {
+	const tokensPerMillion = 1_000_000
+	return (float64(summary.InputTokens)*pricing.InputUSDPerMillion +
+		float64(summary.OutputTokens)*pricing.OutputUSDPerMillion +
+		float64(summary.CacheReadTokens)*pricing.CacheReadUSDPerMillion +
+		float64(summary.CacheWriteTokens)*pricing.CacheWriteUSDPerMillion) / tokensPerMillion
+}
+
+func writeUsageSummary(w io.Writer, summary usageSummary, pricing usagePricing) {
 	if !summary.HasUsage {
 		return
 	}
@@ -1395,6 +1457,9 @@ func writeUsageSummary(w io.Writer, summary usageSummary) {
 		parts = append(parts, fmt.Sprintf("cache_write=%d", summary.CacheWriteTokens))
 	}
 	parts = append(parts, fmt.Sprintf("total=%d", summary.TotalTokens))
+	if usagePricingEnabled(pricing) {
+		parts = append(parts, fmt.Sprintf("cost_usd=%.6f", estimateUsageCostUSD(summary, pricing)))
+	}
 	fmt.Fprintf(w, "usage: %s\n", strings.Join(parts, " "))
 }
 

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -179,6 +179,42 @@ func TestRunCLIUsageReportsTokens(t *testing.T) {
 	}
 }
 
+func TestRunCLIUsageReportsEstimatedCost(t *testing.T) {
+	t.Parallel()
+
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: "hello"},
+		{Type: glue.ProviderEventDone, Message: &glue.Message{
+			Role: glue.MessageRoleAssistant,
+			Usage: &glue.Usage{
+				InputTokens:      1_000_000,
+				OutputTokens:     500_000,
+				CacheReadTokens:  250_000,
+				CacheWriteTokens: 100_000,
+				TotalTokens:      1_850_000,
+			},
+		}},
+	}}}
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run",
+		"--prompt", "say hi",
+		"--store", t.TempDir(),
+		"--usage",
+		"--usage-input-price", "1",
+		"--usage-output-price", "2",
+		"--usage-cache-read-price", "0.25",
+		"--usage-cache-write-price", "3",
+	}, &stdout, &stderr, fakeFactory(provider))
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if got, want := stderr.String(), "usage: input=1000000 output=500000 cache_read=250000 cache_write=100000 total=1850000 cost_usd=2.362500\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
 func TestRunCLIUsageSilentWhenMissing(t *testing.T) {
 	t.Parallel()
 
@@ -189,6 +225,7 @@ func TestRunCLIUsageSilentWhenMissing(t *testing.T) {
 		"--prompt", "go",
 		"--store", t.TempDir(),
 		"--usage",
+		"--usage-input-price", "1",
 	}, &stdout, &stderr, fakeFactory(provider))
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%q", code, stderr.String())
@@ -198,6 +235,24 @@ func TestRunCLIUsageSilentWhenMissing(t *testing.T) {
 	}
 	if stderr.String() != "" {
 		t.Fatalf("stderr = %q, want no usage output", stderr.String())
+	}
+}
+
+func TestRunCLIUsagePriceRejectsNegative(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run",
+		"--prompt", "go",
+		"--usage",
+		"--usage-input-price", "-1",
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}))
+	if code == 0 {
+		t.Fatal("code = 0, want failure")
+	}
+	if !strings.Contains(stderr.String(), "--usage-input-price must be non-negative") {
+		t.Fatalf("stderr = %q", stderr.String())
 	}
 }
 
@@ -667,6 +722,61 @@ func TestRunCLIConnectUsageReportsTokens(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectUsageReportsEstimatedCost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/default/runs":
+			writeJSONResponse(t, w, http.StatusCreated, startRunResult{RunID: "run_1", SessionID: "default", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			writeSSETest(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "done"}})
+			writeSSETest(t, w, daemon.EventEnvelope{Type: "run_done", Payload: connectRunDonePayload{
+				NewMessages: []glue.Message{
+					{
+						Role: glue.MessageRoleAssistant,
+						Usage: &glue.Usage{
+							InputTokens:  1_000_000,
+							OutputTokens: 500_000,
+							TotalTokens:  1_500_000,
+						},
+					},
+					{
+						Role: glue.MessageRoleAssistant,
+						Usage: &glue.Usage{
+							CacheReadTokens:  250_000,
+							CacheWriteTokens: 100_000,
+							TotalTokens:      350_000,
+						},
+					},
+				},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--prompt", "hello",
+		"--usage",
+		"--usage-input-price", "1",
+		"--usage-output-price", "2",
+		"--usage-cache-read-price", "0.25",
+		"--usage-cache-write-price", "3",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if got, want := stderr.String(), "usage: input=1000000 output=500000 cache_read=250000 cache_write=100000 total=1850000 cost_usd=2.362500\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
 func TestRunCLIConnectUsageSilentWhenMissing(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -686,6 +796,7 @@ func TestRunCLIConnectUsageSilentWhenMissing(t *testing.T) {
 		"connect",
 		"--prompt", "hello",
 		"--usage",
+		"--usage-input-price", "1",
 		"--base-url", ts.URL,
 		"--token", "tok",
 		"--metadata", "",


### PR DESCRIPTION
## Summary

- add optional USD-per-1M-token price flags for `glue run --usage` and prompt-mode `glue connect --usage`
- append deterministic `cost_usd=...` estimates only when pricing flags are supplied and provider usage exists
- keep existing usage output unchanged when no pricing is supplied
- document the local-pricing behavior in the root and Peggy READMEs/changelog

Closes #226.

## Validation

- `go test ./cmd/glue -run 'TestRunCLIUsage|TestRunCLIConnectUsage' -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
