### PR TITLE
agents/peggy: add memory forget command

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -46,6 +46,10 @@ not formally follow SemVer until v1.0.
 - **Memory inspection.** `peggy memories` lists curated memories from
   the configured store without starting a provider, and `--json`
   exports the same list for scripts or backups.
+- **Memory forgetting.** Curated memories now have stable IDs, and
+  `peggy memories forget <id>` removes one memory from the dedicated
+  `__memories__` session without touching ordinary conversation
+  history.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -601,10 +601,12 @@ Inspect curated memories from the terminal without starting a provider:
 peggy memories --config ~/.config/peggy/settings.json
 peggy memories --config ~/.config/peggy/settings.json --json
 peggy memories --config ~/.config/peggy/settings.json --limit 20
+peggy memories forget --config ~/.config/peggy/settings.json mem_123
 ```
 
-Memory forgetting remains a near-term follow-up; this command is
-intentionally read-only.
+Each memory has a stable `id` in human and JSON output. `forget` only
+removes curated `remember` records from the dedicated memory session; it
+does not delete ordinary conversation history.
 
 ## What Peggy supports today
 
@@ -665,9 +667,8 @@ priority order:
   runs, and daemon/client discovery for reusable workflows.
 - **Later ecosystem polish.** `providers/anthropic` when budget allows.
 
-Near-term follow-ups that may ship as patches: `peggy memories forget`,
-edit-in-place Telegram streaming, FTS5 prefix-match on session ids for
-channel-scoped recall.
+Near-term follow-ups that may ship as patches: edit-in-place Telegram
+streaming, FTS5 prefix-match on session ids for channel-scoped recall.
 
 ## As a library
 

--- a/agents/peggy/memory.go
+++ b/agents/peggy/memory.go
@@ -2,6 +2,8 @@ package peggy
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +43,7 @@ You have two tools for durable memory:
 
 // Memory is a single curated memory record.
 type Memory struct {
+	ID        string    `json:"id"`
 	Content   string    `json:"content"`
 	Tags      []string  `json:"tags,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
