### PR TITLE
agents/peggy: add telegram daemon role commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,9 +687,10 @@ go run ./agents/peggy/cmd/peggy-telegram --daemon
 ```
 
 In daemon-client mode, allowlisted Telegram chats can also use
-`/skills`, `/skill <name> key=value`, `/memories`, `/recall <query>`,
-`/recall_memories <query>`, and `/forget_memory <id>` for reusable
-workflow runs plus memory inspection, search, and correction.
+`/roles`, `/role <name> <prompt>`, `/skills`,
+`/skill <name> key=value`, `/memories`, `/recall <query>`,
+`/recall_memories <query>`, and `/forget_memory <id>` for role-shaped
+runs, reusable workflow runs, and memory inspection/search/correction.
 
 Peggy can assign permission tiers by daemon client/channel in
 `settings.json`. The default remains `prompt`; `read_only` denies

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -74,6 +74,9 @@ not formally follow SemVer until v1.0.
   allowlisted Telegram chats can use `/skills` to inspect reusable
   workspace skills and `/skill <name> key=value` to run one through the
   shared daemon.
+- **Telegram daemon role commands.** In daemon-client mode,
+  allowlisted Telegram chats can use `/roles` to inspect workspace
+  roles and `/role <name> <prompt>` to start a role-shaped daemon run.
 
 ## v0.4.0 — 2026-05-24
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -349,9 +349,10 @@ peggy-telegram --daemon
 In daemon-client mode, Telegram keeps its chat allowlist and inline
 permission buttons, but Peggy, memory, coding tools, and remembered
 permission scopes live in the daemon process.
-Allowlisted chats can also use `/skills`, `/skill <name> key=value`,
-`/memories [limit]`, `/recall <query>`, `/recall_memories <query>`,
-and `/forget_memory <id>` to run workspace skills and inspect or
+Allowlisted chats can also use `/roles`, `/role <name> <prompt>`,
+`/skills`, `/skill <name> key=value`, `/memories [limit]`,
+`/recall <query>`, `/recall_memories <query>`, and
+`/forget_memory <id>` to run workspace roles/skills and inspect or
 correct daemon memory from chat.
 
 Permission tiers apply in daemon mode by daemon `client_id`: `cli:*`
@@ -639,6 +640,8 @@ from an allowlisted chat with `/memories [limit]` and
 They can also inspect and run reusable workspace skills from chat:
 
 ```text
+/roles
+/role reviewer summarize the latest diff
 /skills
 /skill triage issue=GLUE-123
 ```

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -69,9 +69,11 @@ daemon request is sent.
 
 Daemon-client mode also supports memory commands from allowlisted
 chats without starting a model run, plus skill commands for reusable
-workspace workflows:
+workspace workflows and role-shaped runs:
 
 ```text
+/roles
+/role reviewer summarize the latest diff
 /skills
 /skill triage issue=GLUE-123
 /memories
@@ -233,6 +235,8 @@ binary allowlist, overwrite policy, timeouts, and output limits.
   session transcript / sqlite store.
 - Inline-keyboard permission prompts for side-effecting coding tools
   in allowlisted chats.
+- Daemon-client role commands for listing workspace roles and starting
+  role-shaped prompt runs from chat.
 - Daemon-client skill commands for listing and running reusable
   workspace skills from chat.
 - Daemon-client memory commands for listing, recall search,

--- a/agents/peggy/channels/telegram/daemon_client.go
+++ b/agents/peggy/channels/telegram/daemon_client.go
@@ -44,6 +44,7 @@ type daemonStartRunPayload struct {
 	Text      string            `json:"text,omitempty"`
 	Skill     string            `json:"skill,omitempty"`
 	Arguments map[string]string `json:"arguments,omitempty"`
+	Role      string            `json:"role,omitempty"`
 	ClientID  string            `json:"client_id,omitempty"`
 }
 
