### PR TITLE
daemon: persist permission grants

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -16,6 +16,10 @@ not formally follow SemVer until v1.0.
   fresh-setup path covering install, Codex auth, starter workspace,
   minimal dogfood settings, `peggy doctor`, daemon smoke checks,
   recall, and optional Telegram daemon wiring.
+- **Persistent daemon permission grants.** `peggy serve` now persists
+  remembered daemon permission grants to `permissions.remember_path`,
+  and terminal daemon clients can list or revoke them with
+  `glue connect --permissions` and `--forget-permission`.
 - **Telegram daemon status command.** In daemon-client mode,
   allowlisted Telegram chats can use `/status` to check daemon health,
   active runs, tool count, and advertised capabilities without opening

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -236,6 +236,7 @@ and emits a stderr diagnostic.
 | `mcp.servers.<name>.headers_env` | `{}` | Map HTTP header names to env var names. Peggy resolves the env vars at startup and does not write secret values back to settings. |
 | `mcp.servers.<name>.timeout_seconds` | `30` | Timeout for initialize, `tools/list`, `tools/call`, `resources/list`, and `resources/read` requests. |
 | `permissions.default_tier` | `prompt` | Permission tier for side-effecting tools when a channel has no override. One of `prompt`, `read_only`, or `trusted`. |
+| `permissions.remember_path` | `~/.peggy/permissions.json` | JSON file where daemon-mode remembered permission grants are persisted. Set to `off` to keep remembers process-local. |
 | `permissions.channels.<name>` | inherited | Channel override keyed by `cli`, `telegram`, or a future daemon client prefix. |
 
 Missing `settings.json` is non-fatal — Peggy uses the built-in
@@ -399,6 +400,8 @@ peggy serve --config ~/.config/peggy/settings.json
 glue connect --inspect
 glue connect --memories
 glue connect --forget-memory mem_123
+glue connect --permissions
+glue connect --forget-permission grant_123
 glue connect --skills
 glue connect --roles
 glue connect --skill triage --arg issue=GLUE-123 --id cli:triage

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -1290,6 +1290,9 @@ func doctorPermissionsCheck(settings Settings) doctorCheck {
 		return doctorFail("permissions", "permission policy is invalid", err.Error(), "Use prompt, read_only, or trusted tiers.")
 	}
 	detail := "default=" + settings.Permissions.DefaultTier
+	if settings.Permissions.RememberPath != "" {
+		detail += " remember_path=" + settings.Permissions.RememberPath
+	}
 	keys := sortedStringMapKeys(settings.Permissions.Channels)
 	for _, key := range keys {
 		detail += " " + key + "=" + settings.Permissions.Channels[key]
@@ -1523,6 +1526,9 @@ func writeStatusCoding(w io.Writer, coding statusCoding) {
 
 func writeStatusPermissions(w io.Writer, permissions PermissionSettings) {
 	fmt.Fprintf(w, "permissions: default=%s", permissions.DefaultTier)
+	if permissions.RememberPath != "" {
+		fmt.Fprintf(w, " remember_path=%s", permissions.RememberPath)
+	}
 	keys := sortedStringMapKeys(permissions.Channels)
 	for _, key := range keys {
 		fmt.Fprintf(w, " %s=%s", key, permissions.Channels[key])
@@ -2324,6 +2330,10 @@ Flags:
 		}
 		fmt.Fprintf(stderr, "peggy serve: coding tools enabled for %s\n", workDir)
 	}
+	permissionStore := daemon.NewFilePermissionStore(settings.Permissions.RememberPath)
+	if permissionStore != nil {
+		fmt.Fprintf(stderr, "peggy serve: permission remembers persisted at %s\n", settings.Permissions.RememberPath)
+	}
 
 	token, tokenSource, err := daemon.ResolveToken(*tokenFlag)
 	if err != nil {
@@ -2350,6 +2360,7 @@ Flags:
 		Host:              p,
 		Token:             token,
 		PermissionPolicy:  NewDaemonPermissionPolicy(settings.Permissions),
+		PermissionStore:   permissionStore,
 		PermissionTimeout: *permissionTimeout,
 	})
 	if err != nil {

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -122,8 +122,9 @@ type MCPServerSettings struct {
 // PermissionSettings configures Peggy permission tiers. Channel keys are
 // lower-case names such as "cli" and "telegram".
 type PermissionSettings struct {
-	DefaultTier string            `json:"default_tier"`
-	Channels    map[string]string `json:"channels,omitempty"`
+	DefaultTier  string            `json:"default_tier"`
+	RememberPath string            `json:"remember_path,omitempty"`
+	Channels     map[string]string `json:"channels,omitempty"`
 }
 
 // Environment variables consulted when paths aren't given explicitly.
@@ -196,6 +197,15 @@ func LoadSettings(path string) (Settings, string, error) {
 			return Settings{}, resolved, err
 		}
 		s.Context.WorkDir = expanded
+	}
+	if permissionRememberPathDisabled(s.Permissions.RememberPath) {
+		s.Permissions.RememberPath = ""
+	} else if s.Permissions.RememberPath != "" {
+		expanded, err := expandPath(s.Permissions.RememberPath)
+		if err != nil {
+			return Settings{}, resolved, err
+		}
+		s.Permissions.RememberPath = expanded
 	}
 	if len(s.MCP.Servers) > 0 {
 		expanded, err := expandMCPSettings(s.MCP)
@@ -345,5 +355,18 @@ func fillDefaults(s Settings) Settings {
 		s.Coding.AllowedBinaries = append([]string(nil), DefaultCodingAllowedBinaries...)
 	}
 	s.Permissions = normalizePermissionSettings(s.Permissions)
+	if s.Permissions.RememberPath == "" {
+		home, _ := os.UserHomeDir()
+		s.Permissions.RememberPath = filepath.Join(home, ".peggy", "permissions.json")
+	}
 	return s
+}
+
+func permissionRememberPathDisabled(path string) bool {
+	switch strings.ToLower(strings.TrimSpace(path)) {
+	case "off", "none", "false":
+		return true
+	default:
+		return false
+	}
 }

--- a/agents/peggy/settings_test.go
+++ b/agents/peggy/settings_test.go
@@ -51,6 +51,9 @@ func TestLoadSettings_HappyPathWithDefaults(t *testing.T) {
 	if s.Compaction.KeepRecent != 8 {
 		t.Errorf("keep_recent default = %d", s.Compaction.KeepRecent)
 	}
+	if !strings.HasSuffix(s.Permissions.RememberPath, filepath.Join(".peggy", "permissions.json")) {
+		t.Errorf("permissions.remember_path default = %q", s.Permissions.RememberPath)
+	}
 }
 
 func TestLoadSettings_ContextWorkDir(t *testing.T) {
@@ -66,6 +69,36 @@ func TestLoadSettings_ContextWorkDir(t *testing.T) {
 	}
 	if got := s.Context.WorkDir; got != filepath.Join(home, "workspace") {
 		t.Fatalf("context.work_dir = %q, want expanded path", got)
+	}
+}
+
+func TestLoadSettings_PermissionRememberPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeJSON(t, path, map[string]any{
+		"permissions": map[string]any{"remember_path": "$HOME/peggy-permissions.json"},
+	})
+	s, _, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got := s.Permissions.RememberPath; got != filepath.Join(home, "peggy-permissions.json") {
+		t.Fatalf("permissions.remember_path = %q, want expanded path", got)
+	}
+}
+
+func TestLoadSettings_PermissionRememberPathDisabled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeJSON(t, path, map[string]any{
+		"permissions": map[string]any{"remember_path": "off"},
+	})
+	s, _, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if s.Permissions.RememberPath != "" {
+		t.Fatalf("permissions.remember_path = %q, want disabled", s.Permissions.RememberPath)
 	}
 }
 

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -151,6 +151,10 @@ type daemonMCPPromptCatalog struct {
 	Prompts []daemon.MCPPromptCatalogEntry `json:"prompts"`
 }
 