@@ -48,8 +51,8 @@ type Memory struct {
 
 // RecallOptions configures a Recall call.
 type RecallOptions struct {
-	Limit         int
-	OnlyMemories  bool
+	Limit        int
+	OnlyMemories bool
 }
 
 // RecallOption is a functional option for Peggy.Recall.
@@ -104,10 +107,12 @@ func (p *Peggy) AddMemory(ctx context.Context, content string, tags []string) (M
 		state.CreatedAt = now
 	}
 	tagsCopy := append([]string(nil), tags...)
+	id := memoryID(now, content)
 	state.Messages = append(state.Messages, glue.Message{
 		Role:    glue.MessageRoleAssistant,
 		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: content}},
 		Metadata: map[string]any{
+			"id":     id,
 			"memory": true,
 			"tags":   tagsCopy,
 		},
@@ -117,7 +122,7 @@ func (p *Peggy) AddMemory(ctx context.Context, content string, tags []string) (M
 	if err := p.store.Save(ctx, MemoriesSessionID, state); err != nil {
 		return Memory{}, fmt.Errorf("peggy: save memories: %w", err)
 	}
-	return Memory{Content: content, Tags: tagsCopy, Timestamp: now}, nil
+	return Memory{ID: id, Content: content, Tags: tagsCopy, Timestamp: now}, nil
 }
 
 // ListMemories returns the curated memory list, newest first. Useful
@@ -132,29 +137,9 @@ func (p *Peggy) ListMemories(ctx context.Context) ([]Memory, error) {
 	}
 	out := make([]Memory, 0, len(state.Messages))
 	for _, m := range state.Messages {
-		if m.Role != glue.MessageRoleAssistant {
+		mem, ok := memoryFromMessage(m)
+		if !ok {
 			continue
-		}
-		mem := Memory{Timestamp: m.CreatedAt}
-		for _, p := range m.Content {
-			if p.Type == glue.ContentTypeText {
-				if mem.Content != "" {
-					mem.Content += "\n"
-				}
-				mem.Content += p.Text
-			}
-		}
-		if mem.Content == "" {
-			continue
-		}
-		if tags, ok := m.Metadata["tags"].([]string); ok {
-			mem.Tags = append([]string(nil), tags...)
-		} else if anyTags, ok := m.Metadata["tags"].([]any); ok {
-			for _, t := range anyTags {
-				if s, ok := t.(string); ok {
-					mem.Tags = append(mem.Tags, s)
-				}
-			}
 		}
 		out = append(out, mem)
 	}
@@ -162,6 +147,88 @@ func (p *Peggy) ListMemories(ctx context.Context) ([]Memory, error) {
 		return out[i].Timestamp.After(out[j].Timestamp)
 	})
 	return out, nil
+}
+
+// ForgetMemory deletes one curated memory by id from the __memories__
+// session and returns the removed memory.
+func (p *Peggy) ForgetMemory(ctx context.Context, id string) (Memory, error) {
+	if p == nil || p.store == nil {
+		return Memory{}, errors.New("peggy: ForgetMemory: not initialised")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Memory{}, errors.New("peggy: ForgetMemory: id is required")
+	}
+	memoryWriteMu.Lock()
+	defer memoryWriteMu.Unlock()
+
+	state, _, err := p.store.Load(ctx, MemoriesSessionID)
+	if err != nil {
+		return Memory{}, fmt.Errorf("peggy: load memories: %w", err)
+	}
+	var removed Memory
+	found := false
+	kept := state.Messages[:0]
+	for _, m := range state.Messages {
+		mem, ok := memoryFromMessage(m)
+		if ok && mem.ID == id && !found {
+			removed = mem
+			found = true
+			continue
+		}
+		kept = append(kept, m)
+	}
+	if !found {
+		return Memory{}, fmt.Errorf("peggy: memory %q not found", id)
+	}
+	state.Messages = kept
+	state.UpdatedAt = time.Now().UTC()
+	if err := p.store.Save(ctx, MemoriesSessionID, state); err != nil {
+		return Memory{}, fmt.Errorf("peggy: save memories: %w", err)
+	}
+	return removed, nil
+}
+
+func memoryFromMessage(m glue.Message) (Memory, bool) {
+	if m.Role != glue.MessageRoleAssistant {
+		return Memory{}, false
+	}
+	mem := Memory{Timestamp: m.CreatedAt}
+	for _, p := range m.Content {
+		if p.Type == glue.ContentTypeText {
+			if mem.Content != "" {
+				mem.Content += "\n"
+			}
+			mem.Content += p.Text
+		}
+	}
+	mem.Content = strings.TrimSpace(mem.Content)
+	if mem.Content == "" {
+		return Memory{}, false
+	}
+	if id, ok := m.Metadata["id"].(string); ok {
+		mem.ID = strings.TrimSpace(id)
+	}
+	if mem.ID == "" {
+		mem.ID = memoryID(mem.Timestamp, mem.Content)
+	}
+	if tags, ok := m.Metadata["tags"].([]string); ok {
+		mem.Tags = append([]string(nil), tags...)
+	} else if anyTags, ok := m.Metadata["tags"].([]any); ok {
+		for _, t := range anyTags {
+			if s, ok := t.(string); ok {
+				mem.Tags = append(mem.Tags, s)
+			}
+		}
+	}
+	return mem, true
+}
+
+func memoryID(timestamp time.Time, content string) string {
+	content = strings.TrimSpace(content)
+	stamp := timestamp.UTC().Format(time.RFC3339Nano)
+	sum := sha256.Sum256([]byte(stamp + "\n" + content))
+	return fmt.Sprintf("mem_%d_%s", timestamp.UTC().UnixNano(), hex.EncodeToString(sum[:4]))
 }
 
 // Recall searches Peggy's history (everything by default; restrict

