### PR TITLE
daemon: expose Peggy recall over connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,11 +648,12 @@ explicit daemon endpoint. Use `--inspect` for a compact authenticated
 status-and-catalog preflight, or `--status`, `--tools`,
 `--mcp-resources`, or `--mcp-prompts` to render each view separately.
 Peggy daemons also support `--mcp-read` and `--mcp-prompt` for direct
-resource reads and prompt rendering. Each inspect/action mode also has a
-`-json` form for scripts. Add `--usage` to `run` or prompt-mode
-`connect` to print provider-reported token usage on stderr without
-changing streamed stdout. Add the `--usage-*-price` flags when you
-want a local USD estimate from prices you supply.
+resource reads and prompt rendering, plus `--recall` for direct
+memory/session search. Each inspect/action mode also has a `-json` form
+for scripts. Add `--usage` to `run` or prompt-mode `connect` to print
+provider-reported token usage on stderr without changing streamed
+stdout. Add the `--usage-*-price` flags when you want a local USD
+estimate from prices you supply.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:
@@ -664,6 +665,7 @@ go run ./cmd/glue connect --mcp-resources
 go run ./cmd/glue connect --mcp-prompts
 go run ./cmd/glue connect --mcp-read --server filesystem --uri file:///workspace/README.md
 go run ./cmd/glue connect --mcp-prompt --server linear --name summarize_issue --arg issue=GLUE-123
+go run ./cmd/glue connect --recall "Australian Shepherd"
 go run ./cmd/glue connect --prompt "Say hi to Peggy" --id cli:daily
 ```
 

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -53,6 +53,10 @@ not formally follow SemVer until v1.0.
 - **Recall search command.** `peggy recall <query>` searches the
   configured SQLite store without starting a provider, with
   memories-only, limit, and JSON modes.
+- **Daemon recall.** `peggy serve` now exposes authenticated recall
+  search through the daemon host, and `glue connect --recall <query>`
+  can search the live Peggy store with JSON, memories-only, and limit
+  modes without starting a model run.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -15,7 +15,7 @@ A long-running personal-assistant agent built on the
 - **token-aware summarizing compaction** so long sessions don't blow
   the context window
 - **FTS5 session search** under the hood, exposed via
-  `Agent.SearchSessions`
+  `Agent.SearchSessions`, `peggy recall`, and daemon `glue connect --recall`
 - opt-in local **coding tools** for reading files, writing files,
   running allowlisted commands, and inspecting git branch context
 - per-call permission prompts for side-effecting coding tools in the
@@ -303,6 +303,7 @@ glue connect --mcp-resources
 glue connect --mcp-prompts
 glue connect --mcp-read --server filesystem --uri file:///workspace/README.md
 glue connect --mcp-prompt --server linear --name summarize_issue --arg issue=GLUE-123
+glue connect --recall "Australian Shepherd"
 glue connect --prompt "summarize today's plan" --id cli:daily --usage
 ```
 
@@ -325,9 +326,9 @@ bearer token. `glue connect --inspect` includes status, tools,
 daemon-advertised skills, daemon-advertised roles, and any
 daemon-advertised MCP resource/prompt catalogs. Use `--skills-json`,
 `--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
-`--mcp-read-json`, or `--mcp-prompt-json` when another client needs the
-payload as data. Add `--usage` to prompt or skill-mode `glue connect`
-when you want provider-reported token usage on stderr. Add
+`--mcp-read-json`, `--mcp-prompt-json`, or `--recall-json` when another
+client needs the payload as data. Add `--usage` to prompt or skill-mode
+`glue connect` when you want provider-reported token usage on stderr. Add
 `--usage-input-price`, `--usage-output-price`, and optional cache price
 flags to estimate USD cost from prices you supply. Stop the daemon with
 SIGINT/SIGTERM.
@@ -617,9 +618,18 @@ peggy recall --config ~/.config/peggy/settings.json --memories "preference"
 peggy recall --config ~/.config/peggy/settings.json --json "project"
 ```
 
