### PR TITLE
daemon: expose Peggy memory forget over connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,11 +649,12 @@ status-and-catalog preflight, or `--status`, `--tools`,
 `--mcp-resources`, or `--mcp-prompts` to render each view separately.
 Peggy daemons also support `--mcp-read` and `--mcp-prompt` for direct
 resource reads and prompt rendering, `--memories` for curated memory
-catalogs, plus `--recall` for direct memory/session search. Each
-inspect/action mode also has a `-json` form for scripts. Add `--usage`
-to `run` or prompt-mode `connect` to print provider-reported token usage
-on stderr without changing streamed stdout. Add the `--usage-*-price`
-flags when you want a local USD estimate from prices you supply.
+catalogs, `--forget-memory` for memory deletion, plus `--recall` for
+direct memory/session search. Each inspect/action mode also has a
+`-json` form for scripts. Add `--usage` to `run` or prompt-mode
+`connect` to print provider-reported token usage on stderr without
+changing streamed stdout. Add the `--usage-*-price` flags when you want
+a local USD estimate from prices you supply.
 
 Peggy can serve the same daemon protocol with the personal-assistant
 agent, settings, memory store, and coding tools loaded once:
@@ -662,6 +663,7 @@ agent, settings, memory store, and coding tools loaded once:
 go run ./agents/peggy/cmd/peggy serve --coding --workdir .
 go run ./cmd/glue connect --inspect
 go run ./cmd/glue connect --memories
+go run ./cmd/glue connect --forget-memory mem_123
 go run ./cmd/glue connect --mcp-resources
 go run ./cmd/glue connect --mcp-prompts
 go run ./cmd/glue connect --mcp-read --server filesystem --uri file:///workspace/README.md

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -61,6 +61,9 @@ not formally follow SemVer until v1.0.
   curated-memory listing through the daemon host, and
   `glue connect --memories` can render or JSON-export the live memory
   catalog with an optional limit.
+- **Daemon memory deletion.** `glue connect --forget-memory <id>` now
+  removes one curated memory from a Peggy daemon and can return the
+  removed record as JSON.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -298,6 +298,7 @@ session history and memory store.
 peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
 glue connect --memories
+glue connect --forget-memory mem_123
 glue connect --skills
 glue connect --roles
 glue connect --skill triage --arg issue=GLUE-123 --id cli:triage
@@ -329,8 +330,10 @@ daemon-advertised skills, daemon-advertised roles, and any
 daemon-advertised MCP resource/prompt catalogs. Use `--skills-json`,
 `--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
 `--mcp-read-json`, `--mcp-prompt-json`, `--recall-json`, or
-`--memories-json` when another client needs the payload as data. Add
-`--usage` to prompt or skill-mode `glue connect` when you want
+`--memories-json` when another client needs catalog/search payloads as
+data. Use `--forget-memory-json` when another client needs the removed
+memory record as data. Add `--usage` to prompt or skill-mode
+`glue connect` when you want
 provider-reported token usage on stderr. Add
 `--usage-input-price`, `--usage-output-price`, and optional cache price
 flags to estimate USD cost from prices you supply. Stop the daemon with
@@ -620,6 +623,8 @@ the same curated memory catalog:
 glue connect --memories
 glue connect --memories-json
 glue connect --memories --memory-limit 20
+glue connect --forget-memory mem_123
+glue connect --forget-memory mem_123 --forget-memory-json
 ```
 
 Search stored sessions and memories directly when using a SQLite store:

--- a/agents/peggy/daemon_test.go
+++ b/agents/peggy/daemon_test.go
@@ -454,6 +454,69 @@ func TestPeggyDaemonListsMemories(t *testing.T) {
 	}
 }
 
