### PR TITLE
agents/peggy: add telegram daemon memory commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,11 @@ allowlist and inline permission buttons:
 go run ./agents/peggy/cmd/peggy-telegram --daemon
 ```
 
+In daemon-client mode, allowlisted Telegram chats can also use
+`/memories`, `/recall <query>`, `/recall_memories <query>`, and
+`/forget_memory <id>` for memory inspection, search, and correction
+without starting a model run.
+
 Peggy can assign permission tiers by daemon client/channel in
 `settings.json`. The default remains `prompt`; `read_only` denies
 side-effecting tools before any client prompt, and `trusted` allows

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -66,6 +66,10 @@ not formally follow SemVer until v1.0.
   removed record as JSON.
 - **Inspect memory panel.** `glue connect --inspect` now includes
   daemon-advertised memories, with `--memory-limit` to cap the section.
+- **Telegram daemon memory commands.** In daemon-client mode,
+  allowlisted Telegram chats can use `/memories`, `/recall`,
+  `/recall_memories`, and `/forget_memory` to list, search, and delete
+  curated daemon memory without starting a model run.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -349,6 +349,9 @@ peggy-telegram --daemon
 In daemon-client mode, Telegram keeps its chat allowlist and inline
 permission buttons, but Peggy, memory, coding tools, and remembered
 permission scopes live in the daemon process.
+Allowlisted chats can also use `/memories [limit]`, `/recall <query>`,
+`/recall_memories <query>`, and `/forget_memory <id>` to inspect and
+correct daemon memory without starting a model run.
 
 Permission tiers apply in daemon mode by daemon `client_id`: `cli:*`
 uses the `cli` tier and `telegram:<chat_id>` uses the `telegram` tier.
@@ -628,6 +631,10 @@ glue connect --forget-memory mem_123
 glue connect --forget-memory mem_123 --forget-memory-json
 ```
 
+Telegram daemon-client users can run the same memory-management loop
+from an allowlisted chat with `/memories [limit]` and
+`/forget_memory <id>`.
+
 Search stored sessions and memories directly when using a SQLite store:
 
 ```sh
@@ -645,9 +652,11 @@ glue connect --recall "preference" --recall-memories
 glue connect --recall "project" --recall-json
 ```
 
-`peggy recall` and daemon `glue connect --recall` use the configured
-store only; neither starts a provider. File-backed stores do not
-support search, so use the default SQLite store for recall.
+Telegram daemon-client users can run `/recall <query>` or
+`/recall_memories <query>` from an allowlisted chat. `peggy recall`,
+daemon `glue connect --recall`, and Telegram daemon recall commands use
+the configured store only; none starts a provider. File-backed stores do
+not support search, so use the default SQLite store for recall.
 
 ## What Peggy supports today
 

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -67,6 +67,17 @@ peggy-telegram --daemon
 `GLUE_DAEMON_TOKEN`. Telegram still enforces `allow_chats` before any
 daemon request is sent.
 