+type daemonPermissionCatalog struct {
+	Permissions []daemon.PermissionGrant `json:"permissions"`
+}
+
 type daemonToolCatalogEntry struct {
 	Name                    string          `json:"name"`
 	Description             string          `json:"description,omitempty"`
@@ -174,6 +178,7 @@ type daemonInspect struct {
 	Skills       []daemon.SkillCatalogEntry       `json:"skills,omitempty"`
 	Roles        []daemon.RoleCatalogEntry        `json:"roles,omitempty"`
 	Memories     []daemon.MemoryEntry             `json:"memories,omitempty"`
+	Permissions  []daemon.PermissionGrant         `json:"permissions,omitempty"`
 	MCPResources []daemon.MCPResourceCatalogEntry `json:"mcp_resources,omitempty"`
 	MCPPrompts   []daemon.MCPPromptCatalogEntry   `json:"mcp_prompts,omitempty"`
 }
@@ -413,6 +418,10 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	memoryLimit := flags.Int("memory-limit", 0, "maximum memories to return; 0 means no limit")
 	forgetMemoryID := flags.String("forget-memory", "", "delete one daemon memory by id and exit without starting a run")
 	forgetMemoryJSON := flags.Bool("forget-memory-json", false, "print --forget-memory output as JSON")
+	showPermissions := flags.Bool("permissions", false, "list daemon permission grants and exit without starting a run")
+	permissionsJSON := flags.Bool("permissions-json", false, "print --permissions output as JSON")
+	forgetPermissionID := flags.String("forget-permission", "", "delete one daemon permission grant by id and exit without starting a run")
+	forgetPermissionJSON := flags.Bool("forget-permission-json", false, "print --forget-permission output as JSON")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
@@ -462,16 +471,20 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *memoriesJSON {
 		*showMemories = true
 	}
+	if *permissionsJSON {
+		*showPermissions = true
+	}
 	showRecall := strings.TrimSpace(*recallQuery) != "" || *recallJSON
 	showForgetMemory := strings.TrimSpace(*forgetMemoryID) != "" || *forgetMemoryJSON
+	showForgetPermission := strings.TrimSpace(*forgetPermissionID) != "" || *forgetPermissionJSON
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, showForgetMemory, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, showForgetMemory, *showPermissions, showForgetPermission, *showStatus, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --forget-memory, --status, or --inspect")
+		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --forget-memory, --permissions, --forget-permission, --status, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" && strings.TrimSpace(*skillName) == "" {
 		return errors.New("missing required --prompt or --skill")
@@ -531,6 +544,12 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 	if showForgetMemory {
 		return runConnectForgetMemory(ctx, cfg, *forgetMemoryID, *forgetMemoryJSON, stdout, client)
+	}
+	if *showPermissions {
+		return runConnectPermissions(ctx, cfg, *permissionsJSON, stdout, client)
+	}
+	if showForgetPermission {
+		return runConnectForgetPermission(ctx, cfg, *forgetPermissionID, *forgetPermissionJSON, stdout, client)
 	}
 	if *showStatus {
 		return runConnectStatus(ctx, cfg, *statusJSON, stdout, client)
@@ -779,6 +798,38 @@ func runConnectForgetMemory(ctx context.Context, cfg connectConfig, id string, j
 	return nil
 }
 
+func runConnectPermissions(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	catalog, err := fetchDaemonPermissions(ctx, cfg, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(catalog)
+	}
+	writeDaemonPermissions(stdout, catalog.Permissions)
+	return nil
+}
+
+func runConnectForgetPermission(ctx context.Context, cfg connectConfig, id string, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("--forget-permission is required")
+	}
+	forgotten, err := requestDaemonForgetPermission(ctx, cfg, id, client)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(forgotten)
+	}
+	writeDaemonPermission(stdout, forgotten.Permission)
+	return nil
+}
+
 func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
 	status, err := fetchDaemonStatus(ctx, cfg, client)
 	if err != nil {
@@ -826,6 +877,13 @@ func runConnectInspect(ctx context.Context, cfg connectConfig, memoryLimit int, 
 			return err
 		}
 		inspect.Memories = memories.Memories
+	}
+	if daemonHasCapability(status, "permission_grants") {
+		permissions, err := fetchDaemonPermissions(ctx, cfg, client)
+		if err != nil {
+			return err
+		}
+		inspect.Permissions = permissions.Permissions
 	}
 	if daemonHasCapability(status, "mcp_resources") {
 		resources, err := fetchDaemonMCPResources(ctx, cfg, client)
@@ -904,6 +962,11 @@ func writeDaemonInspect(w io.Writer, inspect daemonInspect) {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "memories:")
 		writeDaemonMemoriesIndented(w, inspect.Memories, "  ")
+	}
+	if daemonHasCapability(inspect.Status, "permission_grants") {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "permissions:")
+		writeDaemonPermissionsIndented(w, inspect.Permissions, "  ")
 	}
 	if daemonHasCapability(inspect.Status, "mcp_resources") {
 		fmt.Fprintln(w)
@@ -1036,6 +1099,51 @@ func requestDaemonForgetMemory(ctx context.Context, cfg connectConfig, id string
 	var forgotten daemon.MemoryForgetResponse
 	if err := json.NewDecoder(resp.Body).Decode(&forgotten); err != nil {
 		return daemon.MemoryForgetResponse{}, err
+	}
+	return forgotten, nil
+}
+
+func fetchDaemonPermissions(ctx context.Context, cfg connectConfig, client httpDoer) (daemonPermissionCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+"/v1/permissions", nil)
+	if err != nil {
+		return daemonPermissionCatalog{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonPermissionCatalog{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonPermissionCatalog{}, fmt.Errorf("daemon permissions: %s", httpStatusError(resp))
+	}
+	var catalog daemonPermissionCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		return daemonPermissionCatalog{}, err
+	}
+	if catalog.Permissions == nil {
+		catalog.Permissions = []daemon.PermissionGrant{}
+	}
+	return catalog, nil
+}
+
+func requestDaemonForgetPermission(ctx context.Context, cfg connectConfig, id string, client httpDoer) (daemon.PermissionForgetResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, cfg.BaseURL+"/v1/permissions/"+url.PathEscape(id), nil)
+	if err != nil {
+		return daemon.PermissionForgetResponse{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemon.PermissionForgetResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemon.PermissionForgetResponse{}, fmt.Errorf("daemon permission delete: %s", httpStatusError(resp))
+	}
+	var forgotten daemon.PermissionForgetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&forgotten); err != nil {
+		return daemon.PermissionForgetResponse{}, err
 	}
 	return forgotten, nil
 }
