### PR TITLE
agents/peggy: add telegram daemon skill commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,9 +687,9 @@ go run ./agents/peggy/cmd/peggy-telegram --daemon
 ```
 
 In daemon-client mode, allowlisted Telegram chats can also use
-`/memories`, `/recall <query>`, `/recall_memories <query>`, and
-`/forget_memory <id>` for memory inspection, search, and correction
-without starting a model run.
+`/skills`, `/skill <name> key=value`, `/memories`, `/recall <query>`,
+`/recall_memories <query>`, and `/forget_memory <id>` for reusable
+workflow runs plus memory inspection, search, and correction.
 
 Peggy can assign permission tiers by daemon client/channel in
 `settings.json`. The default remains `prompt`; `read_only` denies

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -70,6 +70,10 @@ not formally follow SemVer until v1.0.
   allowlisted Telegram chats can use `/memories`, `/recall`,
   `/recall_memories`, and `/forget_memory` to list, search, and delete
   curated daemon memory without starting a model run.
+- **Telegram daemon skill commands.** In daemon-client mode,
+  allowlisted Telegram chats can use `/skills` to inspect reusable
+  workspace skills and `/skill <name> key=value` to run one through the
+  shared daemon.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -349,9 +349,10 @@ peggy-telegram --daemon
 In daemon-client mode, Telegram keeps its chat allowlist and inline
 permission buttons, but Peggy, memory, coding tools, and remembered
 permission scopes live in the daemon process.
-Allowlisted chats can also use `/memories [limit]`, `/recall <query>`,
-`/recall_memories <query>`, and `/forget_memory <id>` to inspect and
-correct daemon memory without starting a model run.
+Allowlisted chats can also use `/skills`, `/skill <name> key=value`,
+`/memories [limit]`, `/recall <query>`, `/recall_memories <query>`,
+and `/forget_memory <id>` to run workspace skills and inspect or
+correct daemon memory from chat.
 
 Permission tiers apply in daemon mode by daemon `client_id`: `cli:*`
 uses the `cli` tier and `telegram:<chat_id>` uses the `telegram` tier.
@@ -634,6 +635,13 @@ glue connect --forget-memory mem_123 --forget-memory-json
 Telegram daemon-client users can run the same memory-management loop
 from an allowlisted chat with `/memories [limit]` and
 `/forget_memory <id>`.
+
+They can also inspect and run reusable workspace skills from chat:
+
+```text
+/skills
+/skill triage issue=GLUE-123
+```
 
 Search stored sessions and memories directly when using a SQLite store:
 

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -68,9 +68,12 @@ peggy-telegram --daemon
 daemon request is sent.
 
 Daemon-client mode also supports memory commands from allowlisted
-chats without starting a model run:
+chats without starting a model run, plus skill commands for reusable
+workspace workflows:
 
 ```text
+/skills
+/skill triage issue=GLUE-123
 /memories
 /memories 20
 /recall Australian Shepherd
@@ -230,6 +233,8 @@ binary allowlist, overwrite policy, timeouts, and output limits.
   session transcript / sqlite store.
 - Inline-keyboard permission prompts for side-effecting coding tools
   in allowlisted chats.
+- Daemon-client skill commands for listing and running reusable
+  workspace skills from chat.
 - Daemon-client memory commands for listing, recall search,
   memories-only recall, and curated-memory deletion.
 - Optional Peggy permission tiers for prompt/read-only/trusted channel