--- a/agents/peggy/memory_test.go
+++ b/agents/peggy/memory_test.go
@@ -70,6 +70,9 @@ func TestAddMemory_RoundTripsThroughStore(t *testing.T) {
 	if memories[0].Tags == nil || memories[0].Tags[0] != "preference" {
 		t.Errorf("tags missing: %+v", memories[0])
 	}
+	if memories[0].ID == "" || !strings.HasPrefix(memories[0].ID, "mem_") {
+		t.Errorf("memory id missing: %+v", memories[0])
+	}
 }
 
 func TestAddMemory_PersistsAcrossPeggyRebuild(t *testing.T) {
@@ -112,6 +115,64 @@ func TestAddMemory_RejectsBlankContent(t *testing.T) {
 	p := newFileBackedPeggy(t)
 	if _, err := p.AddMemory(context.Background(), "   ", nil); err == nil {
 		t.Fatal("expected error for blank content")
+	}
+}
+
+func TestListMemoriesSynthesizesIDsForExistingRecords(t *testing.T) {
+	p := newFileBackedPeggy(t)
+	ctx := context.Background()
+	mem, err := p.AddMemory(ctx, "User likes green tea.", []string{"preference"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, _, err := p.store.Load(ctx, MemoriesSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delete(state.Messages[0].Metadata, "id")
+	if err := p.store.Save(ctx, MemoriesSessionID, state); err != nil {
+		t.Fatal(err)
+	}
+	memories, err := p.ListMemories(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(memories) != 1 || memories[0].ID == "" || memories[0].ID != mem.ID {
+		t.Fatalf("memories = %+v, want synthesized stable id %s", memories, mem.ID)
+	}
+}
+
+func TestForgetMemory_RemovesByID(t *testing.T) {
+	p := newFileBackedPeggy(t)
+	ctx := context.Background()
+	keep, err := p.AddMemory(ctx, "User likes green tea.", []string{"preference"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	remove, err := p.AddMemory(ctx, "User dislikes stale context.", []string{"preference"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	forgotten, err := p.ForgetMemory(ctx, remove.ID)
+	if err != nil {
+		t.Fatalf("ForgetMemory: %v", err)
+	}
+	if forgotten.ID != remove.ID {
+		t.Fatalf("forgotten = %+v, want %s", forgotten, remove.ID)
+	}
+	memories, err := p.ListMemories(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(memories) != 1 || memories[0].ID != keep.ID {
+		t.Fatalf("memories after forget = %+v, want only %s", memories, keep.ID)
+	}
+}
+
+func TestForgetMemory_UnknownIDErrors(t *testing.T) {
+	p := newFileBackedPeggy(t)
+	if _, err := p.ForgetMemory(context.Background(), "mem_missing"); err == nil {
+		t.Fatal("expected error for unknown memory id")
 	}
 }
 

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -686,6 +686,9 @@ func writeRoleCatalog(w io.Writer, catalog []roleCatalogEntry) {
 }
 
 func runMemories(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "forget" {
+		return runMemoriesForget(ctx, args[1:], stdout, stderr)
+	}
 	fs := flag.NewFlagSet("peggy memories", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
@@ -703,6 +706,7 @@ Examples:
   peggy memories --config ~/.config/peggy/settings.json
   peggy memories --config ~/.config/peggy/settings.json --json
   peggy memories --limit 20
+  peggy memories forget <id>
 
 Flags:
 `)
@@ -723,18 +727,13 @@ Flags:
 		return 2
 	}
 
-	settings, settingsPath, err := LoadSettings(*configPath)
+	store, missingSettings, err := openStoreForRunner(*configPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy memories: %v\n", err)
 		return 1
 	}
-	if settingsPath == "" {
+	if missingSettings {
 		fmt.Fprintln(stderr, "peggy memories: no settings.json found; using built-in defaults")
-	}
-	store, err := buildStore(settings)
-	if err != nil {
-		fmt.Fprintf(stderr, "peggy memories: store: %v\n", err)
-		return 1
 	}
 	if closer, ok := store.(io.Closer); ok {
 		defer closer.Close()
@@ -762,6 +761,99 @@ Flags:
 	return 0
 }
 
+func runMemoriesForget(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy memories forget", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy memories forget - delete one curated memory by id.
+
+Usage:
+  peggy memories forget [flags] <id>
+
+Examples:
+  peggy memories forget --config ~/.config/peggy/settings.json mem_123
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	id, err := parseMemoriesForgetArgs(fs.Args(), configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories forget: %v\n", err)
+		return 2
+	}
+	store, missingSettings, err := openStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories forget: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy memories forget: no settings.json found; using built-in defaults")
+	}
+	if closer, ok := store.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	p := &Peggy{store: store}
+	removed, err := p.ForgetMemory(ctx, id)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories forget: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "forgot %s\n", removed.ID)
+	fmt.Fprintf(stdout, "  content: %s\n", singleLine(removed.Content))
+	return 0
+}
+
+func parseMemoriesForgetArgs(args []string, configPath *string) (string, error) {
+	var id string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--config" || arg == "-config":
+			if i+1 >= len(args) {
+				return "", errors.New("--config requires a value")
+			}
+			*configPath = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--config="):
+			*configPath = strings.TrimPrefix(arg, "--config=")
+		case strings.HasPrefix(arg, "-config="):
+			*configPath = strings.TrimPrefix(arg, "-config=")
+		case strings.HasPrefix(arg, "-"):
+			return "", fmt.Errorf("unknown flag %s", arg)
+		default:
+			if id != "" {
+				return "", errors.New("exactly one memory id is required")
+			}
+			id = strings.TrimSpace(arg)
+		}
+	}
+	if id == "" {
+		return "", errors.New("exactly one memory id is required")
+	}
+	return id, nil
+}
+
+func openStoreForRunner(configPath string) (glue.Store, bool, error) {
+	settings, settingsPath, err := LoadSettings(configPath)
+	if err != nil {
+		return nil, false, err
+	}
+	store, err := buildStore(settings)
+	if err != nil {
+		return nil, settingsPath == "", fmt.Errorf("store: %w", err)
+	}
+	return store, settingsPath == "", nil
+}
+
 func writeMemories(w io.Writer, memories []Memory) {
 	if len(memories) == 0 {
 		fmt.Fprintln(w, "No memories recorded.")
@@ -776,6 +868,7 @@ func writeMemories(w io.Writer, memories []Memory) {
 			timestamp = memory.Timestamp.Format(time.RFC3339)
 		}
 		fmt.Fprintf(w, "%s\n", timestamp)
+		fmt.Fprintf(w, "  id: %s\n", memory.ID)
 		fmt.Fprintf(w, "  content: %s\n", singleLine(memory.Content))
 		if len(memory.Tags) > 0 {
 			fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -395,7 +395,7 @@ func TestRunMemoriesListsWithoutProvider(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
 	}
-	for _, want := range []string{"content: User prefers terse responses.", "tags: preference"} {
+	for _, want := range []string{"id: mem_", "content: User prefers terse responses.", "tags: preference"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("stdout = %q, missing %q", out.String(), want)
 		}
@@ -421,8 +421,57 @@ func TestRunMemoriesJSONAndLimit(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &memories); err != nil {
 		t.Fatalf("decode stdout: %v\n%s", err, out.String())
 	}
-	if len(memories) != 1 {
+	if len(memories) != 1 || memories[0].ID == "" {
 		t.Fatalf("memories = %+v, want one result", memories)
+	}
+}
+
+func TestRunMemoriesForgetDeletesWithoutProvider(t *testing.T) {
+	storePath := seedRunnerMemories(t)
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": storePath,
+		},
+	})
+	memories := readRunnerMemoriesJSON(t, cfgPath)
+	if len(memories) != 2 {
+		t.Fatalf("seeded memories = %+v", memories)
+	}
+	forgetID := memories[0].ID
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "forget", forgetID, "--config", cfgPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "forgot "+forgetID) {
+		t.Fatalf("stdout = %q, want forgot id", out.String())
+	}
+
+	memories = readRunnerMemoriesJSON(t, cfgPath)
+	if len(memories) != 1 || memories[0].ID == forgetID {
+		t.Fatalf("memories after forget = %+v", memories)
+	}
+}
+
+func TestRunMemoriesForgetUnknownID(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": filepath.Join(t.TempDir(), "sessions"),
+		},
+	})
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "forget", "--config", cfgPath, "mem_missing"}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), `memory "mem_missing" not found`) {
+		t.Fatalf("stderr = %q", errOut.String())
 	}
 }
 
@@ -487,6 +536,20 @@ func seedRunnerMemories(t *testing.T) string {
 		t.Fatalf("Close: %v", err)
 	}
 	return storePath
+}
+
+func readRunnerMemoriesJSON(t *testing.T, cfgPath string) []Memory {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "--config", cfgPath, "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("memories json exit = %d stderr=%q", code, errOut.String())
+	}
+	var memories []Memory
+	if err := json.Unmarshal(out.Bytes(), &memories); err != nil {
+		t.Fatalf("decode memories: %v\n%s", err, out.String())
+	}
+	return memories
 }
 
 func TestRunSkillsListsWorkspaceSkills(t *testing.T) {


### PR DESCRIPTION
## Summary

- persist stable IDs for new curated Peggy memories and synthesize deterministic IDs for existing records
- show memory IDs in `peggy memories` human output and JSON export
- add provider-free `peggy memories forget <id>` to delete one curated memory from `__memories__`
- document that forget does not delete ordinary conversation history

Closes #230.

## Validation

- `go test ./agents/peggy -run 'TestRunMemories|TestAddMemory|TestListMemories|TestForgetMemory|TestMemoryTools' -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
