### PR TITLE
daemon: expose Peggy memories over connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,12 +648,12 @@ explicit daemon endpoint. Use `--inspect` for a compact authenticated
 status-and-catalog preflight, or `--status`, `--tools`,
 `--mcp-resources`, or `--mcp-prompts` to render each view separately.
 Peggy daemons also support `--mcp-read` and `--mcp-prompt` for direct
-resource reads and prompt rendering, plus `--recall` for direct
-memory/session search. Each inspect/action mode also has a `-json` form
-for scripts. Add `--usage` to `run` or prompt-mode `connect` to print
-provider-reported token usage on stderr without changing streamed
-stdout. Add the `--usage-*-price` flags when you want a local USD
-estimate from prices you supply.
+resource reads and prompt rendering, `--memories` for curated memory
+catalogs, plus `--recall` for direct memory/session search. Each
+inspect/action mode also has a `-json` form for scripts. Add `--usage`
+to `run` or prompt-mode `connect` to print provider-reported token usage
+on stderr without changing streamed stdout. Add the `--usage-*-price`
+flags when you want a local USD estimate from prices you supply.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:
@@ -661,6 +661,7 @@ agent, settings, memory store, and coding tools loaded once:
 ```sh
 go run ./agents/peggy/cmd/peggy serve --coding --workdir .
 go run ./cmd/glue connect --inspect
+go run ./cmd/glue connect --memories
 go run ./cmd/glue connect --mcp-resources
 go run ./cmd/glue connect --mcp-prompts
 go run ./cmd/glue connect --mcp-read --server filesystem --uri file:///workspace/README.md

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -57,6 +57,10 @@ not formally follow SemVer until v1.0.
   search through the daemon host, and `glue connect --recall <query>`
   can search the live Peggy store with JSON, memories-only, and limit
   modes without starting a model run.
+- **Daemon memory catalog.** `peggy serve` now exposes authenticated
+  curated-memory listing through the daemon host, and
+  `glue connect --memories` can render or JSON-export the live memory
+  catalog with an optional limit.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -26,6 +26,7 @@ A long-running personal-assistant agent built on the
 - starter workspace scaffolding via `peggy init`
 - local readiness status for config, identity, memory, context,
   coding, and MCP setup
+- daemon-readable curated memory catalogs via `glue connect --memories`
 - four model backends: Codex (ChatGPT subscription), Gemini,
   OpenRouter, NVIDIA build
 
@@ -296,6 +297,7 @@ session history and memory store.
 ```sh
 peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
+glue connect --memories
 glue connect --skills
 glue connect --roles
 glue connect --skill triage --arg issue=GLUE-123 --id cli:triage