@@ -1276,6 +1384,50 @@ func writeDaemonMemoryFields(w io.Writer, memory daemon.MemoryEntry, indent stri
 	fmt.Fprintf(w, "%s  content: %s\n", indent, oneLine(memory.Content))
 	if len(memory.Tags) > 0 {
 		fmt.Fprintf(w, "%s  tags: %s\n", indent, strings.Join(memory.Tags, ", "))
+	}
+}
+
+func writeDaemonPermissions(w io.Writer, permissions []daemon.PermissionGrant) {
+	writeDaemonPermissionsIndented(w, permissions, "")
+}
+
+func writeDaemonPermissionsIndented(w io.Writer, permissions []daemon.PermissionGrant, indent string) {
+	if len(permissions) == 0 {
+		fmt.Fprintf(w, "%sNo daemon permissions remembered.\n", indent)
+		return
+	}
+	for i, permission := range permissions {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s%d. %s\n", indent, i+1, permission.ID)
+		writeDaemonPermissionFields(w, permission, indent)
+	}
+}
+
+func writeDaemonPermission(w io.Writer, permission daemon.PermissionGrant) {
+	fmt.Fprintln(w, permission.ID)
+	writeDaemonPermissionFields(w, permission, "")
+}
+
+func writeDaemonPermissionFields(w io.Writer, permission daemon.PermissionGrant, indent string) {
+	fmt.Fprintf(w, "%s  scope: %s\n", indent, permission.Scope)
+	if permission.Owner != "" {
+		fmt.Fprintf(w, "%s  owner: %s\n", indent, permission.Owner)
+	}
+	if permission.ClientID != "" {
+		fmt.Fprintf(w, "%s  client_id: %s\n", indent, permission.ClientID)
+	}
+	if permission.SessionID != "" {
+		fmt.Fprintf(w, "%s  session_id: %s\n", indent, permission.SessionID)
+	}
+	fmt.Fprintf(w, "%s  tool: %s\n", indent, permission.Tool)
+	fmt.Fprintf(w, "%s  action: %s\n", indent, permission.Action)
+	if permission.Target != "" {
+		fmt.Fprintf(w, "%s  target: %s\n", indent, permission.Target)
+	}
+	if !permission.CreatedAt.IsZero() {
+		fmt.Fprintf(w, "%s  created_at: %s\n", indent, permission.CreatedAt.Format(time.RFC3339))
 	}
 }
 