-`peggy recall` uses the configured store only; it does not start a
-provider. File-backed stores do not support search, so use the default
-SQLite store for recall.
+When Peggy is already running as a daemon, connected clients can search
+the same live store without starting a run:
+
+```sh
+glue connect --recall "Australian Shepherd"
+glue connect --recall "preference" --recall-memories
+glue connect --recall "project" --recall-json
+```
+
+`peggy recall` and daemon `glue connect --recall` use the configured
+store only; neither starts a provider. File-backed stores do not
+support search, so use the default SQLite store for recall.
 
 ## What Peggy supports today
 
@@ -631,7 +641,7 @@ SQLite store for recall.
 - **Model-callable `remember` / `recall` tools** for durable
   cross-session memory.
 - **Cross-session FTS5 search** via `Agent.SearchSessions` library
-  API (a `peggy recall` subcommand is a near-term follow-up).
+  API, `peggy recall`, and daemon `glue connect --recall`.
 - **Token-aware summarizing compaction** via the configured provider.
 - Identity injected from `SOUL.md` into the system prompt.
 - Opt-in **local coding mode** for CLI and Telegram: read files, write

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -3,6 +3,7 @@ package peggy
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"github.com/erain/glue"
 	"github.com/erain/glue/daemon"
 	filestore "github.com/erain/glue/stores/file"