@@ -326,9 +328,10 @@ bearer token. `glue connect --inspect` includes status, tools,
 daemon-advertised skills, daemon-advertised roles, and any
 daemon-advertised MCP resource/prompt catalogs. Use `--skills-json`,
 `--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
-`--mcp-read-json`, `--mcp-prompt-json`, or `--recall-json` when another
-client needs the payload as data. Add `--usage` to prompt or skill-mode
-`glue connect` when you want provider-reported token usage on stderr. Add
+`--mcp-read-json`, `--mcp-prompt-json`, `--recall-json`, or
+`--memories-json` when another client needs the payload as data. Add
+`--usage` to prompt or skill-mode `glue connect` when you want
+provider-reported token usage on stderr. Add
 `--usage-input-price`, `--usage-output-price`, and optional cache price
 flags to estimate USD cost from prices you supply. Stop the daemon with
 SIGINT/SIGTERM.
@@ -609,6 +612,15 @@ peggy memories forget --config ~/.config/peggy/settings.json mem_123
 Each memory has a stable `id` in human and JSON output. `forget` only
 removes curated `remember` records from the dedicated memory session; it
 does not delete ordinary conversation history.
+
+When Peggy is already running as a daemon, connected clients can list
+the same curated memory catalog:
+
+```sh
+glue connect --memories
+glue connect --memories-json
+glue connect --memories --memory-limit 20
+```
 
 Search stored sessions and memories directly when using a SQLite store:
 

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -411,6 +411,49 @@ func TestPeggyDaemonRecallFileStoreExplainsSearchRequirement(t *testing.T) {
 	}
 }
 
+func TestPeggyDaemonListsMemories(t *testing.T) {
+	p, err := New(Options{
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+	if _, err := p.AddMemory(context.Background(), "User's Australian Shepherd is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := p.AddMemory(context.Background(), "User prefers terse responses.", []string{"preference"}); err != nil {
+		t.Fatalf("AddMemory 2: %v", err)
+	}
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	var catalog daemon.MemoryCatalogResponse
+	getPeggyDaemonJSON(t, ts.URL+"/v1/memories?limit=1", &catalog)
+	if len(catalog.Memories) != 1 || catalog.Memories[0].ID == "" || !strings.Contains(catalog.Memories[0].Content, "terse") {
+		t.Fatalf("memories = %+v", catalog.Memories)
+	}
+	if len(catalog.Memories[0].Tags) != 1 || catalog.Memories[0].Tags[0] != "preference" {
+		t.Fatalf("tags = %+v", catalog.Memories[0].Tags)
+	}
+
+	var status struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/status", &status)
+	if !containsString(status.Capabilities, "memories") {
+		t.Fatalf("capabilities = %v, missing memories", status.Capabilities)
+	}
+}
+
 type startRunResponse struct {
 	RunID     string `json:"run_id"`
 	EventsURL string `json:"events_url"`

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -288,6 +288,27 @@ func (p *Peggy) RecallSearch(ctx context.Context, req daemon.RecallRequest) (dae
 	return daemon.RecallResponse{Hits: out}, nil
 }
 
+// MemoryCatalog implements daemon.MemoryCatalogHost.
+func (p *Peggy) MemoryCatalog(ctx context.Context, req daemon.MemoryCatalogRequest) (daemon.MemoryCatalogResponse, error) {
+	memories, err := p.ListMemories(ctx)
+	if err != nil {
+		return daemon.MemoryCatalogResponse{}, err
+	}
+	if req.Limit > 0 && len(memories) > req.Limit {
+		memories = memories[:req.Limit]
+	}
+	out := make([]daemon.MemoryEntry, 0, len(memories))
+	for _, memory := range memories {
+		out = append(out, daemon.MemoryEntry{
+			ID:        memory.ID,
+			Content:   memory.Content,
+			Tags:      append([]string(nil), memory.Tags...),
+			Timestamp: memory.Timestamp,
+		})
+	}
+	return daemon.MemoryCatalogResponse{Memories: out}, nil
+}
+
 // MCPResourceCatalog implements daemon.MCPResourceCatalogHost.
 func (p *Peggy) MCPResourceCatalog(ctx context.Context) ([]daemon.MCPResourceCatalogEntry, error) {
 	if p == nil || p.mcpManager == nil {

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -407,6 +407,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	recallJSON := flags.Bool("recall-json", false, "print --recall output as JSON")
 	recallMemories := flags.Bool("recall-memories", false, "restrict --recall to curated memories")
 	recallLimit := flags.Int("recall-limit", 0, "maximum recall hits; 0 uses daemon default")
+	showMemories := flags.Bool("memories", false, "list daemon memories and exit without starting a run")
+	memoriesJSON := flags.Bool("memories-json", false, "print --memories output as JSON")
+	memoryLimit := flags.Int("memory-limit", 0, "maximum memories to return; 0 means no limit")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
@@ -453,15 +456,18 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *recallJSON && strings.TrimSpace(*recallQuery) == "" && flags.NArg() == 1 {
 		*recallQuery = flags.Arg(0)
 	}
+	if *memoriesJSON {
+		*showMemories = true
+	}
 	showRecall := strings.TrimSpace(*recallQuery) != "" || *recallJSON
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --status, or --inspect")
+		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" && strings.TrimSpace(*skillName) == "" {
 		return errors.New("missing required --prompt or --skill")
@@ -515,6 +521,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if showRecall {
 		return runConnectRecall(ctx, cfg, *recallQuery, *recallMemories, *recallLimit, *recallJSON, stdout, client)
+	}
+	if *showMemories {
+		return runConnectMemories(ctx, cfg, *memoryLimit, *memoriesJSON, stdout, client)
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
@@ -728,6 +737,23 @@ func runConnectRecall(ctx context.Context, cfg connectConfig, query string, memo
 	return nil
 }
 
+func runConnectMemories(ctx context.Context, cfg connectConfig, limit int, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	if limit < 0 {
+		return errors.New("--memory-limit must be non-negative")
+	}
+	catalog, err := fetchDaemonMemories(ctx, cfg, limit, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(catalog)
+	}
+	writeDaemonMemories(stdout, catalog.Memories)
+	return nil
+}
+
 func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
 	status, err := fetchDaemonStatus(ctx, cfg, client)
 	if err != nil {
@@ -919,6 +945,36 @@ func fetchDaemonRoles(ctx context.Context, cfg connectConfig, client httpDoer) (
 	}
 	if catalog.Roles == nil {
 		catalog.Roles = []daemon.RoleCatalogEntry{}
+	}
+	return catalog, nil
+}
+
+func fetchDaemonMemories(ctx context.Context, cfg connectConfig, limit int, client httpDoer) (daemon.MemoryCatalogResponse, error) {
+	endpoint := cfg.BaseURL + "/v1/memories"
+	if limit > 0 {
+		values := url.Values{}
+		values.Set("limit", fmt.Sprint(limit))
+		endpoint += "?" + values.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return daemon.MemoryCatalogResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemon.MemoryCatalogResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.MemoryCatalogResponse{}, fmt.Errorf("daemon memories: %s", httpStatusError(resp))
+	}
+	var catalog daemon.MemoryCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		return daemon.MemoryCatalogResponse{}, err
+	}
+	if catalog.Memories == nil {
+		catalog.Memories = []daemon.MemoryEntry{}
 	}
 	return catalog, nil
 }
@@ -1125,6 +1181,30 @@ func writeDaemonRoleCatalogIndented(w io.Writer, roles []daemon.RoleCatalogEntry
 		}
 		if role.Model != "" {
 			fmt.Fprintf(w, "%s  model: %s\n", indent, role.Model)
+		}
+	}
+}
+
+func writeDaemonMemories(w io.Writer, memories []daemon.MemoryEntry) {
+	if len(memories) == 0 {
+		fmt.Fprintln(w, "No daemon memories reported.")
+		return
+	}
+	for i, memory := range memories {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		timestamp := ""
+		if !memory.Timestamp.IsZero() {
+			timestamp = memory.Timestamp.Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%d. %s\n", i+1, memory.ID)
+		if timestamp != "" {
+			fmt.Fprintf(w, "  timestamp: %s\n", timestamp)
+		}
+		fmt.Fprintf(w, "  content: %s\n", oneLine(memory.Content))
+		if len(memory.Tags) > 0 {
+			fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
 		}
 	}
 }
@@ -1731,6 +1811,7 @@ func printUsage(w io.Writer) {
   glue connect --mcp-read --server <name> --uri <uri> [--mcp-read-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --mcp-prompt --server <name> --name <prompt> [--arg key=value] [--mcp-prompt-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --recall <query> [--recall-json] [--recall-memories] [--recall-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --memories [--memories-json] [--memory-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
@@ -1789,6 +1870,11 @@ Flags:
              Connect --recall mode: search only curated memories.
   --recall-limit
              Connect --recall mode: maximum hits; 0 uses daemon default.
+  --memories Connect mode: list daemon memories and exit without starting a run.
+  --memories-json
+             Connect --memories mode: print JSON.
+  --memory-limit
+             Connect --memories mode: maximum memories; 0 means no limit.
   --server   MCP server name for --mcp-read or --mcp-prompt.
   --uri      MCP resource URI for --mcp-read.
   --name     MCP prompt name for --mcp-prompt.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -1643,6 +1643,115 @@ func TestRunCLIConnectRecallValidation(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectListsMemories(t *testing.T) {
+	var sawMemories bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/memories":
+			sawMemories = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("memories method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("memories auth = %q", auth)
+			}
+			if got := r.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("limit query = %q, want 1", got)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.MemoryCatalogResponse{Memories: []daemon.MemoryEntry{{
+				ID:        "mem_1",
+				Content:   "User prefers terse responses.",
+				Tags:      []string{"preference"},
+				Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--memories",
+		"--memory-limit", "1",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawMemories || sawRun {
+		t.Fatalf("sawMemories=%v sawRun=%v", sawMemories, sawRun)
+	}
+	for _, want := range []string{
+		"mem_1",
+		"timestamp: 2026-05-24T12:00:00Z",
+		"content: User prefers terse responses.",
+		"tags: preference",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectListsMemoriesJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/memories" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemon.MemoryCatalogResponse{Memories: []daemon.MemoryEntry{{
+			ID:      "mem_1",
+			Content: "User prefers terse responses.",
+		}}})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--memories-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var catalog daemon.MemoryCatalogResponse
+	if err := json.Unmarshal(stdout.Bytes(), &catalog); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if len(catalog.Memories) != 1 || catalog.Memories[0].ID != "mem_1" {
+		t.Fatalf("catalog = %+v", catalog)
+	}
+}
+
+func TestRunCLIConnectMemoriesValidation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--memories",
+		"--memory-limit", "-1",
+		"--base-url", "http://daemon",
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code == 0 {
+		t.Fatal("code = 0, want memory limit validation failure")
+	}
+	if !strings.Contains(stderr.String(), "--memory-limit must be non-negative") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestRunCLIConnectShowsStatus(t *testing.T) {
 	var sawStatus bool
 	var sawRun bool

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -74,6 +75,12 @@ type MCPPromptRendererHost interface {
 // history without starting a run.
 type RecallHost interface {
 	RecallSearch(context.Context, RecallRequest) (RecallResponse, error)
+}
+
+// MemoryCatalogHost is optionally implemented by hosts that can expose curated
+// memory records without starting a run.
+type MemoryCatalogHost interface {
+	MemoryCatalog(context.Context, MemoryCatalogRequest) (MemoryCatalogResponse, error)
 }
 
 // SkillCatalogEntry describes one reusable skill advertised by a host.
@@ -184,6 +191,24 @@ type RecallHit struct {
 // RecallResponse contains stored session search hits.
 type RecallResponse struct {
 	Hits []RecallHit `json:"hits"`
+}
+
+// MemoryCatalogRequest configures a memory catalog request.
+type MemoryCatalogRequest struct {
+	Limit int
+}
+
+// MemoryEntry describes one curated host memory.
+type MemoryEntry struct {
+	ID        string    `json:"id"`
+	Content   string    `json:"content"`
+	Tags      []string  `json:"tags,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+}
+
+// MemoryCatalogResponse contains curated host memories.
+type MemoryCatalogResponse struct {
+	Memories []MemoryEntry `json:"memories"`
 }
 
 // Options configures [New].