+func TestPeggyDaemonForgetsMemory(t *testing.T) {
+	p, err := New(Options{
+		Provider: &fakeProvider{text: "ok"},
+		Store:    filestore.New(filepath.Join(t.TempDir(), "sessions")),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+	keep, err := p.AddMemory(context.Background(), "User's Australian Shepherd is named Inkblot.", []string{"pet"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	drop, err := p.AddMemory(context.Background(), "User prefers terse responses.", []string{"preference"})
+	if err != nil {
+		t.Fatalf("AddMemory 2: %v", err)
+	}
+	srv, err := daemon.New(daemon.Options{
+		Host:  p,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatalf("daemon.New: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/memories/"+drop.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var forgotten daemon.MemoryForgetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&forgotten); err != nil {
+		t.Fatal(err)
+	}
+	if forgotten.Memory.ID != drop.ID || !strings.Contains(forgotten.Memory.Content, "terse") {
+		t.Fatalf("forgotten = %+v", forgotten.Memory)
+	}
+
+	var catalog daemon.MemoryCatalogResponse
+	getPeggyDaemonJSON(t, ts.URL+"/v1/memories", &catalog)
+	if len(catalog.Memories) != 1 || catalog.Memories[0].ID != keep.ID {
+		t.Fatalf("memories after forget = %+v", catalog.Memories)
+	}
+
+	var status struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	getPeggyDaemonJSON(t, ts.URL+"/v1/status", &status)
+	if !containsString(status.Capabilities, "memory_forget") {
+		t.Fatalf("capabilities = %v, missing memory_forget", status.Capabilities)
+	}
+}
+
 type startRunResponse struct {
 	RunID     string `json:"run_id"`
 	EventsURL string `json:"events_url"`

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -299,14 +299,31 @@ func (p *Peggy) MemoryCatalog(ctx context.Context, req daemon.MemoryCatalogReque
 	}
 	out := make([]daemon.MemoryEntry, 0, len(memories))
 	for _, memory := range memories {
-		out = append(out, daemon.MemoryEntry{
-			ID:        memory.ID,
-			Content:   memory.Content,
-			Tags:      append([]string(nil), memory.Tags...),
-			Timestamp: memory.Timestamp,
-		})
+		out = append(out, daemonMemoryEntry(memory))
 	}
 	return daemon.MemoryCatalogResponse{Memories: out}, nil
+}
+
+// MemoryForget implements daemon.MemoryForgetHost.
+func (p *Peggy) MemoryForget(ctx context.Context, req daemon.MemoryForgetRequest) (daemon.MemoryForgetResponse, error) {
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		return daemon.MemoryForgetResponse{}, errors.New("memory id is required")
+	}
+	memory, err := p.ForgetMemory(ctx, id)
+	if err != nil {
+		return daemon.MemoryForgetResponse{}, err
+	}
+	return daemon.MemoryForgetResponse{Memory: daemonMemoryEntry(memory)}, nil
+}
+
+func daemonMemoryEntry(memory Memory) daemon.MemoryEntry {
+	return daemon.MemoryEntry{
+		ID:        memory.ID,
+		Content:   memory.Content,
+		Tags:      append([]string(nil), memory.Tags...),
+		Timestamp: memory.Timestamp,
+	}
 }
 
 // MCPResourceCatalog implements daemon.MCPResourceCatalogHost.

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -410,6 +410,8 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	showMemories := flags.Bool("memories", false, "list daemon memories and exit without starting a run")
 	memoriesJSON := flags.Bool("memories-json", false, "print --memories output as JSON")
 	memoryLimit := flags.Int("memory-limit", 0, "maximum memories to return; 0 means no limit")
+	forgetMemoryID := flags.String("forget-memory", "", "delete one daemon memory by id and exit without starting a run")
+	forgetMemoryJSON := flags.Bool("forget-memory-json", false, "print --forget-memory output as JSON")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
@@ -460,14 +462,15 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 		*showMemories = true
 	}
 	showRecall := strings.TrimSpace(*recallQuery) != "" || *recallJSON
+	showForgetMemory := strings.TrimSpace(*forgetMemoryID) != "" || *forgetMemoryJSON
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, showForgetMemory, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --status, or --inspect")
+		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --forget-memory, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" && strings.TrimSpace(*skillName) == "" {
 		return errors.New("missing required --prompt or --skill")
@@ -524,6 +527,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if *showMemories {
 		return runConnectMemories(ctx, cfg, *memoryLimit, *memoriesJSON, stdout, client)
+	}
+	if showForgetMemory {
+		return runConnectForgetMemory(ctx, cfg, *forgetMemoryID, *forgetMemoryJSON, stdout, client)
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
@@ -754,6 +760,24 @@ func runConnectMemories(ctx context.Context, cfg connectConfig, limit int, jsonO
 	return nil
 }
 
+func runConnectForgetMemory(ctx context.Context, cfg connectConfig, id string, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("--forget-memory is required")
+	}
+	forgotten, err := requestDaemonForgetMemory(ctx, cfg, id, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(forgotten)
+	}
+	writeDaemonMemory(stdout, forgotten.Memory)
+	return nil
+}
+
 func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
 	status, err := fetchDaemonStatus(ctx, cfg, client)
 	if err != nil {
@@ -979,6 +1003,27 @@ func fetchDaemonMemories(ctx context.Context, cfg connectConfig, limit int, clie
 	return catalog, nil
 }
 
+func requestDaemonForgetMemory(ctx context.Context, cfg connectConfig, id string, client httpDoer) (daemon.MemoryForgetResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, cfg.BaseURL+"/v1/memories/"+url.PathEscape(id), nil)
+	if err != nil {
+		return daemon.MemoryForgetResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemon.MemoryForgetResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.MemoryForgetResponse{}, fmt.Errorf("daemon memory delete: %s", httpStatusError(resp))
+	}
+	var forgotten daemon.MemoryForgetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&forgotten); err != nil {
+		return daemon.MemoryForgetResponse{}, err
+	}
+	return forgotten, nil
+}
+
 func fetchDaemonMCPResources(ctx context.Context, cfg connectConfig, client httpDoer) (daemonMCPResourceCatalog, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/mcp/resources", nil)
 	if err != nil {
@@ -1194,18 +1239,23 @@ func writeDaemonMemories(w io.Writer, memories []daemon.MemoryEntry) {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		timestamp := ""
-		if !memory.Timestamp.IsZero() {
-			timestamp = memory.Timestamp.Format(time.RFC3339)
-		}
 		fmt.Fprintf(w, "%d. %s\n", i+1, memory.ID)
-		if timestamp != "" {
-			fmt.Fprintf(w, "  timestamp: %s\n", timestamp)
-		}
-		fmt.Fprintf(w, "  content: %s\n", oneLine(memory.Content))
-		if len(memory.Tags) > 0 {
-			fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
-		}
+		writeDaemonMemoryFields(w, memory)
+	}
+}
+
+func writeDaemonMemory(w io.Writer, memory daemon.MemoryEntry) {
+	fmt.Fprintln(w, memory.ID)
+	writeDaemonMemoryFields(w, memory)
+}
+
+func writeDaemonMemoryFields(w io.Writer, memory daemon.MemoryEntry) {
+	if !memory.Timestamp.IsZero() {
+		fmt.Fprintf(w, "  timestamp: %s\n", memory.Timestamp.Format(time.RFC3339))
+	}
+	fmt.Fprintf(w, "  content: %s\n", oneLine(memory.Content))
+	if len(memory.Tags) > 0 {
+		fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
 	}
 }
 
@@ -1812,6 +1862,7 @@ func printUsage(w io.Writer) {
   glue connect --mcp-prompt --server <name> --name <prompt> [--arg key=value] [--mcp-prompt-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --recall <query> [--recall-json] [--recall-memories] [--recall-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --memories [--memories-json] [--memory-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --forget-memory <id> [--forget-memory-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
@@ -1875,6 +1926,10 @@ Flags:
              Connect --memories mode: print JSON.
   --memory-limit
              Connect --memories mode: maximum memories; 0 means no limit.
+  --forget-memory
+             Connect mode: delete one daemon memory by id and exit without starting a run.
+  --forget-memory-json
+             Connect --forget-memory mode: print JSON.
   --server   MCP server name for --mcp-read or --mcp-prompt.
   --uri      MCP resource URI for --mcp-read.
   --name     MCP prompt name for --mcp-prompt.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -1752,6 +1752,111 @@ func TestRunCLIConnectMemoriesValidation(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectForgetsMemory(t *testing.T) {
+	var sawForget bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/memories/mem_1":
+			sawForget = true
+			if r.Method != http.MethodDelete {
+				t.Fatalf("forget method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("forget auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.MemoryForgetResponse{Memory: daemon.MemoryEntry{
+				ID:        "mem_1",
+				Content:   "User prefers terse responses.",
+				Tags:      []string{"preference"},
+				Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+			}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--forget-memory", "mem_1",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawForget || sawRun {
+		t.Fatalf("sawForget=%v sawRun=%v", sawForget, sawRun)
+	}
+	for _, want := range []string{
+		"mem_1",
+		"timestamp: 2026-05-24T12:00:00Z",
+		"content: User prefers terse responses.",
+		"tags: preference",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectForgetsMemoryJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/memories/mem_1" {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemon.MemoryForgetResponse{Memory: daemon.MemoryEntry{
+			ID:      "mem_1",
+			Content: "User prefers terse responses.",
+		}})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--forget-memory", "mem_1",
+		"--forget-memory-json",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var forgotten daemon.MemoryForgetResponse
+	if err := json.Unmarshal(stdout.Bytes(), &forgotten); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if forgotten.Memory.ID != "mem_1" {
+		t.Fatalf("forgotten = %+v", forgotten)
+	}
+}
+
+func TestRunCLIConnectForgetMemoryValidation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--forget-memory-json",
+		"--base-url", "http://daemon",
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code == 0 {
+		t.Fatal("code = 0, want forget-memory validation failure")
+	}
+	if !strings.Contains(stderr.String(), "--forget-memory is required") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestRunCLIConnectShowsStatus(t *testing.T) {
 	var sawStatus bool
 	var sawRun bool

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -83,6 +83,12 @@ type MemoryCatalogHost interface {
 	MemoryCatalog(context.Context, MemoryCatalogRequest) (MemoryCatalogResponse, error)
 }
 
+// MemoryForgetHost is optionally implemented by hosts that can delete one
+// curated memory record without starting a run.
+type MemoryForgetHost interface {
+	MemoryForget(context.Context, MemoryForgetRequest) (MemoryForgetResponse, error)
+}
+
 // SkillCatalogEntry describes one reusable skill advertised by a host.
 type SkillCatalogEntry struct {
 	Name        string `json:"name"`
@@ -209,6 +215,16 @@ type MemoryEntry struct {
 // MemoryCatalogResponse contains curated host memories.
 type MemoryCatalogResponse struct {
 	Memories []MemoryEntry `json:"memories"`
+}
+
+// MemoryForgetRequest selects one curated memory by stable id.
+type MemoryForgetRequest struct {
+	ID string `json:"id"`
+}
+
+// MemoryForgetResponse contains the deleted memory record.
+type MemoryForgetResponse struct {
+	Memory MemoryEntry `json:"memory"`
 }
 
 // Options configures [New].
@@ -496,6 +512,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if memoryID, ok := parseMemoryPath(r.URL.Path); ok {
+		if r.Method != http.MethodDelete {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleMemoryForget(w, r, memoryID)
+		return
+	}
+
 	if r.URL.Path == "/v1/mcp/resources" {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
@@ -612,6 +637,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	}
 	if _, ok := s.host.(MemoryCatalogHost); ok {
 		capabilities = append(capabilities, "memories")
+	}
+	if _, ok := s.host.(MemoryForgetHost); ok {
+		capabilities = append(capabilities, "memory_forget")
 	}
 	writeJSON(w, http.StatusOK, statusResponse{
 		OK:           true,
@@ -767,6 +795,25 @@ func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
 		catalog.Memories = catalog.Memories[:limit]
 	}
 	writeJSON(w, http.StatusOK, catalog)
+}
+
+func (s *Server) handleMemoryForget(w http.ResponseWriter, r *http.Request, id string) {
+	host, ok := s.host.(MemoryForgetHost)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "memory deletion is not supported by this host", false)
+		return
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "memory id is required", false)
+		return
+	}
+	forgotten, err := host.MemoryForget(r.Context(), MemoryForgetRequest{ID: id})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	writeJSON(w, http.StatusOK, forgotten)
 }
 
 func (s *Server) handleMCPResources(w http.ResponseWriter, r *http.Request) {
@@ -1092,6 +1139,19 @@ func parsePermissionDecisionPath(path string) (runID, permissionID string, ok bo
 
 func parseRunPath(path string) (string, bool) {
 	const prefix = "/v1/runs/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	raw := strings.TrimPrefix(path, prefix)
+	if raw == "" || strings.Contains(raw, "/") {
+		return "", false
+	}
+	id, err := url.PathUnescape(raw)
+	return id, err == nil && id != ""
+}
+
+func parseMemoryPath(path string) (string, bool) {
+	const prefix = "/v1/memories/"
 	if !strings.HasPrefix(path, prefix) {
 		return "", false
 	}

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -206,6 +206,21 @@ func (h *memoryCatalogHost) MemoryCatalog(_ context.Context, req MemoryCatalogRe
 	return MemoryCatalogResponse{Memories: h.memories}, h.err
 }
 
+type memoryForgetHost struct {
+	req    MemoryForgetRequest
+	memory MemoryEntry
+	err    error
+}
+
+func (memoryForgetHost) Session(context.Context, string, ...glue.SessionOption) (*glue.Session, error) {
+	return nil, errors.New("unused")
+}
+
+func (h *memoryForgetHost) MemoryForget(_ context.Context, req MemoryForgetRequest) (MemoryForgetResponse, error) {
+	h.req = req
+	return MemoryForgetResponse{Memory: h.memory}, h.err
+}
+
 func TestServerAuthAndHealth(t *testing.T) {
 	srv := newTestServer(t, glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}}))
 	ts := httptest.NewServer(srv)
@@ -732,6 +747,82 @@ func TestServerMemoriesValidationAndUnsupportedHost(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("negative limit status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestServerMemoryForget(t *testing.T) {
+	host := &memoryForgetHost{memory: MemoryEntry{
+		ID:        "mem_1",
+		Content:   "User prefers terse responses.",
+		Tags:      []string{"preference"},
+		Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+	}}
+	srv := newTestServer(t, host)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/memories/mem_1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated forget status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	req, err = http.NewRequest(http.MethodDelete, ts.URL+"/v1/memories/mem_1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("forget status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var forgotten MemoryForgetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&forgotten); err != nil {
+		t.Fatal(err)
+	}
+	if forgotten.Memory.ID != "mem_1" || host.req.ID != "mem_1" {
+		t.Fatalf("forgotten=%+v request=%+v", forgotten, host.req)
+	}
+
+	statusResp := getJSON(t, ts.URL+"/v1/status", "token")
+	defer statusResp.Body.Close()
+	var status statusResponse
+	if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(status.Capabilities, "memory_forget") {
+		t.Fatalf("capabilities = %v, missing memory_forget", status.Capabilities)
+	}
+}
+
+func TestServerMemoryForgetUnsupportedHost(t *testing.T) {
+	srv := newTestServer(t, sessionOnlyHost{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/memories/mem_1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unsupported forget status = %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 

--- a/docs/adr/0010-daemon-protocol.md
+++ b/docs/adr/0010-daemon-protocol.md
@@ -145,7 +145,7 @@ Response:
   "version": 1,
   "active_runs": 0,
   "tools_count": 4,
-  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "memories", "recall", "status"]
+  "capabilities": ["runs", "events", "permissions", "tools", "skills", "roles", "memories", "memory_forget", "recall", "status"]
 }
 ```
 
@@ -286,6 +286,30 @@ Response:
 
 Hosts that do not expose memories return an empty `memories` array. A
 host that exposes memories advertises the `memories` capability in
+`/v1/status`.
+
+Daemon clients can delete one curated host memory by stable id:
+
+```http
+DELETE /v1/memories/mem_1779638400000000000_ab12cd34
+Authorization: Bearer <token>
+```
+
+Response:
+
+```json
+{
+  "memory": {
+    "id": "mem_1779638400000000000_ab12cd34",
+    "content": "The user prefers terse responses.",
+    "tags": ["preference"],
+    "timestamp": "2026-05-24T12:00:00Z"
+  }
+}
+```
+
+Hosts that do not support memory deletion return `404`. A host that
+supports deletion advertises the `memory_forget` capability in
 `/v1/status`.
 
 ### 5. Runs and sessions


### PR DESCRIPTION
## Summary

- add authenticated daemon `DELETE /v1/memories/{id}` behind an optional host capability
- have Peggy implement the capability using `ForgetMemory`
- add `glue connect --forget-memory <id>` and `--forget-memory-json`
- document daemon memory deletion in README, Peggy docs, changelog, and ADR-0010

Closes #238.

## Validation

- `go test ./daemon ./agents/peggy ./cmd/glue -run 'TestServerMemoryForget|TestPeggyDaemonForgetsMemory|TestRunCLIConnectForgetsMemory|TestRunCLIConnectForgetMemoryValidation' -count=1`
- `go test ./daemon ./agents/peggy ./cmd/glue -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