+	sqlitestore "github.com/erain/glue/stores/sqlite"
 )
 
 func TestPeggyDaemonCodingPermissionViaDaemon(t *testing.T) {
@@ -315,6 +317,97 @@ func TestPeggyDaemonReadsMCPResourceAndRendersPrompt(t *testing.T) {
 	postPeggyDaemonJSON(t, ts.URL+"/v1/mcp/prompts/get", `{"server":"briefs","name":"daily_brief","arguments":{"topic":"Go"}}`, &rendered)
 	if rendered.Server != "briefs" || rendered.Name != "daily_brief" || len(rendered.Messages) != 1 || !strings.Contains(string(rendered.Messages[0].Content), "Brief me on Go.") {
 		t.Fatalf("rendered = %+v", rendered)
+	}
+}
+
+func TestPeggyDaemonRecallSearchesSQLite(t *testing.T) {
+	store, err := sqlitestore.Open(sqlitestore.Options{Path: filepath.Join(t.TempDir(), "peggy.db")})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	p, err := New(Options{
+		Provider: &fakeProvider{text: "Australian context saved."},
+		Store:    store,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+	if _, err := p.AddMemory(context.Background(), "User's Australian Shepherd is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := p.Prompt(context.Background(), "casual", "Australian project note", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	var recall daemon.RecallResponse
+	postPeggyDaemonJSON(t, ts.URL+"/v1/recall", `{"query":"Australian","limit":1,"memories_only":true}`, &recall)
+	if len(recall.Hits) != 1 || recall.Hits[0].SessionID != MemoriesSessionID || !strings.Contains(recall.Hits[0].Snippet, "Australian") {
+		t.Fatalf("recall = %+v", recall.Hits)
+	}
+
+	var status struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/status", &status)
+	if !containsString(status.Capabilities, "recall") {
+		t.Fatalf("capabilities = %v, missing recall", status.Capabilities)
+	}
+}
+
+func TestPeggyDaemonRecallFileStoreExplainsSearchRequirement(t *testing.T) {
+	p, err := New(Options{
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/recall", strings.NewReader(`{"query":"anything"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	var body struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body.Error.Message, "use sqlite store") {
+		t.Fatalf("error = %+v", body.Error)
 	}
 }
 

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -258,6 +258,36 @@ func (p *Peggy) RoleCatalog(ctx context.Context) ([]daemon.RoleCatalogEntry, err
 	return out, nil
 }
 
+// RecallSearch implements daemon.RecallHost.
+func (p *Peggy) RecallSearch(ctx context.Context, req daemon.RecallRequest) (daemon.RecallResponse, error) {
+	var opts []RecallOption
+	if req.Limit > 0 {
+		opts = append(opts, WithRecallLimit(req.Limit))
+	}
+	if req.MemoriesOnly {
+		opts = append(opts, WithMemoriesOnly())
+	}
+	hits, err := p.Recall(ctx, req.Query, opts...)
+	if err != nil {
+		if errors.Is(err, glue.ErrSearchNotSupported) {
+			return daemon.RecallResponse{}, errors.New("configured store does not support search; use sqlite store")
+		}
+		return daemon.RecallResponse{}, err
+	}
+	out := make([]daemon.RecallHit, 0, len(hits))
+	for _, hit := range hits {
+		out = append(out, daemon.RecallHit{
+			SessionID: hit.SessionID,
+			Index:     hit.Index,
+			Role:      hit.Role,
+			Snippet:   hit.Snippet,
+			Score:     hit.Score,
+			Timestamp: hit.Timestamp,
+		})
+	}
+	return daemon.RecallResponse{Hits: out}, nil
+}
+
 // MCPResourceCatalog implements daemon.MCPResourceCatalogHost.
 func (p *Peggy) MCPResourceCatalog(ctx context.Context) ([]daemon.MCPResourceCatalogEntry, error) {
 	if p == nil || p.mcpManager == nil {

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -403,6 +403,10 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	mcpServer := flags.String("server", "", "MCP server name for --mcp-read or --mcp-prompt")
 	mcpURI := flags.String("uri", "", "MCP resource URI for --mcp-read")
 	mcpName := flags.String("name", "", "MCP prompt name for --mcp-prompt")
+	recallQuery := flags.String("recall", "", "search daemon recall history and exit without starting a run")
+	recallJSON := flags.Bool("recall-json", false, "print --recall output as JSON")
+	recallMemories := flags.Bool("recall-memories", false, "restrict --recall to curated memories")
+	recallLimit := flags.Int("recall-limit", 0, "maximum recall hits; 0 uses daemon default")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
@@ -446,14 +450,18 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *inspectJSON {
 		*showInspect = true
 	}
+	if *recallJSON && strings.TrimSpace(*recallQuery) == "" && flags.NArg() == 1 {
+		*recallQuery = flags.Arg(0)
+	}
+	showRecall := strings.TrimSpace(*recallQuery) != "" || *recallJSON
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --status, or --inspect")
+		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" && strings.TrimSpace(*skillName) == "" {
 		return errors.New("missing required --prompt or --skill")
@@ -504,6 +512,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showMCPPrompt {
 		return runConnectMCPPrompt(ctx, cfg, *mcpServer, *mcpName, runArgsMap, *mcpPromptJSON, stdout, client)
+	}
+	if showRecall {
+		return runConnectRecall(ctx, cfg, *recallQuery, *recallMemories, *recallLimit, *recallJSON, stdout, client)
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
@@ -689,6 +700,31 @@ func runConnectMCPPrompt(ctx context.Context, cfg connectConfig, server, name st
 		return enc.Encode(rendered)
 	}
 	writeDaemonMCPPrompt(stdout, rendered)
+	return nil
+}
+
+func runConnectRecall(ctx context.Context, cfg connectConfig, query string, memoriesOnly bool, limit int, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return errors.New("--recall query is required")
+	}
+	if limit < 0 {
+		return errors.New("--recall-limit must be non-negative")
+	}
+	recall, err := requestDaemonRecall(ctx, cfg, daemon.RecallRequest{
+		Query:        query,
+		Limit:        limit,
+		MemoriesOnly: memoriesOnly,
+	}, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(recall)
+	}
+	writeDaemonRecallHits(stdout, recall.Hits)
 	return nil
 }
 
@@ -995,6 +1031,35 @@ func requestDaemonMCPPrompt(ctx context.Context, cfg connectConfig, server, name
 	return rendered, nil
 }
 
+func requestDaemonRecall(ctx context.Context, cfg connectConfig, request daemon.RecallRequest, client httpDoer) (daemon.RecallResponse, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(request); err != nil {
+		return daemon.RecallResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.BaseURL+"/v1/recall", &body)
+	if err != nil {
+		return daemon.RecallResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemon.RecallResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.RecallResponse{}, fmt.Errorf("daemon recall: %s", httpStatusError(resp))
+	}
+	var recall daemon.RecallResponse
+	if err := json.NewDecoder(resp.Body).Decode(&recall); err != nil {
+		return daemon.RecallResponse{}, err
+	}
+	if recall.Hits == nil {
+		recall.Hits = []daemon.RecallHit{}
+	}
+	return recall, nil
+}
+
 func writeDaemonToolCatalog(w io.Writer, tools []daemonToolCatalogEntry) {
 	writeDaemonToolCatalogIndented(w, tools, "")
 }
@@ -1193,6 +1258,28 @@ func writeDaemonMCPPrompt(w io.Writer, rendered daemon.MCPPromptRenderResponse) 
 			continue
 		}
 		fmt.Fprintf(w, "      content: %s\n", compactJSON(message.Content))
+	}
+}
+
+func writeDaemonRecallHits(w io.Writer, hits []daemon.RecallHit) {
+	if len(hits) == 0 {
+		fmt.Fprintln(w, "No recall hits.")
+		return
+	}
+	for i, hit := range hits {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		timestamp := ""
+		if !hit.Timestamp.IsZero() {
+			timestamp = hit.Timestamp.Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%d. %s#%d\n", i+1, hit.SessionID, hit.Index)
+		if timestamp != "" {
+			fmt.Fprintf(w, "  timestamp: %s\n", timestamp)
+		}
+		fmt.Fprintf(w, "  score: %.2f\n", hit.Score)
+		fmt.Fprintf(w, "  snippet: %s\n", oneLine(hit.Snippet))
 	}
 }
 
@@ -1643,11 +1730,12 @@ func printUsage(w io.Writer) {
   glue connect --mcp-prompts [--mcp-prompts-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-read --server <name> --uri <uri> [--mcp-read-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-prompt --server <name> --name <prompt> [--arg key=value] [--mcp-prompt-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --recall <query> [--recall-json] [--recall-memories] [--recall-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
   serve    Start a local HTTP+SSE daemon for Glue sessions.
-  connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP catalogs.
+  connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP/recall surfaces.
 
 Flags:
   --id       Session id. Defaults to "default".
@@ -1694,6 +1782,13 @@ Flags:
              Connect mode: render one daemon MCP prompt and exit without starting a run.
   --mcp-prompt-json
              Connect --mcp-prompt mode: print JSON.
+  --recall   Connect mode: search daemon recall history and exit without starting a run.
+  --recall-json
+             Connect --recall mode: print JSON. With no --recall flag, one positional query is accepted.
+  --recall-memories
+             Connect --recall mode: search only curated memories.
+  --recall-limit
+             Connect --recall mode: maximum hits; 0 uses daemon default.
   --server   MCP server name for --mcp-read or --mcp-prompt.
   --uri      MCP resource URI for --mcp-read.
   --name     MCP prompt name for --mcp-prompt.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -1503,6 +1503,146 @@ func TestRunCLIConnectRendersMCPPromptJSON(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectRecall(t *testing.T) {
+	var sawRecall bool
+	var sawRun bool
+	var request daemon.RecallRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/recall":
+			sawRecall = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("recall method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("recall auth = %q", auth)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.RecallResponse{Hits: []daemon.RecallHit{{
+				SessionID: "__memories__",
+				Index:     7,
+				Role:      glue.MessageRoleAssistant,
+				Snippet:   "User prefers terse responses.",
+				Score:     1.25,
+				Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--recall", "terse",
+		"--recall-memories",
+		"--recall-limit", "1",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawRecall || sawRun {
+		t.Fatalf("sawRecall=%v sawRun=%v", sawRecall, sawRun)
+	}
+	if request.Query != "terse" || request.Limit != 1 || !request.MemoriesOnly {
+		t.Fatalf("request = %+v", request)
+	}
+	for _, want := range []string{
+		"__memories__#7",
+		"timestamp: 2026-05-24T12:00:00Z",
+		"score: 1.25",
+		"snippet: User prefers terse responses.",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectRecallJSON(t *testing.T) {
+	var request daemon.RecallRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/recall" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemon.RecallResponse{Hits: []daemon.RecallHit{{
+			SessionID: "default",
+			Index:     1,
+			Snippet:   "project note",
+		}}})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+		"--recall-json", "project",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if request.Query != "project" {
+		t.Fatalf("request = %+v", request)
+	}
+	var recall daemon.RecallResponse
+	if err := json.Unmarshal(stdout.Bytes(), &recall); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if len(recall.Hits) != 1 || recall.Hits[0].SessionID != "default" {
+		t.Fatalf("recall = %+v", recall)
+	}
+}
+
+func TestRunCLIConnectRecallValidation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--recall-json",
+		"--base-url", "http://daemon",
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code == 0 {
+		t.Fatal("code = 0, want recall query validation failure")
+	}
+	if !strings.Contains(stderr.String(), "--recall query is required") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--recall", "project",
+		"--recall-limit", "-1",
+		"--base-url", "http://daemon",
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code == 0 {
+		t.Fatal("code = 0, want recall limit validation failure")
+	}
+	if !strings.Contains(stderr.String(), "--recall-limit must be non-negative") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestRunCLIConnectShowsStatus(t *testing.T) {
 	var sawStatus bool
 	var sawRun bool

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -70,6 +70,12 @@ type MCPPromptRendererHost interface {
 	MCPRenderPrompt(context.Context, MCPPromptRenderRequest) (MCPPromptRenderResponse, error)
 }
 
+// RecallHost is optionally implemented by hosts that can search stored session
+// history without starting a run.
+type RecallHost interface {
+	RecallSearch(context.Context, RecallRequest) (RecallResponse, error)
+}
+
 // SkillCatalogEntry describes one reusable skill advertised by a host.
 type SkillCatalogEntry struct {
 	Name        string `json:"name"`
@@ -155,6 +161,29 @@ type MCPPromptRenderResponse struct {
 type MCPPromptMessage struct {
 	Role    string          `json:"role"`
 	Content json.RawMessage `json:"content"`
+}
+
+// RecallRequest searches stored session history.
+type RecallRequest struct {
+	Query        string `json:"query"`
+	Limit        int    `json:"limit,omitempty"`
+	MemoriesOnly bool   `json:"memories_only,omitempty"`
+}
+
+// RecallHit is one stored session search result returned by a recall-capable
+// daemon host.
+type RecallHit struct {
+	SessionID string           `json:"session_id"`
+	Index     int              `json:"index"`
+	Role      glue.MessageRole `json:"role,omitempty"`
+	Snippet   string           `json:"snippet"`
+	Score     float64          `json:"score"`
+	Timestamp time.Time        `json:"timestamp,omitempty"`
+}
+
+// RecallResponse contains stored session search hits.
+type RecallResponse struct {
+	Hits []RecallHit `json:"hits"`
 }
 
 // Options configures [New].
@@ -424,6 +453,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/v1/recall" {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleRecall(w, r)
+		return
+	}
+
 	if r.URL.Path == "/v1/mcp/resources" {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
@@ -535,6 +573,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	if _, ok := s.host.(RoleCatalogHost); ok {
 		capabilities = append(capabilities, "roles")
 	}
+	if _, ok := s.host.(RecallHost); ok {
+		capabilities = append(capabilities, "recall")
+	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:           true,
 		Version:      protocolVersion,
@@ -633,6 +674,37 @@ func (s *Server) handleRoles(w http.ResponseWriter, r *http.Request) {
 		roles = []RoleCatalogEntry{}
 	}
 	writeJSON(w, http.StatusOK, roleCatalogResponse{Roles: roles})
+}
+
+func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.host.(RecallHost)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "recall is not supported by this host", false)
+		return
+	}
+	var req RecallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body", false)
+		return
+	}
+	req.Query = strings.TrimSpace(req.Query)
+	if req.Query == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "query is required", false)
+		return
+	}
+	if req.Limit < 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "limit must be non-negative", false)
+		return
+	}
+	hits, err := host.RecallSearch(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if hits.Hits == nil {
+		hits.Hits = []RecallHit{}
+	}
+	writeJSON(w, http.StatusOK, RecallResponse{Hits: hits.Hits})
 }
 
 func (s *Server) handleMCPResources(w http.ResponseWriter, r *http.Request) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -176,6 +176,21 @@ func (mcpActionHost) MCPRenderPrompt(_ context.Context, req MCPPromptRenderReque
 	}, nil
 }
 
+type recallHost struct {
+	req  RecallRequest
+	hits []RecallHit
+	err  error
+}
+
+func (recallHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
+func (h *recallHost) RecallSearch(_ context.Context, req RecallRequest) (RecallResponse, error) {
+	h.req = req
+	return RecallResponse{Hits: h.hits}, h.err
+}
+
 func TestServerAuthAndHealth(t *testing.T) {
 	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
 	ts := httptest.NewServer(srv)
@@ -557,6 +572,77 @@ func TestServerMCPActionValidation(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("prompt validation status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestServerRecall(t *testing.T) {
+	host := &recallHost{hits: []RecallHit{{
+		SessionID: "default",
+		Index:     3,
+		Role:      glue.MessageRoleAssistant,
+		Snippet:   "User prefers terse responses.",
+		Score:     1.25,
+		Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+	}}}
+	srv := newTestServer(t, host)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/recall", "", `{"query":"terse"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated recall status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/recall", "token", `{"query":"terse","limit":1,"memories_only":true}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("recall status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var recall RecallResponse
+	if err := json.NewDecoder(resp.Body).Decode(&recall); err != nil {
+		t.Fatal(err)
+	}
+	if len(recall.Hits) != 1 || recall.Hits[0].SessionID != "default" || host.req.Query != "terse" || host.req.Limit != 1 || !host.req.MemoriesOnly {
+		t.Fatalf("recall=%+v request=%+v", recall, host.req)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	var status statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(status.Capabilities, "recall") {
+		t.Fatalf("capabilities = %v, missing recall", status.Capabilities)
+	}
+}
+
+func TestServerRecallValidationAndUnsupportedHost(t *testing.T) {
+	srv := newTestServer(t, sessionOnlyHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/recall", "token", `{"query":"anything"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unsupported recall status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	srv = newTestServer(t, &recallHost{})
+	ts = httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp = postJSON(t, ts.URL+"/v1/recall", "token", `{"query":"   "}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("empty query status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	resp = postJSON(t, ts.URL+"/v1/recall", "token", `{"query":"x","limit":-1}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("negative limit status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 

--- a/docs/adr/0010-daemon-protocol.md
+++ b/docs/adr/0010-daemon-protocol.md
@@ -145,7 +145,7 @@ Response:
   "version": 1,
   "active_runs": 0,
   "tools_count": 4,
-  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "status"]
+  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "recall", "status"]
 }
 ```
 
@@ -226,6 +226,40 @@ Hosts that do not expose a role catalog return an empty `roles` array.
 A host that exposes a catalog advertises the `roles` capability in
 `/v1/status`. Runs apply roles through the existing `role` field on
 the run-start request.
+
+Daemon clients can ask recall-capable hosts to search stored session
+history without starting a run:
+
+```http
+POST /v1/recall
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "query": "Australian Shepherd",
+  "limit": 5,
+  "memories_only": false
+}
+```
+
+Response:
+
+```json
+{
+  "hits": [
+    {
+      "session_id": "__memories__",
+      "index": 0,
+      "snippet": "The user's Australian Shepherd is named Inkblot.",
+      "score": 1.23,
+      "timestamp": "2026-05-24T12:00:00Z"
+    }
+  ]
+}
+```
+
+Hosts that do not expose recall return `404`. A host that exposes
+recall advertises the `recall` capability in `/v1/status`.
 
 ### 5. Runs and sessions
 


### PR DESCRIPTION
## Summary

- add authenticated daemon `POST /v1/recall` behind an optional host capability
- have Peggy implement daemon recall over the existing SQLite-backed `Peggy.Recall` API
- add `glue connect --recall`, `--recall-json`, `--recall-memories`, and `--recall-limit`
- document recall-over-daemon in README, Peggy docs, changelog, and ADR-0010

Closes #234.

## Validation

- `go test ./daemon ./agents/peggy ./cmd/glue -run 'TestServerRecall|TestPeggyDaemonRecall|TestRunCLIConnectRecall' -count=1`
- `go test ./daemon ./agents/peggy ./cmd/glue -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
