### PR TITLE
agents/peggy: add telegram daemon status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,10 +687,11 @@ go run ./agents/peggy/cmd/peggy-telegram --daemon
 ```
 
 In daemon-client mode, allowlisted Telegram chats can also use
-`/roles`, `/role <name> <prompt>`, `/skills`,
+`/status`, `/roles`, `/role <name> <prompt>`, `/skills`,
 `/skill <name> key=value`, `/memories`, `/recall <query>`,
 `/recall_memories <query>`, and `/forget_memory <id>` for role-shaped
-runs, reusable workflow runs, and memory inspection/search/correction.
+runs, reusable workflow runs, status checks, and memory
+inspection/search/correction.
 
 Peggy can assign permission tiers by daemon client/channel in
 `settings.json`. The default remains `prompt`; `read_only` denies

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -6,7 +6,12 @@ not formally follow SemVer until v1.0.
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Added
+
+- **Telegram daemon status command.** In daemon-client mode,
+  allowlisted Telegram chats can use `/status` to check daemon health,
+  active runs, tool count, and advertised capabilities without opening
+  a terminal.
 
 ## v0.5.0 — 2026-05-25
 

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -353,9 +353,9 @@ peggy-telegram --daemon
 In daemon-client mode, Telegram keeps its chat allowlist and inline
 permission buttons, but Peggy, memory, coding tools, and remembered
 permission scopes live in the daemon process.
-Allowlisted chats can also use `/roles`, `/role <name> <prompt>`,
-`/skills`, `/skill <name> key=value`, `/memories [limit]`,
-`/recall <query>`, `/recall_memories <query>`, and
+Allowlisted chats can also use `/status`, `/roles`,
+`/role <name> <prompt>`, `/skills`, `/skill <name> key=value`,
+`/memories [limit]`, `/recall <query>`, `/recall_memories <query>`, and
 `/forget_memory <id>` to run workspace roles/skills and inspect or
 correct daemon memory from chat.
 
@@ -644,6 +644,7 @@ from an allowlisted chat with `/memories [limit]` and
 They can also inspect and run reusable workspace skills from chat:
 
 ```text