+Daemon-client mode also supports memory commands from allowlisted
+chats without starting a model run:
+
+```text
+/memories
+/memories 20
+/recall Australian Shepherd
+/recall_memories preference
+/forget_memory mem_123
+```
+
 You can also put daemon settings under `channels.telegram.daemon`:
 
 ```json
@@ -219,6 +230,8 @@ binary allowlist, overwrite policy, timeouts, and output limits.
   session transcript / sqlite store.
 - Inline-keyboard permission prompts for side-effecting coding tools
   in allowlisted chats.
+- Daemon-client memory commands for listing, recall search,
+  memories-only recall, and curated-memory deletion.
 - Optional Peggy permission tiers for prompt/read-only/trusted channel
   behavior.
 

--- a/agents/peggy/channels/telegram/channel.go
+++ b/agents/peggy/channels/telegram/channel.go
@@ -225,6 +225,18 @@ func (c *Channel) handleUpdate(ctx context.Context, u Update) {
 	var text string
 	var err error
 	if c.daemon != nil {
+		if reply, handled, commandErr := c.daemon.Command(ctx, u.Message.Text); handled {
+			if commandErr != nil {
+				fmt.Fprintf(c.stderr, "telegram: daemon command failed for chat %d: %v\n", chatID, commandErr)
+				reply = "Command error: " + commandErr.Error()
+			}
+			if strings.TrimSpace(reply) != "" {
+				if err := c.api.SendMessage(ctx, chatID, strings.TrimSpace(reply)); err != nil {
+					fmt.Fprintf(c.stderr, "telegram: send to chat %d: %v\n", chatID, err)
+				}
+			}
+			return
+		}
 		text, err = c.daemon.Prompt(ctx, sessionID, u.Message.Text, c.api, chatID)
 	} else {
 		text, err = c.peggy.Prompt(ctx, sessionID, u.Message.Text, &buf)

--- a/agents/peggy/channels/telegram/daemon_client.go
+++ b/agents/peggy/channels/telegram/daemon_client.go
@@ -62,6 +62,11 @@ type daemonPermissionDecision struct {
 	RememberFor string `json:"remember_for,omitempty"`
 }
 
+const (
+	defaultTelegramMemoryLimit = 10
+	defaultTelegramRecallLimit = 5
+)
+
 // ResolveDaemonClientConfig applies metadata and environment fallback rules.
 func ResolveDaemonClientConfig(cfg DaemonClientConfig) (DaemonClientConfig, error) {
 	if strings.TrimSpace(cfg.MetadataPath) == "" {
@@ -133,6 +138,62 @@ func (d *DaemonClient) Prompt(ctx context.Context, sessionID, text string, api *
 	return d.streamRun(ctx, start, api, chatID, clientID)
 }
 
+// Command handles Telegram slash commands that map to daemon runtime actions.
+func (d *DaemonClient) Command(ctx context.Context, text string) (string, bool, error) {
+	if d == nil {
+		return "", false, errors.New("telegram daemon: client is not configured")
+	}
+	trimmed := strings.TrimSpace(text)
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], "/") {
+		return "", false, nil
+	}
+	token := fields[0]
+	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, token))
+	switch telegramCommandName(token) {
+	case "memories":
+		limit, err := parseTelegramMemoryLimit(rest)
+		if err != nil {
+			return "", true, err
+		}
+		catalog, err := d.memoryCatalog(ctx, limit)
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramMemories(catalog.Memories), true, nil
+	case "recall":
+		if rest == "" {
+			return "", true, errors.New("/recall query is required")
+		}
+		recall, err := d.recall(ctx, daemon.RecallRequest{Query: rest, Limit: defaultTelegramRecallLimit})
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramRecallHits(recall.Hits), true, nil
+	case "recall_memories":
+		if rest == "" {
+			return "", true, errors.New("/recall_memories query is required")
+		}
+		recall, err := d.recall(ctx, daemon.RecallRequest{Query: rest, Limit: defaultTelegramRecallLimit, MemoriesOnly: true})
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramRecallHits(recall.Hits), true, nil
+	case "forget_memory":
+		id, err := parseTelegramForgetMemoryID(rest)
+		if err != nil {
+			return "", true, err
+		}
+		forgotten, err := d.forgetMemory(ctx, id)
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramForgottenMemory(forgotten.Memory), true, nil
+	default:
+		return "", false, nil
+	}
+}
+
 func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api *API) bool {
 	if d == nil || !strings.HasPrefix(cb.Data, permissionCallbackPrefix) {
 		return false
@@ -171,6 +232,83 @@ func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api
 		answerDaemonCallback(ctx, api, cb.ID, "Denied.")
 	}
 	return true
+}
+
+func (d *DaemonClient) recall(ctx context.Context, in daemon.RecallRequest) (daemon.RecallResponse, error) {
+	body, _ := json.Marshal(in)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+"/v1/recall", bytes.NewReader(body))
+	if err != nil {
+		return daemon.RecallResponse{}, err
+	}
+	d.authorize(req)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemon.RecallResponse{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.RecallResponse{}, fmt.Errorf("telegram daemon: recall: %s", httpStatusText(resp))
+	}
+	var out daemon.RecallResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemon.RecallResponse{}, err
+	}
+	if out.Hits == nil {
+		out.Hits = []daemon.RecallHit{}
+	}
+	return out, nil
+}
+
+func (d *DaemonClient) memoryCatalog(ctx context.Context, limit int) (daemon.MemoryCatalogResponse, error) {
+	endpoint := d.baseURL + "/v1/memories"
+	if limit > 0 {
+		values := url.Values{}
+		values.Set("limit", strconv.Itoa(limit))
+		endpoint += "?" + values.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return daemon.MemoryCatalogResponse{}, err
+	}
+	d.authorize(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemon.MemoryCatalogResponse{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.MemoryCatalogResponse{}, fmt.Errorf("telegram daemon: memories: %s", httpStatusText(resp))
+	}
+	var out daemon.MemoryCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemon.MemoryCatalogResponse{}, err
+	}
+	if out.Memories == nil {
+		out.Memories = []daemon.MemoryEntry{}
+	}
+	return out, nil
+}
+
+func (d *DaemonClient) forgetMemory(ctx context.Context, id string) (daemon.MemoryForgetResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, d.baseURL+"/v1/memories/"+url.PathEscape(id), nil)
+	if err != nil {
+		return daemon.MemoryForgetResponse{}, err
+	}
+	d.authorize(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemon.MemoryForgetResponse{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.MemoryForgetResponse{}, fmt.Errorf("telegram daemon: forget memory: %s", httpStatusText(resp))
+	}
+	var out daemon.MemoryForgetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemon.MemoryForgetResponse{}, err
+	}
+	return out, nil
 }
 
 func (d *DaemonClient) startRun(ctx context.Context, sessionID, text, clientID string) (daemonStartRunResponse, error) {
@@ -320,6 +458,106 @@ func (d *DaemonClient) print(format string, args ...any) {
 	if d.stderr != nil {
 		_, _ = fmt.Fprintf(d.stderr, format, args...)
 	}
+}
+
+func telegramCommandName(token string) string {
+	name := strings.TrimPrefix(strings.TrimSpace(token), "/")
+	if at := strings.IndexByte(name, '@'); at >= 0 {
+		name = name[:at]
+	}
+	return strings.ToLower(name)
+}
+
+func parseTelegramMemoryLimit(rest string) (int, error) {
+	if strings.TrimSpace(rest) == "" {
+		return defaultTelegramMemoryLimit, nil
+	}
+	fields := strings.Fields(rest)
+	if len(fields) != 1 {
+		return 0, errors.New("usage: /memories [limit]")
+	}
+	limit, err := strconv.Atoi(fields[0])
+	if err != nil || limit < 0 {
+		return 0, errors.New("/memories limit must be non-negative")
+	}
+	return limit, nil
+}
+
+func parseTelegramForgetMemoryID(rest string) (string, error) {
+	fields := strings.Fields(rest)
+	if len(fields) != 1 {
+		return "", errors.New("usage: /forget_memory <id>")
+	}
+	return fields[0], nil
+}
+
+func formatTelegramMemories(memories []daemon.MemoryEntry) string {
+	if len(memories) == 0 {
+		return "No memories."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Memories (%d):\n", len(memories))
+	for i, memory := range memories {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, memory.ID)
+		if !memory.Timestamp.IsZero() {
+			fmt.Fprintf(&b, "   %s\n", memory.Timestamp.Format(time.RFC3339))
+		}
+		fmt.Fprintf(&b, "   %s\n", telegramOneLine(memory.Content, 260))
+		if len(memory.Tags) > 0 {
+			fmt.Fprintf(&b, "   tags: %s\n", strings.Join(memory.Tags, ", "))
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func formatTelegramRecallHits(hits []daemon.RecallHit) string {
+	if len(hits) == 0 {
+		return "No recall hits."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Recall hits (%d):\n", len(hits))
+	for i, hit := range hits {
+		sessionID := hit.SessionID
+		if sessionID == "" {
+			sessionID = "(unknown session)"
+		}
+		fmt.Fprintf(&b, "%d. %s#%d", i+1, sessionID, hit.Index)
+		if hit.Role != "" {
+			fmt.Fprintf(&b, " %s", hit.Role)
+		}
+		fmt.Fprintln(&b)
+		if !hit.Timestamp.IsZero() {
+			fmt.Fprintf(&b, "   %s\n", hit.Timestamp.Format(time.RFC3339))
+		}
+		fmt.Fprintf(&b, "   %s\n", telegramOneLine(hit.Snippet, 260))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func formatTelegramForgottenMemory(memory daemon.MemoryEntry) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Forgot %s", memory.ID)
+	if memory.Content != "" {
+		fmt.Fprintf(&b, ":\n%s", telegramOneLine(memory.Content, 260))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func telegramOneLine(text string, maxRunes int) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if maxRunes <= 0 {
+		return text
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	const suffix = " ... [truncated]"
+	suffixRunes := []rune(suffix)
+	if maxRunes <= len(suffixRunes) {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-len(suffixRunes)]) + suffix
 }
 
 func daemonTelegramClientID(chatID int64) string {

--- a/agents/peggy/channels/telegram/daemon_client_test.go
+++ b/agents/peggy/channels/telegram/daemon_client_test.go
@@ -110,6 +110,146 @@ func TestDaemonClientMessageStartsRunAndSendsText(t *testing.T) {
 	}
 }
 
+func TestDaemonClientMemoryCommandsUseDaemonWithoutRun(t *testing.T) {
+	var (
+		starts         int
+		memoryLimit    string
+		deletePath     string
+		recallRequests []daemon.RecallRequest
+	)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+			t.Errorf("auth = %q", auth)
+		}
+		switch r.URL.Path {
+		case "/v1/sessions/telegram:123/runs":
+			starts++
+			http.Error(w, "commands should not start runs", http.StatusInternalServerError)
+		case "/v1/memories":
+			if r.Method != http.MethodGet {
+				t.Errorf("memories method = %s", r.Method)
+			}
+			memoryLimit = r.URL.Query().Get("limit")
+			writeJSON(t, w, http.StatusOK, daemon.MemoryCatalogResponse{Memories: []daemon.MemoryEntry{{
+				ID:        "mem_1",
+				Content:   "Project launch is Friday.",
+				Tags:      []string{"project"},
+				Timestamp: time.Date(2026, 5, 25, 1, 2, 3, 0, time.UTC),
+			}}})
+		case "/v1/recall":
+			if r.Method != http.MethodPost {
+				t.Errorf("recall method = %s", r.Method)
+			}
+			var req daemon.RecallRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			recallRequests = append(recallRequests, req)
+			writeJSON(t, w, http.StatusOK, daemon.RecallResponse{Hits: []daemon.RecallHit{{
+				SessionID: "telegram:123",
+				Index:     7,
+				Role:      glue.MessageRoleAssistant,
+				Snippet:   "The launch checklist is ready.",
+				Score:     1.5,
+			}}})
+		case "/v1/memories/mem_1":
+			if r.Method != http.MethodDelete {
+				t.Errorf("forget method = %s", r.Method)
+			}
+			deletePath = r.URL.Path
+			writeJSON(t, w, http.StatusOK, daemon.MemoryForgetResponse{Memory: daemon.MemoryEntry{
+				ID:      "mem_1",
+				Content: "Project launch is Friday.",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/memories@PeggyBot 2"))
+	if memoryLimit != "2" {
+		t.Fatalf("memory limit = %q, want 2", memoryLimit)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "mem_1") || !strings.Contains(got, "Project launch is Friday") {
+		t.Fatalf("memories reply = %q", got)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(2, 123, "/recall project launch"))
+	if len(recallRequests) != 1 {
+		t.Fatalf("recall requests = %d, want 1", len(recallRequests))
+	}
+	if recallRequests[0].Query != "project launch" || recallRequests[0].Limit != defaultTelegramRecallLimit || recallRequests[0].MemoriesOnly {
+		t.Fatalf("recall request = %+v", recallRequests[0])
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "telegram:123#7") || !strings.Contains(got, "launch checklist") {
+		t.Fatalf("recall reply = %q", got)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(3, 123, "/recall_memories launch"))
+	if len(recallRequests) != 2 {
+		t.Fatalf("recall requests = %d, want 2", len(recallRequests))
+	}
+	if recallRequests[1].Query != "launch" || recallRequests[1].Limit != defaultTelegramRecallLimit || !recallRequests[1].MemoriesOnly {
+		t.Fatalf("recall memories request = %+v", recallRequests[1])
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(4, 123, "/forget_memory mem_1"))
+	if deletePath != "/v1/memories/mem_1" {
+		t.Fatalf("delete path = %q", deletePath)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Forgot mem_1") || !strings.Contains(got, "Project launch is Friday") {
+		t.Fatalf("forget reply = %q", got)
+	}
+	if starts != 0 {
+		t.Fatalf("daemon runs started = %d, want 0", starts)
+	}
+}
+
+func TestDaemonClientMemoryCommandValidationDoesNotCallDaemon(t *testing.T) {
+	var requests int
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/recall"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Command error: /recall query is required") {
+		t.Fatalf("validation reply = %q", got)
+	}
+}
+
 func TestDaemonClientAllowlistBeforeDaemonRequest(t *testing.T) {
 	var starts int
 	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {


### PR DESCRIPTION
## Summary
- Add Telegram daemon slash-command handling for `/memories`, `/recall`, `/recall_memories`, and `/forget_memory`.
- Route those commands to authenticated daemon memory/recall endpoints without starting a model run; regular daemon messages still use the existing prompt/SSE path.
- Document the Telegram memory commands in the root README, Peggy README, Telegram README, and Peggy changelog.

Closes #242

## Validation
- `go test ./agents/peggy/channels/telegram -run 'TestDaemonClient(MemoryCommandsUseDaemonWithoutRun|MemoryCommandValidationDoesNotCallDaemon|MessageStartsRunAndSendsText|AllowlistBeforeDaemonRequest)' -count=1`
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./agents/peggy -run 'Test.*Memory|Test.*Recall|Test.*Daemon|Test.*Telegram' -count=1`
- `go test ./agents/peggy/... -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`