@@ -54,6 +55,10 @@ type daemonStartRunResponse struct {
 
 type daemonSkillCatalog struct {
 	Skills []daemon.SkillCatalogEntry `json:"skills"`
+}
+
+type daemonRoleCatalog struct {
+	Roles []daemon.RoleCatalogEntry `json:"roles"`
 }
 
 type daemonPermissionPayload struct {
@@ -157,6 +162,27 @@ func (d *DaemonClient) Command(ctx context.Context, sessionID, text string, api 
 	token := fields[0]
 	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, token))
 	switch telegramCommandName(token) {
+	case "roles":
+		if rest != "" {
+			return "", true, errors.New("usage: /roles")
+		}
+		catalog, err := d.roleCatalog(ctx)
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramRoles(catalog.Roles), true, nil
+	case "role":
+		role, prompt, err := parseTelegramRoleRun(rest)
+		if err != nil {
+			return "", true, err
+		}
+		clientID := daemonTelegramClientID(chatID)
+		start, err := d.startRun(ctx, sessionID, daemonStartRunPayload{Text: prompt, Role: role, ClientID: clientID})
+		if err != nil {
+			return "", true, err
+		}
+		text, err := d.streamRun(ctx, start, api, chatID, clientID)
+		return text, true, err
 	case "skills":
 		if rest != "" {
 			return "", true, errors.New("usage: /skills")
@@ -259,6 +285,30 @@ func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api
 		answerDaemonCallback(ctx, api, cb.ID, "Denied.")
 	}
 	return true
+}
+
+func (d *DaemonClient) roleCatalog(ctx context.Context) (daemonRoleCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.baseURL+"/v1/roles", nil)
+	if err != nil {
+		return daemonRoleCatalog{}, err
+	}
+	d.authorize(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemonRoleCatalog{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonRoleCatalog{}, fmt.Errorf("telegram daemon: roles: %s", httpStatusText(resp))
+	}
+	var out daemonRoleCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemonRoleCatalog{}, err
+	}
+	if out.Roles == nil {
+		out.Roles = []daemon.RoleCatalogEntry{}
+	}
+	return out, nil
 }
 
 func (d *DaemonClient) skillCatalog(ctx context.Context) (daemonSkillCatalog, error) {
@@ -564,6 +614,40 @@ func parseTelegramSkillRun(rest string) (string, map[string]string, error) {
 		args = nil
 	}
 	return name, args, nil
+}
+
+func parseTelegramRoleRun(rest string) (string, string, error) {
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", "", errors.New("/role name is required")
+	}
+	role := strings.TrimSpace(fields[0])
+	if role == "" {
+		return "", "", errors.New("/role name is required")
+	}
+	prompt := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(rest), fields[0]))
+	if prompt == "" {
+		return "", "", errors.New("/role prompt is required")
+	}
+	return role, prompt, nil
+}
+
+func formatTelegramRoles(roles []daemon.RoleCatalogEntry) string {
+	if len(roles) == 0 {
+		return "No daemon roles reported."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Roles (%d):\n", len(roles))
+	for i, role := range roles {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, role.Name)
+		if role.Description != "" {
+			fmt.Fprintf(&b, "   %s\n", telegramOneLine(role.Description, 260))
+		}
+		if role.Model != "" {
+			fmt.Fprintf(&b, "   model: %s\n", role.Model)
+		}
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func formatTelegramSkills(skills []daemon.SkillCatalogEntry) string {

--- a/agents/peggy/channels/telegram/daemon_client_test.go
+++ b/agents/peggy/channels/telegram/daemon_client_test.go
@@ -226,6 +226,123 @@ func TestDaemonClientSkillCommandValidationDoesNotCallDaemon(t *testing.T) {
 	}
 }
 
+func TestDaemonClientRoleCommandsUseDaemon(t *testing.T) {
+	var (
+		start     daemonStartRunPayload
+		starts    int
+		rolesSeen int
+	)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+			t.Errorf("auth = %q", auth)
+		}
+		switch r.URL.Path {
+		case "/v1/roles":
+			if r.Method != http.MethodGet {
+				t.Errorf("roles method = %s", r.Method)
+			}
+			rolesSeen++
+			writeJSON(t, w, http.StatusOK, daemonRoleCatalog{Roles: []daemon.RoleCatalogEntry{{
+				Name:        "reviewer",
+				Description: "Review code changes",
+				Model:       "openrouter/free",
+			}}})
+		case "/v1/sessions/telegram:123/runs":
+			if r.Method != http.MethodPost {
+				t.Errorf("role method = %s", r.Method)
+			}
+			starts++
+			if err := json.NewDecoder(r.Body).Decode(&start); err != nil {
+				t.Fatal(err)
+			}
+			writeJSON(t, w, http.StatusCreated, daemonStartRunResponse{RunID: "run_1", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			writeSSE(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "role done"}})
+			writeSSE(t, w, daemon.EventEnvelope{Type: "run_done"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/roles@PeggyBot"))
+	if rolesSeen != 1 {
+		t.Fatalf("roles requests = %d, want 1", rolesSeen)
+	}
+	if starts != 0 {
+		t.Fatalf("daemon starts after /roles = %d, want 0", starts)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "reviewer") || !strings.Contains(got, "Review code changes") || !strings.Contains(got, "openrouter/free") {
+		t.Fatalf("roles reply = %q", got)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(2, 123, "/role reviewer summarize the diff"))
+	if starts != 1 {
+		t.Fatalf("daemon starts = %d, want 1", starts)
+	}
+	if start.Text != "summarize the diff" || start.Role != "reviewer" || start.ClientID != "telegram:123" {
+		t.Fatalf("role start payload = %+v", start)
+	}
+	if start.Skill != "" || len(start.Arguments) != 0 {
+		t.Fatalf("unexpected skill fields in role start payload = %+v", start)
+	}
+	if got := tg.lastSendText(); got != "role done" {
+		t.Fatalf("role reply = %q", got)
+	}
+}
+
+func TestDaemonClientRoleCommandValidationDoesNotCallDaemon(t *testing.T) {
+	var requests int
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/role"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Command error: /role name is required") {
+		t.Fatalf("validation reply = %q", got)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(2, 123, "/role reviewer"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Command error: /role prompt is required") {
+		t.Fatalf("prompt validation reply = %q", got)
+	}
+}
+
 func TestDaemonClientMemoryCommandsUseDaemonWithoutRun(t *testing.T) {
 	var (
 		starts         int


### PR DESCRIPTION
## Summary
- Add Telegram daemon slash commands for `/roles` and `/role <name> <prompt>`.
- `/roles` calls authenticated `GET /v1/roles` without starting a run; `/role` starts a daemon prompt run with `text`, `role`, and Telegram `client_id`, then reuses the existing SSE/permission flow.
- Document the mobile role workflow in the root README, Peggy README, Telegram README, and Peggy changelog.

Closes #246

## Validation
- `go test ./agents/peggy/channels/telegram -run 'TestDaemonClient(RoleCommandsUseDaemon|RoleCommandValidationDoesNotCallDaemon|SkillCommandsUseDaemon|MessageStartsRunAndSendsText)' -count=1`
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./agents/peggy -run 'Test.*Role|Test.*Skill|Test.*Daemon|Test.*Telegram' -count=1`
- `go test ./agents/peggy/... -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`