+/status
 /roles
 /role reviewer summarize the latest diff
 /skills

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -72,6 +72,7 @@ chats without starting a model run, plus skill commands for reusable
 workspace workflows and role-shaped runs:
 
 ```text
+/status
 /roles
 /role reviewer summarize the latest diff
 /skills
@@ -235,6 +236,8 @@ binary allowlist, overwrite policy, timeouts, and output limits.
   session transcript / sqlite store.
 - Inline-keyboard permission prompts for side-effecting coding tools
   in allowlisted chats.
+- Daemon-client status checks for health, active runs, tools, and
+  advertised capabilities.
 - Daemon-client role commands for listing workspace roles and starting
   role-shaped prompt runs from chat.
 - Daemon-client skill commands for listing and running reusable

--- a/agents/peggy/channels/telegram/daemon_client.go
+++ b/agents/peggy/channels/telegram/daemon_client.go
@@ -61,6 +61,14 @@ type daemonRoleCatalog struct {
 	Roles []daemon.RoleCatalogEntry `json:"roles"`
 }
 
+type daemonStatus struct {
+	OK           bool     `json:"ok"`
+	Version      int      `json:"version"`
+	ActiveRuns   int      `json:"active_runs"`
+	ToolsCount   int      `json:"tools_count"`
+	Capabilities []string `json:"capabilities"`
+}
+
 type daemonPermissionPayload struct {
 	PermissionID string                 `json:"permission_id"`
 	Request      glue.PermissionRequest `json:"request"`
@@ -162,6 +170,15 @@ func (d *DaemonClient) Command(ctx context.Context, sessionID, text string, api 
 	token := fields[0]
 	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, token))
 	switch telegramCommandName(token) {
+	case "status":
+		if rest != "" {
+			return "", true, errors.New("usage: /status")
+		}
+		status, err := d.status(ctx)
+		if err != nil {
+			return "", true, err
+		}
+		return formatTelegramStatus(status), true, nil
 	case "roles":
 		if rest != "" {
 			return "", true, errors.New("usage: /roles")
@@ -285,6 +302,30 @@ func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api
 		answerDaemonCallback(ctx, api, cb.ID, "Denied.")
 	}
 	return true
+}
+
+func (d *DaemonClient) status(ctx context.Context) (daemonStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.baseURL+"/v1/status", nil)
+	if err != nil {
+		return daemonStatus{}, err
+	}
+	d.authorize(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return daemonStatus{}, redactDaemonErr(err, d.token)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonStatus{}, fmt.Errorf("telegram daemon: status: %s", httpStatusText(resp))
+	}
+	var out daemonStatus
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return daemonStatus{}, err
+	}
+	if out.Capabilities == nil {
+		out.Capabilities = []string{}
+	}
+	return out, nil
 }
 
 func (d *DaemonClient) roleCatalog(ctx context.Context) (daemonRoleCatalog, error) {
@@ -630,6 +671,22 @@ func parseTelegramRoleRun(rest string) (string, string, error) {
 		return "", "", errors.New("/role prompt is required")
 	}
 	return role, prompt, nil
+}
+
+func formatTelegramStatus(status daemonStatus) string {
+	state := "not ok"
+	if status.OK {
+		state = "ok"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Daemon status: %s\n", state)
+	fmt.Fprintf(&b, "version: %d\n", status.Version)
+	fmt.Fprintf(&b, "active_runs: %d\n", status.ActiveRuns)
+	fmt.Fprintf(&b, "tools: %d", status.ToolsCount)
+	if len(status.Capabilities) > 0 {
+		fmt.Fprintf(&b, "\ncapabilities: %s", strings.Join(status.Capabilities, ", "))
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func formatTelegramRoles(roles []daemon.RoleCatalogEntry) string {

--- a/agents/peggy/channels/telegram/daemon_client_test.go
+++ b/agents/peggy/channels/telegram/daemon_client_test.go
@@ -110,6 +110,96 @@ func TestDaemonClientMessageStartsRunAndSendsText(t *testing.T) {
 	}
 }
 
+func TestDaemonClientStatusCommandUsesDaemonWithoutRun(t *testing.T) {
+	var (
+		starts     int
+		statusSeen int
+	)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+			t.Errorf("auth = %q", auth)
+		}
+		switch r.URL.Path {
+		case "/v1/status":
+			if r.Method != http.MethodGet {
+				t.Errorf("status method = %s", r.Method)
+			}
+			statusSeen++
+			writeJSON(t, w, http.StatusOK, daemonStatus{
+				OK:           true,
+				Version:      1,
+				ActiveRuns:   2,
+				ToolsCount:   7,
+				Capabilities: []string{"runs", "roles", "skills", "memories"},
+			})
+		case "/v1/sessions/telegram:123/runs":
+			starts++
+			http.Error(w, "status should not start runs", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/status@PeggyBot"))
+	if statusSeen != 1 {
+		t.Fatalf("status requests = %d, want 1", statusSeen)
+	}
+	if starts != 0 {
+		t.Fatalf("daemon starts = %d, want 0", starts)
+	}
+	got := tg.lastSendText()
+	for _, want := range []string{"Daemon status: ok", "version: 1", "active_runs: 2", "tools: 7", "roles", "skills"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("status reply = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestDaemonClientStatusCommandValidationDoesNotCallDaemon(t *testing.T) {
+	var requests int
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/status now"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	if got := tg.lastSendText(); !strings.Contains(got, "Command error: usage: /status") {
+		t.Fatalf("validation reply = %q", got)
+	}
+}
+
 func TestDaemonClientSkillCommandsUseDaemon(t *testing.T) {
 	var (
 		start      daemonStartRunPayload


### PR DESCRIPTION
## Summary
- Add Telegram daemon `/status` command backed by authenticated `GET /v1/status`.
- Render daemon ok/version, active run count, tool count, and advertised capabilities without starting a model run.
- Document the mobile status command in the root README, Peggy README, Telegram README, and Peggy changelog.

Closes #250

## Validation
- `go test ./agents/peggy/channels/telegram -run 'TestDaemonClient(StatusCommandUsesDaemonWithoutRun|StatusCommandValidationDoesNotCallDaemon|MessageStartsRunAndSendsText)' -count=1`
- `go test ./agents/peggy/channels/telegram -count=1`
- `go test ./agents/peggy -run 'Test.*Daemon|Test.*Telegram|Test.*Status' -count=1`
- `go test ./agents/peggy/... -count=1`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u GEMINI_API_KEY go test ./...`
- `go vet ./...`
- `git diff --check -- . ':(exclude).gitignore'`