### PR TITLE
agents/peggy: add memories command

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -43,6 +43,9 @@ not formally follow SemVer until v1.0.
 - **Priced usage estimates.** `glue run --usage` and prompt-mode
   `glue connect --usage` can append `cost_usd=...` when users supply
   USD-per-1M-token price flags for input, output, and cache tokens.
+- **Memory inspection.** `peggy memories` lists curated memories from
+  the configured store without starting a provider, and `--json`
+  exports the same list for scripts or backups.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -162,6 +162,7 @@ peggy init [flags]
 peggy skill [flags] <name>
 peggy skills [flags]
 peggy roles [flags]
+peggy memories [flags]
 peggy mcp prompt [flags]
 peggy mcp prompts [flags]
 peggy mcp read [flags]
@@ -594,8 +595,16 @@ for _, m := range mems {
 }
 ```
 
-A `peggy memories` subcommand for list / forget / export is a
-near-term follow-up.
+Inspect curated memories from the terminal without starting a provider:
+
+```sh
+peggy memories --config ~/.config/peggy/settings.json
+peggy memories --config ~/.config/peggy/settings.json --json
+peggy memories --config ~/.config/peggy/settings.json --limit 20
+```
+
+Memory forgetting remains a near-term follow-up; this command is
+intentionally read-only.
 
 ## What Peggy supports today
 
@@ -656,9 +665,9 @@ priority order:
   runs, and daemon/client discovery for reusable workflows.
 - **Later ecosystem polish.** `providers/anthropic` when budget allows.
 
-Near-term follow-ups that may ship as patches: a `peggy memories`
-subcommand (list / export / forget), edit-in-place Telegram
-streaming, FTS5 prefix-match on session ids for channel-scoped recall.
+Near-term follow-ups that may ship as patches: `peggy memories forget`,
+edit-in-place Telegram streaming, FTS5 prefix-match on session ids for
+channel-scoped recall.
 
 ## As a library
 

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -132,6 +132,8 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 			return runSkills(args[1:], stdout, stderr)
 		case "roles":
 			return runRoles(args[1:], stdout, stderr)
+		case "memories":
+			return runMemories(ctx, args[1:], stdout, stderr)
 		case "status":
 			return runStatus(args[1:], stdout, stderr)
 		case "mcp":
@@ -160,6 +162,7 @@ Usage:
   peggy skill [flags] <name>
   peggy skills [flags]
   peggy roles [flags]
+  peggy memories [flags]
   peggy status [flags]
   peggy mcp [command]
   peggy serve [flags]
@@ -172,6 +175,7 @@ Examples:
   peggy init --workdir .
   peggy skills --config ~/.config/peggy/settings.json
   peggy roles --config ~/.config/peggy/settings.json
+  peggy memories --config ~/.config/peggy/settings.json
   peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
   peggy status --config ~/.config/peggy/settings.json
   peggy mcp tools --config ~/.config/peggy/settings.json
@@ -677,6 +681,104 @@ func writeRoleCatalog(w io.Writer, catalog []roleCatalogEntry) {
 		}
 		if entry.Model != "" {
 			fmt.Fprintf(w, "  model: %s\n", entry.Model)
+		}
+	}
+}
+
+func runMemories(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy memories", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+		limit      = fs.Int("limit", 0, "maximum memories to return; 0 means no limit")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy memories - list curated memories from Peggy's store.
+
+Usage:
+  peggy memories [flags]
+
+Examples:
+  peggy memories --config ~/.config/peggy/settings.json
+  peggy memories --config ~/.config/peggy/settings.json --json
+  peggy memories --limit 20
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy memories: positional args not supported")
+		return 2
+	}
+	if *limit < 0 {
+		fmt.Fprintln(stderr, "peggy memories: --limit must be non-negative")
+		return 2
+	}
+
+	settings, settingsPath, err := LoadSettings(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories: %v\n", err)
+		return 1
+	}
+	if settingsPath == "" {
+		fmt.Fprintln(stderr, "peggy memories: no settings.json found; using built-in defaults")
+	}
+	store, err := buildStore(settings)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories: store: %v\n", err)
+		return 1
+	}
+	if closer, ok := store.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	p := &Peggy{store: store}
+	memories, err := p.ListMemories(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories: %v\n", err)
+		return 1
+	}
+	if *limit > 0 && len(memories) > *limit {
+		memories = memories[:*limit]
+	}
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(memories); err != nil {
+			fmt.Fprintf(stderr, "peggy memories: encode memories: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeMemories(stdout, memories)
+	return 0
+}
+
+func writeMemories(w io.Writer, memories []Memory) {
+	if len(memories) == 0 {
+		fmt.Fprintln(w, "No memories recorded.")
+		return
+	}
+	for i, memory := range memories {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		timestamp := "unknown"
+		if !memory.Timestamp.IsZero() {
+			timestamp = memory.Timestamp.Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%s\n", timestamp)
+		fmt.Fprintf(w, "  content: %s\n", singleLine(memory.Content))
+		if len(memory.Tags) > 0 {
+			fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
 		}
 	}
 }

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	filestore "github.com/erain/glue/stores/file"
 	toolsmcp "github.com/erain/glue/tools/mcp"
 )
 
@@ -377,6 +378,115 @@ func TestRunInitSkipsExistingAndForceOverwrites(t *testing.T) {
 	if !strings.Contains(out.String(), "wrote AGENTS.md") {
 		t.Fatalf("force stdout = %q", out.String())
 	}
+}
+
+func TestRunMemoriesListsWithoutProvider(t *testing.T) {
+	storePath := seedRunnerMemories(t)
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": storePath,
+		},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	for _, want := range []string{"content: User prefers terse responses.", "tags: preference"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", out.String(), want)
+		}
+	}
+}
+
+func TestRunMemoriesJSONAndLimit(t *testing.T) {
+	storePath := seedRunnerMemories(t)
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": storePath,
+		},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "--config", cfgPath, "--json", "--limit", "1"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var memories []Memory
+	if err := json.Unmarshal(out.Bytes(), &memories); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, out.String())
+	}
+	if len(memories) != 1 {
+		t.Fatalf("memories = %+v, want one result", memories)
+	}
+}
+
+func TestRunMemoriesEmpty(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": filepath.Join(t.TempDir(), "sessions"),
+		},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if got, want := out.String(), "No memories recorded.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = Run(context.Background(), []string{"memories", "--config", cfgPath, "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("json exit = %d stderr=%q", code, errOut.String())
+	}
+	if got, want := strings.TrimSpace(out.String()), "[]"; got != want {
+		t.Fatalf("json stdout = %q, want %q", out.String(), want)
+	}
+}
+
+func TestRunMemoriesRejectsNegativeLimit(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "--limit", "-1"}, &out, &errOut)
+	if code != 2 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "--limit must be non-negative") {
+		t.Fatalf("stderr = %q", errOut.String())
+	}
+}
+
+func seedRunnerMemories(t *testing.T) string {
+	t.Helper()
+	storePath := filepath.Join(t.TempDir(), "sessions")
+	p, err := New(Options{
+		Settings: Settings{},
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(storePath),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := p.AddMemory(context.Background(), "User's Aussie is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := p.AddMemory(context.Background(), "User prefers terse responses.", []string{"preference"}); err != nil {
+		t.Fatalf("AddMemory 2: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return storePath
 }
 
 func TestRunSkillsListsWorkspaceSkills(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `peggy memories` to list curated memory records from the configured store without constructing a provider
- support `--json` export and `--limit` for scripts/backups
- keep empty stores explicit in human output and `[]` in JSON output
- document the read-only memory inspection path and leave destructive forgetting as a follow-up

Closes #228.

## Validation

- `go test ./agents/peggy -run 'TestRunMemories|TestAddMemory|TestMemoryTools' -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