@@ -462,6 +487,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/v1/memories" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleMemories(w, r)
+		return
+	}
+
 	if r.URL.Path == "/v1/mcp/resources" {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
@@ -575,6 +609,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	}
 	if _, ok := s.host.(RecallHost); ok {
 		capabilities = append(capabilities, "recall")
+	}
+	if _, ok := s.host.(MemoryCatalogHost); ok {
+		capabilities = append(capabilities, "memories")
 	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:           true,
@@ -705,6 +742,31 @@ func (s *Server) handleRecall(w http.ResponseWriter, r *http.Request) {
 		hits.Hits = []RecallHit{}
 	}
 	writeJSON(w, http.StatusOK, RecallResponse{Hits: hits.Hits})
+}
+
+func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
+	limit, err := nonNegativeIntQuery(r, "limit")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error(), false)
+		return
+	}
+	host, ok := s.host.(MemoryCatalogHost)
+	if !ok {
+		writeJSON(w, http.StatusOK, MemoryCatalogResponse{Memories: []MemoryEntry{}})
+		return
+	}
+	catalog, err := host.MemoryCatalog(r.Context(), MemoryCatalogRequest{Limit: limit})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if catalog.Memories == nil {
+		catalog.Memories = []MemoryEntry{}
+	}
+	if limit > 0 && len(catalog.Memories) > limit {
+		catalog.Memories = catalog.Memories[:limit]
+	}
+	writeJSON(w, http.StatusOK, catalog)
 }
 
 func (s *Server) handleMCPResources(w http.ResponseWriter, r *http.Request) {
@@ -1049,6 +1111,18 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 
 func writeError(w http.ResponseWriter, status int, code, message string, retryable bool) {
 	writeJSON(w, status, errorResponse{Error: protocolError{Code: code, Message: message, Retryable: retryable}})
+}
+
+func nonNegativeIntQuery(r *http.Request, name string) (int, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(name))
+	if raw == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", name)
+	}
+	return n, nil
 }
 
 func writeSSE(w http.ResponseWriter, event EventEnvelope) error {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -191,6 +191,21 @@ func (h *recallHost) RecallSearch(_ context.Context, req RecallRequest) (RecallR
 	return RecallResponse{Hits: h.hits}, h.err
 }
 
+type memoryCatalogHost struct {
+	req      MemoryCatalogRequest
+	memories []MemoryEntry
+	err      error
+}
+
+func (memoryCatalogHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
+func (h *memoryCatalogHost) MemoryCatalog(_ context.Context, req MemoryCatalogRequest) (MemoryCatalogResponse, error) {
+	h.req = req
+	return MemoryCatalogResponse{Memories: h.memories}, h.err
+}
+
 func TestServerAuthAndHealth(t *testing.T) {
 	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
 	ts := httptest.NewServer(srv)
@@ -640,6 +655,80 @@ func TestServerRecallValidationAndUnsupportedHost(t *testing.T) {
 	}
 
 	resp = postJSON(t, ts.URL+"/v1/recall", "token", `{"query":"x","limit":-1}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("negative limit status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestServerMemories(t *testing.T) {
+	host := &memoryCatalogHost{memories: []MemoryEntry{
+		{
+			ID:        "mem_2",
+			Content:   "User prefers terse responses.",
+			Tags:      []string{"preference"},
+			Timestamp: time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:        "mem_1",
+			Content:   "User's Australian Shepherd is named Inkblot.",
+			Tags:      []string{"pet"},
+			Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+		},
+	}}
+	srv := newTestServer(t, host)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/memories", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated memories status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/memories?limit=1", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("memories status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var catalog MemoryCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Memories) != 1 || catalog.Memories[0].ID != "mem_2" || host.req.Limit != 1 {
+		t.Fatalf("catalog=%+v request=%+v", catalog.Memories, host.req)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/status", "token")
+	defer resp.Body.Close()
+	var status statusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(status.Capabilities, "memories") {
+		t.Fatalf("capabilities = %v, missing memories", status.Capabilities)
+	}
+}
+
+func TestServerMemoriesValidationAndUnsupportedHost(t *testing.T) {
+	srv := newTestServer(t, sessionOnlyHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := getJSON(t, ts.URL+"/v1/memories", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unsupported memories status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var catalog MemoryCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Memories) != 0 {
+		t.Fatalf("catalog = %+v, want empty", catalog.Memories)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/memories?limit=-1", "token")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("negative limit status = %d, want %d", resp.StatusCode, http.StatusBadRequest)

--- a/docs/adr/0010-daemon-protocol.md
+++ b/docs/adr/0010-daemon-protocol.md
@@ -145,7 +145,7 @@ Response:
   "version": 1,
   "active_runs": 0,
   "tools_count": 4,
-  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "recall", "status"]
+  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "memories", "recall", "status"]
 }
 ```
 
@@ -260,6 +260,33 @@ Response:
 
 Hosts that do not expose recall return `404`. A host that exposes
 recall advertises the `recall` capability in `/v1/status`.
+
+Daemon clients can inspect curated host memories without starting a
+run:
+
+```http
+GET /v1/memories?limit=20
+Authorization: Bearer <token>
+```
+
+Response:
+
+```json
+{
+  "memories": [
+    {
+      "id": "mem_1779638400000000000_ab12cd34",
+      "content": "The user prefers terse responses.",
+      "tags": ["preference"],
+      "timestamp": "2026-05-24T12:00:00Z"
+    }
+  ]
+}
+```
+
+Hosts that do not expose memories return an empty `memories` array. A
+host that exposes memories advertises the `memories` capability in
+`/v1/status`.
 
 ### 5. Runs and sessions
 


### PR DESCRIPTION
## Summary

- add authenticated daemon `GET /v1/memories` behind an optional memory catalog host capability
- have Peggy implement the capability using `ListMemories`
- add `glue connect --memories`, `--memories-json`, and `--memory-limit`
- document daemon memory catalog support in README, Peggy docs, changelog, and ADR-0010

Closes #236.

## Validation

- `go test ./daemon ./agents/peggy ./cmd/glue -run 'TestServerMemories|TestPeggyDaemonListsMemories|TestRunCLIConnectListsMemories|TestRunCLIConnectMemoriesValidation' -count=1`
- `go test ./daemon ./agents/peggy ./cmd/glue -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