@@ -1883,6 +2035,8 @@ func printUsage(w io.Writer) {
   glue connect --recall <query> [--recall-json] [--recall-memories] [--recall-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --memories [--memories-json] [--memory-limit <n>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --forget-memory <id> [--forget-memory-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --permissions [--permissions-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --forget-permission <id> [--forget-permission-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
   run      Run the local Gemini-backed agent.
@@ -1950,6 +2104,14 @@ Flags:
              Connect mode: delete one daemon memory by id and exit without starting a run.
   --forget-memory-json
              Connect --forget-memory mode: print JSON.
+  --permissions
+             Connect mode: list daemon permission grants and exit without starting a run.
+  --permissions-json
+             Connect --permissions mode: print JSON.
+  --forget-permission
+             Connect mode: delete one daemon permission grant by id and exit without starting a run.
+  --forget-permission-json
+             Connect --forget-permission mode: print JSON.
   --server   MCP server name for --mcp-read or --mcp-prompt.
   --uri      MCP resource URI for --mcp-read.
   --name     MCP prompt name for --mcp-prompt.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -1857,6 +1857,145 @@ func TestRunCLIConnectForgetMemoryValidation(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectListsPermissions(t *testing.T) {
+	var sawPermissions bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/permissions":
+			sawPermissions = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("permissions method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("permissions auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.PermissionCatalogResponse{Permissions: []daemon.PermissionGrant{{
+				ID:        "grant_1",
+				Scope:     "forever",
+				Owner:     "client:telegram:123",
+				ClientID:  "telegram:123",
+				SessionID: "telegram:123",
+				Tool:      "shell_exec",
+				Action:    "exec",
+				Target:    "go test ./...",
+				CreatedAt: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
+			}}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--permissions",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawPermissions || sawRun {
+		t.Fatalf("sawPermissions=%v sawRun=%v", sawPermissions, sawRun)
+	}
+	for _, want := range []string{
+		"grant_1",
+		"scope: forever",
+		"owner: client:telegram:123",
+		"client_id: telegram:123",
+		"session_id: telegram:123",
+		"tool: shell_exec",
+		"action: exec",
+		"target: go test ./...",
+		"created_at: 2026-05-24T12:00:00Z",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectForgetsPermission(t *testing.T) {
+	var sawForget bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/permissions/grant_1":
+			sawForget = true
+			if r.Method != http.MethodDelete {
+				t.Fatalf("forget method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer tok" {
+				t.Fatalf("forget auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.PermissionForgetResponse{Permission: daemon.PermissionGrant{
+				ID:       "grant_1",
+				Scope:    "session_target",
+				Owner:    "client:cli:test",
+				ClientID: "cli:test",
+				Tool:     "shell_exec",
+				Action:   "exec",
+				Target:   "go test ./...",
+			}})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--forget-permission", "grant_1",
+		"--base-url", ts.URL,
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawForget || sawRun {
+		t.Fatalf("sawForget=%v sawRun=%v", sawForget, sawRun)
+	}
+	for _, want := range []string{
+		"grant_1",
+		"scope: session_target",
+		"owner: client:cli:test",
+		"tool: shell_exec",
+		"target: go test ./...",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunCLIConnectForgetPermissionValidation(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--forget-permission-json",
+		"--base-url", "http://daemon",
+		"--token", "tok",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code == 0 {
+		t.Fatal("code = 0, want forget-permission validation failure")
+	}
+	if !strings.Contains(stderr.String(), "--forget-permission is required") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestRunCLIConnectShowsStatus(t *testing.T) {
 	var sawStatus bool
 	var sawRun bool
@@ -2028,7 +2167,7 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemonStatus{
 				OK:           true,
 				Version:      1,
-				Capabilities: []string{"status", "tools", "memories"},
+				Capabilities: []string{"status", "tools", "memories", "permission_grants"},
 			})
 		case "/v1/tools":
 			writeJSONResponse(t, w, http.StatusOK, daemonToolCatalog{Tools: []daemonToolCatalogEntry{{
@@ -2043,6 +2182,14 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, daemon.MemoryCatalogResponse{Memories: []daemon.MemoryEntry{{
 				ID:      "mem_1",
 				Content: "User prefers terse responses.",
+			}}})
+		case "/v1/permissions":
+			writeJSONResponse(t, w, http.StatusOK, daemon.PermissionCatalogResponse{Permissions: []daemon.PermissionGrant{{
+				ID:     "grant_1",
+				Scope:  "forever",
+				Owner:  "client:cli:test",
+				Tool:   "shell_exec",
+				Action: "exec",
 			}}})
 		default:
 			http.NotFound(w, r)
@@ -2074,6 +2221,9 @@ func TestRunCLIConnectInspectsDaemonJSON(t *testing.T) {
 	}
 	if len(inspect.Memories) != 1 || inspect.Memories[0].ID != "mem_1" {
 		t.Fatalf("memories = %+v", inspect.Memories)
+	}
+	if len(inspect.Permissions) != 1 || inspect.Permissions[0].ID != "grant_1" {
+		t.Fatalf("permissions = %+v", inspect.Permissions)
 	}
 }
 

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -5,6 +5,7 @@ package daemon
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -12,6 +13,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -227,6 +231,105 @@ type MemoryForgetResponse struct {
 	Memory MemoryEntry `json:"memory"`
 }
 
+// PermissionGrant is one remembered daemon permission decision.
+type PermissionGrant struct {
+	ID        string    `json:"id"`
+	Scope     string    `json:"scope"`
+	Owner     string    `json:"owner"`
+	ClientID  string    `json:"client_id,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
+	Tool      string    `json:"tool"`
+	Action    string    `json:"action"`
+	Target    string    `json:"target,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+}
+
+// PermissionCatalogResponse contains remembered daemon permissions.
+type PermissionCatalogResponse struct {
+	Permissions []PermissionGrant `json:"permissions"`
+}
+
+// PermissionForgetResponse contains the deleted permission grant.
+type PermissionForgetResponse struct {
+	Permission PermissionGrant `json:"permission"`
+}
+
+// PermissionStore persists remembered daemon permission grants.
+type PermissionStore interface {
+	LoadPermissionGrants() ([]PermissionGrant, error)
+	SavePermissionGrants([]PermissionGrant) error
+}
+
+type filePermissionStore struct {
+	path string
+}
+
+type permissionStoreFile struct {
+	Version     int               `json:"version"`
+	Permissions []PermissionGrant `json:"permissions"`
+}
+
+// NewFilePermissionStore returns a JSON-file-backed permission store. An empty
+// path returns nil so callers can keep process-local permission remembers.
+func NewFilePermissionStore(path string) PermissionStore {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	return filePermissionStore{path: path}
+}
+
+func (s filePermissionStore) LoadPermissionGrants() ([]PermissionGrant, error) {
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("daemon: read permission store %s: %w", s.path, err)
+	}
+	var file permissionStoreFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("daemon: parse permission store %s: %w", s.path, err)
+	}
+	return file.Permissions, nil
+}
+
+func (s filePermissionStore) SavePermissionGrants(grants []PermissionGrant) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("daemon: prepare permission store: %w", err)
+	}
+	file := permissionStoreFile{Version: 1, Permissions: grants}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("daemon: encode permission store: %w", err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".permissions-*.tmp")
+	if err != nil {
+		return fmt.Errorf("daemon: create permission store temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("daemon: write permission store temp: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("daemon: chmod permission store temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("daemon: close permission store temp: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("daemon: replace permission store: %w", err)
+	}
+	return nil
+}
+
 // Options configures [New].
 type Options struct {
 	// Host is required. A *glue.Agent satisfies this interface.
@@ -240,6 +343,10 @@ type Options struct {
 	// permission_request event. The daemon package remains channel-blind:
 	// hosts that need channel/client policy decide from the supplied context.
 	PermissionPolicy PermissionPolicy
+
+	// PermissionStore, when non-nil, persists remembered permission grants
+	// across daemon restarts.
+	PermissionStore PermissionStore
 
 	// Now supplies event timestamps. Nil uses time.Now.
 	Now func() time.Time
@@ -302,6 +409,7 @@ type Server struct {
 	host              Host
 	token             string
 	permissionPolicy  PermissionPolicy
+	permissionStore   PermissionStore
 	now               func() time.Time
 	newID             func(prefix string) string
 	permissionTimeout time.Duration
@@ -310,9 +418,9 @@ type Server struct {
 	runs map[string]*run
 
 	permMu        sync.Mutex
-	sessionAllows map[string]struct{}
-	targetAllows  map[string]struct{}
-	foreverAllows map[string]struct{}
+	sessionAllows map[string]PermissionGrant
+	targetAllows  map[string]PermissionGrant
+	foreverAllows map[string]PermissionGrant
 }
 
 // EventEnvelope is the JSON payload sent in each SSE data frame.
@@ -429,18 +537,27 @@ func New(opts Options) (*Server, error) {
 	if permissionTimeout <= 0 {
 		permissionTimeout = defaultPermissionTimeout
 	}
-	return &Server{
+	s := &Server{
 		host:              opts.Host,
 		token:             token,
 		permissionPolicy:  opts.PermissionPolicy,
+		permissionStore:   opts.PermissionStore,
 		now:               now,
 		newID:             newID,
 		permissionTimeout: permissionTimeout,
 		runs:              map[string]*run{},
-		sessionAllows:     map[string]struct{}{},
-		targetAllows:      map[string]struct{}{},
-		foreverAllows:     map[string]struct{}{},
-	}, nil
+		sessionAllows:     map[string]PermissionGrant{},
+		targetAllows:      map[string]PermissionGrant{},
+		foreverAllows:     map[string]PermissionGrant{},
+	}
+	if opts.PermissionStore != nil {
+		grants, err := opts.PermissionStore.LoadPermissionGrants()
+		if err != nil {
+			return nil, err
+		}
+		s.loadPermissionGrants(grants)
+	}
+	return s, nil
 }
 
 // ServeHTTP implements http.Handler.
@@ -509,6 +626,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleMemories(w, r)
+		return
+	}
+
+	if r.URL.Path == "/v1/permissions" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handlePermissions(w, r)
+		return
+	}
+
+	if permissionID, ok := parsePermissionGrantPath(r.URL.Path); ok {
+		if r.Method != http.MethodDelete {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handlePermissionForget(w, r, permissionID)
 		return
 	}
 
@@ -611,6 +746,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 		"runs",
 		"events",
 		"permissions",
+		"permission_grants",
 		"tools",
 		"status",
 	}
@@ -795,6 +931,28 @@ func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
 		catalog.Memories = catalog.Memories[:limit]
 	}
 	writeJSON(w, http.StatusOK, catalog)
+}
+
+func (s *Server) handlePermissions(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, PermissionCatalogResponse{Permissions: s.permissionGrants()})
+}
+
+func (s *Server) handlePermissionForget(w http.ResponseWriter, _ *http.Request, id string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "permission id is required", false)
+		return
+	}
+	grant, ok, err := s.forgetPermissionGrant(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error(), false)
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "permission grant not found", false)
+		return
+	}
+	writeJSON(w, http.StatusOK, PermissionForgetResponse{Permission: grant})
 }
 
 func (s *Server) handleMemoryForget(w http.ResponseWriter, r *http.Request, id string) {
@@ -1163,6 +1321,19 @@ func parseMemoryPath(path string) (string, bool) {
 	return id, err == nil && id != ""
 }
 
+func parsePermissionGrantPath(path string) (string, bool) {
+	const prefix = "/v1/permissions/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	raw := strings.TrimPrefix(path, prefix)
+	if raw == "" || strings.Contains(raw, "/") {
+		return "", false
+	}
+	id, err := url.PathUnescape(raw)
+	return id, err == nil && id != ""
+}
+
 func writeJSON(w http.ResponseWriter, status int, value any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -1251,19 +1422,25 @@ func (s *Server) decidePermission(ctx context.Context, run *run, req glue.Permis
 	defer timer.Stop()
 	select {
 	case decision := <-pending.done:
-		s.rememberPermission(run, req, decision)
+		if err := s.rememberPermission(run, req, decision); err != nil {
+			return glue.PermissionDecision{}, err
+		}
 		return decision, nil
 	case <-timer.C:
 		if !run.expirePermission(permissionID, pending) {
 			decision := <-pending.done
-			s.rememberPermission(run, req, decision)
+			if err := s.rememberPermission(run, req, decision); err != nil {
+				return glue.PermissionDecision{}, err
+			}
 			return decision, nil
 		}
 		return glue.PermissionDecision{Allow: false, Reason: "permission denied: daemon permission request timed out"}, nil
 	case <-ctx.Done():
 		if !run.expirePermission(permissionID, pending) {
 			decision := <-pending.done
-			s.rememberPermission(run, req, decision)
+			if err := s.rememberPermission(run, req, decision); err != nil {
+				return glue.PermissionDecision{}, err
+			}
 			return decision, nil
 		}
 		return glue.PermissionDecision{}, ctx.Err()
@@ -1325,19 +1502,168 @@ func (s *Server) cachedPermission(run *run, req glue.PermissionRequest) (glue.Pe
 	return glue.PermissionDecision{}, false
 }
 
-func (s *Server) rememberPermission(run *run, req glue.PermissionRequest, decision glue.PermissionDecision) {
+func (s *Server) rememberPermission(run *run, req glue.PermissionRequest, decision glue.PermissionDecision) error {
 	if !decision.Allow {
-		return
+		return nil
 	}
 	s.permMu.Lock()
 	defer s.permMu.Unlock()
 	switch decision.RememberFor {
 	case glue.RememberSession:
-		s.sessionAllows[permissionSessionKey(run, req)] = struct{}{}
+		grant := permissionGrantFor(run, req, decision.RememberFor, s.now())
+		s.sessionAllows[permissionSessionKey(run, req)] = grant
 	case glue.RememberSessionTarget:
-		s.targetAllows[permissionTargetKey(run, req)] = struct{}{}
+		grant := permissionGrantFor(run, req, decision.RememberFor, s.now())
+		s.targetAllows[permissionTargetKey(run, req)] = grant
 	case glue.RememberForever:
-		s.foreverAllows[permissionForeverKey(run, req)] = struct{}{}
+		grant := permissionGrantFor(run, req, decision.RememberFor, s.now())
+		s.foreverAllows[permissionForeverKey(run, req)] = grant
+	default:
+		return nil
+	}
+	return s.persistPermissionGrantsLocked()
+}
+
+func (s *Server) loadPermissionGrants(grants []PermissionGrant) {
+	s.permMu.Lock()
+	defer s.permMu.Unlock()
+	for _, grant := range grants {
+		grant = normalizePermissionGrant(grant)
+		if grant.ID == "" || grant.Owner == "" || grant.Tool == "" || grant.Action == "" {
+			continue
+		}
+		switch grant.Scope {
+		case "session":
+			if grant.SessionID != "" {
+				s.sessionAllows[permissionSessionKeyFromGrant(grant)] = grant
+			}
+		case "session_target":
+			if grant.SessionID != "" {
+				s.targetAllows[permissionTargetKeyFromGrant(grant)] = grant
+			}
+		case "forever":
+			s.foreverAllows[permissionForeverKeyFromGrant(grant)] = grant
+		}
+	}
+}
+
+func (s *Server) permissionGrants() []PermissionGrant {
+	s.permMu.Lock()
+	defer s.permMu.Unlock()
+	return s.permissionGrantsLocked()
+}
+
+func (s *Server) permissionGrantsLocked() []PermissionGrant {
+	out := make([]PermissionGrant, 0, len(s.sessionAllows)+len(s.targetAllows)+len(s.foreverAllows))
+	for _, grant := range s.sessionAllows {
+		out = append(out, grant)
+	}
+	for _, grant := range s.targetAllows {
+		out = append(out, grant)
+	}
+	for _, grant := range s.foreverAllows {
+		out = append(out, grant)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func (s *Server) forgetPermissionGrant(id string) (PermissionGrant, bool, error) {
+	s.permMu.Lock()
+	defer s.permMu.Unlock()
+	for key, grant := range s.sessionAllows {
+		if grant.ID == id {
+			delete(s.sessionAllows, key)
+			return grant, true, s.persistPermissionGrantsLocked()
+		}
+	}
+	for key, grant := range s.targetAllows {
+		if grant.ID == id {
+			delete(s.targetAllows, key)
+			return grant, true, s.persistPermissionGrantsLocked()
+		}
+	}
+	for key, grant := range s.foreverAllows {
+		if grant.ID == id {
+			delete(s.foreverAllows, key)
+			return grant, true, s.persistPermissionGrantsLocked()
+		}
+	}
+	return PermissionGrant{}, false, nil
+}
+
+func (s *Server) persistPermissionGrantsLocked() error {
+	if s.permissionStore == nil {
+		return nil
+	}
+	return s.permissionStore.SavePermissionGrants(s.permissionGrantsLocked())
+}
+
+func permissionGrantFor(run *run, req glue.PermissionRequest, scope glue.RememberScope, now time.Time) PermissionGrant {
+	grant := PermissionGrant{
+		Scope:     rememberScopeString(scope),
+		Owner:     permissionOwnerKey(run, req),
+		SessionID: strings.TrimSpace(req.SessionID),
+		Tool:      strings.TrimSpace(req.Tool),
+		Action:    strings.TrimSpace(req.Action),
+		Target:    strings.TrimSpace(req.Target),
+		CreatedAt: now.UTC(),
+	}
+	if run != nil {
+		grant.ClientID = strings.TrimSpace(run.clientID)
+		if grant.SessionID == "" {
+			grant.SessionID = strings.TrimSpace(run.sessionID)
+		}
+	}
+	grant.ID = permissionGrantID(grant)
+	return grant
+}
+
+func normalizePermissionGrant(grant PermissionGrant) PermissionGrant {
+	grant.Scope = strings.TrimSpace(grant.Scope)
+	grant.Owner = strings.TrimSpace(grant.Owner)
+	grant.ClientID = strings.TrimSpace(grant.ClientID)
+	grant.SessionID = strings.TrimSpace(grant.SessionID)
+	grant.Tool = strings.TrimSpace(grant.Tool)
+	grant.Action = strings.TrimSpace(grant.Action)
+	grant.Target = strings.TrimSpace(grant.Target)
+	if grant.ID == "" {
+		grant.ID = permissionGrantID(grant)
+	}
+	return grant
+}
+
+func permissionGrantID(grant PermissionGrant) string {
+	var key string
+	switch grant.Scope {
+	case "session":
+		key = grant.Scope + "\x00" + permissionSessionKeyFromGrant(grant)
+	case "session_target":
+		key = grant.Scope + "\x00" + permissionTargetKeyFromGrant(grant)
+	case "forever":
+		key = grant.Scope + "\x00" + permissionForeverKeyFromGrant(grant)
+	default:
+		key = grant.Scope + "\x00" + grant.Owner + "\x00" + grant.SessionID + "\x00" + grant.Tool + "\x00" + grant.Action + "\x00" + grant.Target
+	}
+	sum := sha256.Sum256([]byte(key))
+	return "grant_" + hex.EncodeToString(sum[:8])
+}
+
+func rememberScopeString(scope glue.RememberScope) string {
+	switch scope {
+	case glue.RememberSession:
+		return "session"
+	case glue.RememberSessionTarget:
+		return "session_target"
+	case glue.RememberForever:
+		return "forever"
+	default:
+		return "never"
 	}
 }
 
@@ -1351,6 +1677,18 @@ func permissionTargetKey(run *run, req glue.PermissionRequest) string {
 
 func permissionForeverKey(run *run, req glue.PermissionRequest) string {
 	return permissionOwnerKey(run, req) + "\x00" + req.Tool + "\x00" + req.Action + "\x00" + req.Target
+}
+
+func permissionSessionKeyFromGrant(grant PermissionGrant) string {
+	return grant.Owner + "\x00" + grant.SessionID + "\x00" + grant.Tool + "\x00" + grant.Action
+}
+
+func permissionTargetKeyFromGrant(grant PermissionGrant) string {
+	return permissionSessionKeyFromGrant(grant) + "\x00" + grant.Target
+}
+
+func permissionForeverKeyFromGrant(grant PermissionGrant) string {
+	return grant.Owner + "\x00" + grant.Tool + "\x00" + grant.Action + "\x00" + grant.Target
 }
 
 func permissionOwnerKey(run *run, req glue.PermissionRequest) string {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1423,6 +1424,92 @@ func TestServerPermissionRememberForeverIsClientScoped(t *testing.T) {
 	}
 }
 
+func TestServerPermissionStorePersistsAndRevokes(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "permissions.json")
+
+	var firstExecuted atomic.Int32
+	firstAgent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("first done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&firstExecuted)},
+	})
+	firstSrv := newTestServerWithPermissionStore(t, firstAgent, storePath)
+	firstTS := httptest.NewServer(firstSrv)
+	defer firstTS.Close()
+
+	first := startRunWithClient(t, firstTS.URL, "telegram:123", "telegram:123")
+	firstEvents, err := collectSSE(t, firstTS.URL+first.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, firstTS.URL, first.RunID, permissionID(t, event), "token", `{"allow":true,"remember_for":"forever"}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(eventTypes(firstEvents), "permission_request") || firstExecuted.Load() != 1 {
+		t.Fatalf("first events=%v executed=%d", eventTypes(firstEvents), firstExecuted.Load())
+	}
+
+	catalog := getPermissions(t, firstTS.URL)
+	if len(catalog.Permissions) != 1 {
+		t.Fatalf("permissions = %+v, want one grant", catalog.Permissions)
+	}
+	grant := catalog.Permissions[0]
+	if grant.Scope != "forever" || grant.ClientID != "telegram:123" || grant.Owner != "client:telegram:123" {
+		t.Fatalf("grant = %+v", grant)
+	}
+
+	var secondExecuted atomic.Int32
+	secondAgent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("second done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&secondExecuted)},
+	})
+	secondSrv := newTestServerWithPermissionStore(t, secondAgent, storePath)
+	secondTS := httptest.NewServer(secondSrv)
+	defer secondTS.Close()
+
+	second := startRunWithClient(t, secondTS.URL, "telegram:123", "telegram:123")
+	secondEvents := getSSE(t, secondTS.URL+second.EventsURL, "token")
+	if secondExecuted.Load() != 1 {
+		t.Fatalf("second executions = %d, want 1", secondExecuted.Load())
+	}
+	if contains(eventTypes(secondEvents), "permission_request") {
+		t.Fatalf("second events = %v, want persisted grant cache hit", eventTypes(secondEvents))
+	}
+
+	forgotten := deletePermission(t, secondTS.URL, grant.ID)
+	if forgotten.Permission.ID != grant.ID {
+		t.Fatalf("forgotten = %+v, want %s", forgotten.Permission, grant.ID)
+	}
+
+	var thirdExecuted atomic.Int32
+	thirdAgent := glue.NewAgent(glue.AgentOptions{
+		Provider: &turnProvider{turns: [][]glue.ProviderEvent{
+			toolCallTurn(), textTurn("third done"),
+		}},
+		Tools: []glue.Tool{permissionTool(&thirdExecuted)},
+	})
+	thirdSrv := newTestServerWithPermissionStore(t, thirdAgent, storePath)
+	thirdTS := httptest.NewServer(thirdSrv)
+	defer thirdTS.Close()
+
+	third := startRunWithClient(t, thirdTS.URL, "telegram:123", "telegram:123")
+	thirdEvents, err := collectSSE(t, thirdTS.URL+third.EventsURL, "token", func(event EventEnvelope) {
+		if event.Type == "permission_request" {
+			postDecision(t, thirdTS.URL, third.RunID, permissionID(t, event), "token", `{"allow":true}`)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(eventTypes(thirdEvents), "permission_request") {
+		t.Fatalf("third events = %v, want prompt after revoke", eventTypes(thirdEvents))
+	}
+}
+
 func newTestServer(t *testing.T, host Host) *Server {
 	return newTestServerWithTimeout(t, host, time.Second)
 }
@@ -1437,6 +1524,23 @@ func newTestServerWithPolicy(t *testing.T, host Host, policy PermissionPolicy) *
 		Now:               func() time.Time { return now },
 		NewID:             sequenceIDs(),
 		PermissionTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func newTestServerWithPermissionStore(t *testing.T, host Host, path string) *Server {
+	t.Helper()
+	now := time.Date(2026, 5, 23, 20, 46, 0, 0, time.UTC)
+	srv, err := New(Options{
+		Host:              host,
+		Token:             "token",
+		Now:               func() time.Time { return now },
+		NewID:             sequenceIDs(),
+		PermissionTimeout: time.Second,
+		PermissionStore:   NewFilePermissionStore(path),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1651,6 +1755,50 @@ func permissionID(t *testing.T, event EventEnvelope) string {
 func postDecision(t *testing.T, baseURL, runID, permissionID, token, body string) {
 	t.Helper()
 	postDecisionStatus(t, baseURL, runID, permissionID, token, "", body, http.StatusOK)
+}
+
+func getPermissions(t *testing.T, baseURL string) PermissionCatalogResponse {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/permissions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("permissions status = %d, want 200", resp.StatusCode)
+	}
+	var out PermissionCatalogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func deletePermission(t *testing.T, baseURL, id string) PermissionForgetResponse {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, baseURL+"/v1/permissions/"+url.PathEscape(id), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("permission delete status = %d, want 200", resp.StatusCode)
+	}
+	var out PermissionForgetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return out
 }
 
 func postDecisionStatus(t *testing.T, baseURL, runID, permissionID, token, clientID, body string, want int) {


### PR DESCRIPTION
## Summary
- persist daemon remembered permission grants through an optional JSON file store
- expose daemon APIs and `glue connect` commands to list and revoke permission grants
- wire Peggy settings, status, doctor output, and docs to the default `permissions.remember_path`

Closes #255.

## Validation
- `go test ./daemon ./cmd/glue ./agents/peggy -count=1`
- `git diff --check`
- `env -u NVIDIA_API_KEY -u OPENROUTER_API_KEY -u GEMINI_API_KEY go test ./... -count=1`