--- a/agents/peggy/channels/telegram/channel.go
+++ b/agents/peggy/channels/telegram/channel.go
@@ -225,7 +225,7 @@ func (c *Channel) handleUpdate(ctx context.Context, u Update) {
 	var text string
 	var err error
 	if c.daemon != nil {
-		if reply, handled, commandErr := c.daemon.Command(ctx, u.Message.Text); handled {
+		if reply, handled, commandErr := c.daemon.Command(ctx, sessionID, u.Message.Text, c.api, chatID); handled {
 			if commandErr != nil {
 				fmt.Fprintf(c.stderr, "telegram: daemon command failed for chat %d: %v\n", chatID, commandErr)
 				reply = "Command error: " + commandErr.Error()

--- a/agents/peggy/channels/telegram/daemon_client.go
+++ b/agents/peggy/channels/telegram/daemon_client.go
@@ -41,13 +41,19 @@ type daemonPendingPermission struct {
 }
 
 type daemonStartRunPayload struct {
-	Text     string `json:"text"`
-	ClientID string `json:"client_id,omitempty"`
+	Text      string            `json:"text,omitempty"`
+	Skill     string            `json:"skill,omitempty"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+	ClientID  string            `json:"client_id,omitempty"`
 }
 
 type daemonStartRunResponse struct {
 	RunID     string `json:"run_id"`
 	EventsURL string `json:"events_url"`
+}
+
+type daemonSkillCatalog struct {
+	Skills []daemon.SkillCatalogEntry `json:"skills"`
 }
 
 type daemonPermissionPayload struct {
@@ -131,7 +137,7 @@ func (d *DaemonClient) Prompt(ctx context.Context, sessionID, text string, api *
 		return "", errors.New("telegram daemon: client is not configured")
 	}
 	clientID := daemonTelegramClientID(chatID)
-	start, err := d.startRun(ctx, sessionID, text, clientID)
+	start, err := d.startRun(ctx, sessionID, daemonStartRunPayload{Text: text, ClientID: clientID})
 	if err != nil {
 		return "", err
 	}
@@ -139,7 +145,7 @@ func (d *DaemonClient) Prompt(ctx context.Context, sessionID, text string, api *
 }
 
 // Command handles Telegram slash commands that map to daemon runtime actions.
-func (d *DaemonClient) Command(ctx context.Context, text string) (string, bool, error) {
+func (d *DaemonClient) Command(ctx context.Context, sessionID, text string, api *API, chatID int64) (string, bool, error) {
 	if d == nil {
 		return "", false, errors.New("telegram daemon: client is not configured")
 	}
@@ -151,6 +157,27 @@ func (d *DaemonClient) Command(ctx context.Context, text string) (string, bool, 
 	token := fields[0]
 	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, token))
 	switch telegramCommandName(token) {
+	case "skills":
+		if rest != "" {
+			return "", true, errors.New("usage: /skills")
+		}
+		catalog, err := d.skillCatalog(ctx)
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramSkills(catalog.Skills), true, nil
+	case "skill":
+		name, args, err := parseTelegramSkillRun(rest)
+		if err != nil {
+			return "", true, err
+		}
+		clientID := daemonTelegramClientID(chatID)
+		start, err := d.startRun(ctx, sessionID, daemonStartRunPayload{Skill: name, Arguments: args, ClientID: clientID})
+		if err != nil {
+			return "", true, err
+		}
+		text, err := d.streamRun(ctx, start, api, chatID, clientID)
+		return text, true, err
 	case "memories":
 		limit, err := parseTelegramMemoryLimit(rest)
 		if err != nil {
@@ -234,6 +261,30 @@ func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api
 	return true
 }
 
+func (d *DaemonClient) skillCatalog(ctx context.Context) (daemonSkillCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.baseURL+"/v1/skills", nil)
+	if err != nil {
+		return daemonSkillCatalog{}, err
+	}
+	d.authorize(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemonSkillCatalog{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonSkillCatalog{}, fmt.Errorf("telegram daemon: skills: %s", httpStatusText(resp))
+	}
+	var out daemonSkillCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemonSkillCatalog{}, err
+	}
+	if out.Skills == nil {
+		out.Skills = []daemon.SkillCatalogEntry{}
+	}
+	return out, nil
+}
+
 func (d *DaemonClient) recall(ctx context.Context, in daemon.RecallRequest) (daemon.RecallResponse, error) {
 	body, _ := json.Marshal(in)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+"/v1/recall", bytes.NewReader(body))
@@ -311,10 +362,10 @@ func (d *DaemonClient) forgetMemory(ctx context.Context, id string) (daemon.Memo
 	return out, nil
 }
 
-func (d *DaemonClient) startRun(ctx context.Context, sessionID, text, clientID string) (daemonStartRunResponse, error) {
-	payload, _ := json.Marshal(daemonStartRunPayload{Text: text, ClientID: clientID})
+func (d *DaemonClient) startRun(ctx context.Context, sessionID string, payload daemonStartRunPayload) (daemonStartRunResponse, error) {
+	body, _ := json.Marshal(payload)
 	endpoint := d.baseURL + "/v1/sessions/" + url.PathEscape(sessionID) + "/runs"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return daemonStartRunResponse{}, err
 	}
@@ -489,6 +540,45 @@ func parseTelegramForgetMemoryID(rest string) (string, error) {
 		return "", errors.New("usage: /forget_memory <id>")
 	}
 	return fields[0], nil
+}
+
+func parseTelegramSkillRun(rest string) (string, map[string]string, error) {
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", nil, errors.New("/skill name is required")
+	}
+	name := strings.TrimSpace(fields[0])
+	if name == "" {
+		return "", nil, errors.New("/skill name is required")
+	}
+	args := make(map[string]string, len(fields)-1)
+	for _, field := range fields[1:] {
+		key, value, ok := strings.Cut(field, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return "", nil, errors.New("usage: /skill <name> [key=value ...]")
+		}
+		args[key] = strings.TrimSpace(value)
+	}
+	if len(args) == 0 {
+		args = nil
+	}
+	return name, args, nil
+}
+
+func formatTelegramSkills(skills []daemon.SkillCatalogEntry) string {
+	if len(skills) == 0 {
+		return "No daemon skills reported."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Skills (%d):\n", len(skills))
+	for i, skill := range skills {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, skill.Name)
+		if skill.Description != "" {
+			fmt.Fprintf(&b, "   %s\n", telegramOneLine(skill.Description, 260))
+		}
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func formatTelegramMemories(memories []daemon.MemoryEntry) string {

--- a/agents/peggy/channels/telegram/daemon_client_test.go
+++ b/agents/peggy/channels/telegram/daemon_client_test.go
@@ -110,6 +110,122 @@ func TestDaemonClientMessageStartsRunAndSendsText(t *testing.T) {
 	}
 }
 
+func TestDaemonClientSkillCommandsUseDaemon(t *testing.T) {
+	var (
+		start      daemonStartRunPayload
+		starts     int
+		skillsSeen int
+	)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+			t.Errorf("auth = %q", auth)
+		}
+		switch r.URL.Path {
+		case "/v1/skills":
+			if r.Method != http.MethodGet {
+				t.Errorf("skills method = %s", r.Method)
+			}
+			skillsSeen++
+			writeJSON(t, w, http.StatusOK, daemonSkillCatalog{Skills: []daemon.SkillCatalogEntry{{
+				Name:        "triage",
+				Description: "Triage one issue",
+			}}})
+		case "/v1/sessions/telegram:123/runs":
+			if r.Method != http.MethodPost {
+				t.Errorf("skill method = %s", r.Method)
+			}
+			starts++
+			if err := json.NewDecoder(r.Body).Decode(&start); err != nil {
+				t.Fatal(err)
+			}
+			writeJSON(t, w, http.StatusCreated, daemonStartRunResponse{RunID: "run_1", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			writeSSE(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "skill done"}})
+			writeSSE(t, w, daemon.EventEnvelope{Type: "run_done"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/skills@PeggyBot"))
+	if skillsSeen != 1 {
+		t.Fatalf("skills requests = %d, want 1", skillsSeen)
+	}
+	if starts != 0 {
+		t.Fatalf("daemon starts after /skills = %d, want 0", starts)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "triage") || !strings.Contains(got, "Triage one issue") {
+		t.Fatalf("skills reply = %q", got)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(2, 123, "/skill triage issue=GLUE-123 priority=high"))
+	if starts != 1 {
+		t.Fatalf("daemon starts = %d, want 1", starts)
+	}
+	if start.Text != "" || start.Skill != "triage" || start.ClientID != "telegram:123" {
+		t.Fatalf("skill start payload = %+v", start)
+	}
+	if start.Arguments["issue"] != "GLUE-123" || start.Arguments["priority"] != "high" {
+		t.Fatalf("skill start arguments = %+v", start.Arguments)
+	}
+	if got := tg.lastSendText(); got != "skill done" {
+		t.Fatalf("skill reply = %q", got)
+	}
+}
+
+func TestDaemonClientSkillCommandValidationDoesNotCallDaemon(t *testing.T) {
+	var requests int
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/skill"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Command error: /skill name is required") {
+		t.Fatalf("validation reply = %q", got)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(2, 123, "/skill triage issue"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Command error: usage: /skill <name> [key=value ...]") {
+		t.Fatalf("argument validation reply = %q", got)
+	}
+}
+
 func TestDaemonClientMemoryCommandsUseDaemonWithoutRun(t *testing.T) {
 	var (
 		starts         int


### PR DESCRIPTION
## Summary
- Add Telegram daemon slash commands for `/skills` and `/skill <name> key=value`.
- `/skills` calls authenticated `GET /v1/skills` without starting a run; `/skill` starts a daemon skill run with `skill`, `arguments`, and Telegram `client_id`, then reuses the existing SSE/permission flow.
- Document the mobile skill workflow in the root README, Peggy README, Telegram README, and Peggy changelog.

Closes #244

## Validation
- `go test ./agents/peggy/channels/telegram -run 'TestDaemonClient(SkillCommandsUseDaemon|SkillCommandValidationDoesNotCallDaemon|MessageStartsRunAndSendsText)' -count=1`
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./agents/peggy -run 'Test.*Skill|Test.*Daemon|Test.*Telegram|Test.*Memory|Test.*Recall' -count=1`
- `go test ./agents/peggy/... -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`