### PR TITLE
cmd/glue: show daemon memories in inspect output

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,8 @@ Use `--base-url`, `--token`, or `--metadata` when connecting to an
 explicit daemon endpoint. Use `--inspect` for a compact authenticated
 status-and-catalog preflight, or `--status`, `--tools`,
 `--mcp-resources`, or `--mcp-prompts` to render each view separately.
+When supported by the daemon, `--inspect` also includes memory entries;
+use `--memory-limit` to cap that section.
 Peggy daemons also support `--mcp-read` and `--mcp-prompt` for direct
 resource reads and prompt rendering, `--memories` for curated memory
 catalogs, `--forget-memory` for memory deletion, plus `--recall` for

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -64,6 +64,8 @@ not formally follow SemVer until v1.0.
 - **Daemon memory deletion.** `glue connect --forget-memory <id>` now
   removes one curated memory from a Peggy daemon and can return the
   removed record as JSON.
+- **Inspect memory panel.** `glue connect --inspect` now includes
+  daemon-advertised memories, with `--memory-limit` to cap the section.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -326,8 +326,9 @@ Useful `serve` flags:
 
 Startup output prints the `base_url` and metadata path, never the
 bearer token. `glue connect --inspect` includes status, tools,
-daemon-advertised skills, daemon-advertised roles, and any
-daemon-advertised MCP resource/prompt catalogs. Use `--skills-json`,
+daemon-advertised skills, daemon-advertised roles, daemon-advertised
+memories, and any daemon-advertised MCP resource/prompt catalogs. Use
+`--memory-limit` to cap the memory section. Use `--skills-json`,
 `--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
 `--mcp-read-json`, `--mcp-prompt-json`, `--recall-json`, or
 `--memories-json` when another client needs catalog/search payloads as

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -173,6 +173,7 @@ type daemonInspect struct {
 	Tools        []daemonToolCatalogEntry         `json:"tools"`
 	Skills       []daemon.SkillCatalogEntry       `json:"skills,omitempty"`
 	Roles        []daemon.RoleCatalogEntry        `json:"roles,omitempty"`
+	Memories     []daemon.MemoryEntry             `json:"memories,omitempty"`
 	MCPResources []daemon.MCPResourceCatalogEntry `json:"mcp_resources,omitempty"`
 	MCPPrompts   []daemon.MCPPromptCatalogEntry   `json:"mcp_prompts,omitempty"`
 }
@@ -535,7 +536,7 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
 	}
 	if *showInspect {
-		return runConnectInspect(ctx, cfg, *inspectJSON, stdout, client)
+		return runConnectInspect(ctx, cfg, *memoryLimit, *inspectJSON, stdout, client)
 	}
 	return runConnect(ctx, cfg, *showUsage, *usagePricing, stdin, stdout, stderr, client)
 }
@@ -792,7 +793,10 @@ func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, s
 	return nil
 }
 
-func runConnectInspect(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+func runConnectInspect(ctx context.Context, cfg connectConfig, memoryLimit int, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	if memoryLimit < 0 {
+		return errors.New("--memory-limit must be non-negative")
+	}
 	status, err := fetchDaemonStatus(ctx, cfg, client)
 	if err != nil {
 		return err
@@ -815,6 +819,13 @@ func runConnectInspect(ctx context.Context, cfg connectConfig, jsonOutput bool, 
 			return err
 		}
 		inspect.Roles = roles.Roles
+	}
+	if daemonHasCapability(status, "memories") {
+		memories, err := fetchDaemonMemories(ctx, cfg, memoryLimit, client)
+		if err != nil {
+			return err
+		}
+		inspect.Memories = memories.Memories
 	}
 	if daemonHasCapability(status, "mcp_resources") {
 		resources, err := fetchDaemonMCPResources(ctx, cfg, client)
@@ -888,6 +899,11 @@ func writeDaemonInspect(w io.Writer, inspect daemonInspect) {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "roles:")
 		writeDaemonRoleCatalogIndented(w, inspect.Roles, "  ")
+	}
+	if daemonHasCapability(inspect.Status, "memories") {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "memories:")
+		writeDaemonMemoriesIndented(w, inspect.Memories, "  ")
 	}
 	if daemonHasCapability(inspect.Status, "mcp_resources") {
 		fmt.Fprintln(w)
@@ -1231,31 +1247,35 @@ func writeDaemonRoleCatalogIndented(w io.Writer, roles []daemon.RoleCatalogEntry
 }
 
 func writeDaemonMemories(w io.Writer, memories []daemon.MemoryEntry) {
+	writeDaemonMemoriesIndented(w, memories, "")
+}
+
+func writeDaemonMemoriesIndented(w io.Writer, memories []daemon.MemoryEntry, indent string) {
 	if len(memories) == 0 {
-		fmt.Fprintln(w, "No daemon memories reported.")
+		fmt.Fprintf(w, "%sNo daemon memories reported.\n", indent)
 		return
 	}
 	for i, memory := range memories {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintf(w, "%d. %s\n", i+1, memory.ID)
-		writeDaemonMemoryFields(w, memory)
+		fmt.Fprintf(w, "%s%d. %s\n", indent, i+1, memory.ID)
+		writeDaemonMemoryFields(w, memory, indent)
 	}
 }
 
 func writeDaemonMemory(w io.Writer, memory daemon.MemoryEntry) {
 	fmt.Fprintln(w, memory.ID)
-	writeDaemonMemoryFields(w, memory)
+	writeDaemonMemoryFields(w, memory, "")
 }
 
-func writeDaemonMemoryFields(w io.Writer, memory daemon.MemoryEntry) {
+func writeDaemonMemoryFields(w io.Writer, memory daemon.MemoryEntry, indent string) {
 	if !memory.Timestamp.IsZero() {
-		fmt.Fprintf(w, "  timestamp: %s\n", memory.Timestamp.Format(time.RFC3339))
+		fmt.Fprintf(w, "%s  timestamp: %s\n", indent, memory.Timestamp.Format(time.RFC3339))
 	}
-	fmt.Fprintf(w, "  content: %s\n", oneLine(memory.Content))
+	fmt.Fprintf(w, "%s  content: %s\n", indent, oneLine(memory.Content))
 	if len(memory.Tags) > 0 {
-		fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
+		fmt.Fprintf(w, "%s  tags: %s\n", indent, strings.Join(memory.Tags, ", "))
 	}
 }
 
@@ -1925,7 +1945,7 @@ Flags:
   --memories-json
              Connect --memories mode: print JSON.
   --memory-limit
-             Connect --memories mode: maximum memories; 0 means no limit.
+             Connect --memories/--inspect mode: maximum memories; 0 means no limit.
   --forget-memory
              Connect mode: delete one daemon memory by id and exit without starting a run.
   --forget-memory-json

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -2028,13 +2028,21 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
 				OK:           true,
 				Version:      1,
-				Capabilities: []string{"status", "tools"},
+				Capabilities: []string{"status", "tools", "memories"},
 			})
 		case "/v1/tools":
 			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{Tools: []daemonToolCatalogEntry{{
 				Name:               "shell_exec",
 				RequiresPermission: true,
 				PermissionAction:   "exec",
+			}}})
+		case "/v1/memories":
+			if got := r.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("limit query = %q, want 1", got)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.MemoryCatalogResponse{Memories: []daemon.MemoryEntry{{
+				ID:      "mem_1",
+				Content: "User prefers terse responses.",
 			}}})
 		default:
 			http.NotFound(w, r)
@@ -2046,6 +2054,7 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 	code := runCLIWithDeps(context.Background(), []string{
 		"connect",
 		"--inspect-json",
+		"--memory-limit", "1",
 		"--base-url", ts.URL,
 		"--token", "tok",
 		"--metadata", "",
@@ -2063,11 +2072,15 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 	if len(inspect.Tools) != 1 || inspect.Tools[0].Name != "shell_exec" || inspect.Tools[0].PermissionAction != "exec" {
 		t.Fatalf("tools = %+v", inspect.Tools)
 	}
+	if len(inspect.Memories) != 1 || inspect.Memories[0].ID != "mem_1" {
+		t.Fatalf("memories = %+v", inspect.Memories)
+	}
 }
 
 func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 	var sawSkills bool
 	var sawRoles bool
+	var sawMemories bool
 	var sawResources bool
 	var sawPrompts bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2076,7 +2089,7 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
 				OK:           true,
 				Version:      1,
-				Capabilities: []string{"status", "tools", "skills", "roles", "mcp_resources", "mcp_prompts"},
+				Capabilities: []string{"status", "tools", "skills", "roles", "memories", "mcp_resources", "mcp_prompts"},
 			})
 		case "/v1/tools":
 			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{})
@@ -2091,6 +2104,15 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemonRoleCatalog{Roles: []daemon.RoleCatalogEntry{{
 				Name:  "reviewer",
 				Model: "fast-model",
+			}}})
+		case "/v1/memories":
+			sawMemories = true
+			if got := r.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("limit query = %q, want 1", got)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.MemoryCatalogResponse{Memories: []daemon.MemoryEntry{{
+				ID:      "mem_1",
+				Content: "User prefers terse responses.",
 			}}})
 		case "/v1/mcp/resources":
 			sawResources = true
@@ -2115,6 +2137,7 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 	code := runCLIWithDeps(context.Background(), []string{
 		"connect",
 		"--inspect",
+		"--memory-limit", "1",
 		"--base-url", ts.URL,
 		"--token", "tok",
 		"--metadata", "",
@@ -2122,8 +2145,8 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("code = %d stderr=%q", code, stderr.String())
 	}
-	if !sawSkills || !sawRoles || !sawResources || !sawPrompts {
-		t.Fatalf("sawSkills=%v sawRoles=%v sawResources=%v sawPrompts=%v", sawSkills, sawRoles, sawResources, sawPrompts)
+	if !sawSkills || !sawRoles || !sawMemories || !sawResources || !sawPrompts {
+		t.Fatalf("sawSkills=%v sawRoles=%v sawMemories=%v sawResources=%v sawPrompts=%v", sawSkills, sawRoles, sawMemories, sawResources, sawPrompts)
 	}
 	for _, want := range []string{
 		"skills:",
@@ -2131,6 +2154,9 @@ func TestRunCLIConnectInspectIncludesMCPCatalogs(t *testing.T) {
 		"roles:",
 		"reviewer",
 		"model: fast-model",
+		"memories:",
+		"mem_1",
+		"content: User prefers terse responses.",
 		"mcp_resources:",
 		"file:///workspace/README.md",
 		"mcp_prompts:",


### PR DESCRIPTION
## Summary

- include daemon memory entries in `glue connect --inspect` when the daemon advertises `memories`
- include memories in `--inspect-json` payloads
- let `--memory-limit` cap the inspect memory section
- update README, Peggy docs, and changelog

Closes #240.

## Validation

- `go test ./cmd/glue -run 'TestRunCLIConnectInspectsDaemonJSON|TestRunCLIConnectInspectIncludesMCPCatalogs|TestRunCLIConnectMemoriesValidation' -count=1`
- `go test ./cmd/glue -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`
