### PR TITLE
telegram: improve daemon reply UX

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -20,6 +20,10 @@ not formally follow SemVer until v1.0.
   remembered daemon permission grants to `permissions.remember_path`,
   and terminal daemon clients can list or revoke them with
   `glue connect --permissions` and `--forget-permission`.
+- **Telegram daemon reply UX.** Telegram daemon-client runs now send
+  an immediate progress message, split long final replies into multiple
+  Telegram messages instead of truncating them, and expose `/help` for
+  daemon chat commands.
 - **Telegram daemon status command.** In daemon-client mode,
   allowlisted Telegram chats can use `/status` to check daemon health,
   active runs, tool count, and advertised capabilities without opening

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -147,7 +147,8 @@ peggy doctor --config ~/.config/peggy/settings.json --soul ~/.config/peggy/SOUL.
 peggy-telegram --daemon
 ```
 
-Useful Telegram daemon commands: `/status`, `/roles`, `/skills`,
+Useful Telegram daemon commands: `/help`, `/status`, `/roles`,
+`/role <name> <prompt>`, `/skills`, `/skill <name> key=value`,
 `/memories`, `/recall <query>`, `/recall_memories <query>`, and
 `/forget_memory <id>`.
 
@@ -452,7 +453,9 @@ peggy-telegram --daemon
 In daemon-client mode, Telegram keeps its chat allowlist and inline
 permission buttons, but Peggy, memory, coding tools, and remembered
 permission scopes live in the daemon process.
-Allowlisted chats can also use `/status`, `/roles`,
+Allowlisted chats get an immediate progress reply for daemon runs and
+long final replies are split across Telegram messages. They can also
+use `/help`, `/status`, `/roles`,
 `/role <name> <prompt>`, `/skills`, `/skill <name> key=value`,
 `/memories [limit]`, `/recall <query>`, `/recall_memories <query>`, and
 `/forget_memory <id>` to run workspace roles/skills and inspect or

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -67,11 +67,14 @@ peggy-telegram --daemon
 `GLUE_DAEMON_TOKEN`. Telegram still enforces `allow_chats` before any
 daemon request is sent.
 
-Daemon-client mode also supports memory commands from allowlisted
-chats without starting a model run, plus skill commands for reusable
-workspace workflows and role-shaped runs:
+Daemon-client mode sends an immediate progress reply for daemon runs
+and splits long final answers across Telegram messages. It also
+supports memory commands from allowlisted chats without starting a
+model run, plus skill commands for reusable workspace workflows and
+role-shaped runs:
 
 ```text
+/help
 /status
 /roles
 /role reviewer summarize the latest diff

--- a/agents/peggy/channels/telegram/channel.go
+++ b/agents/peggy/channels/telegram/channel.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/erain/glue/agents/peggy"
 )
@@ -231,7 +232,7 @@ func (c *Channel) handleUpdate(ctx context.Context, u Update) {
 				reply = "Command error: " + commandErr.Error()
 			}
 			if strings.TrimSpace(reply) != "" {
-				if err := c.api.SendMessage(ctx, chatID, strings.TrimSpace(reply)); err != nil {
+				if err := sendTelegramText(ctx, c.api, chatID, strings.TrimSpace(reply)); err != nil {
 					fmt.Fprintf(c.stderr, "telegram: send to chat %d: %v\n", chatID, err)
 				}
 			}
@@ -245,7 +246,7 @@ func (c *Channel) handleUpdate(ctx context.Context, u Update) {
 		fmt.Fprintf(c.stderr, "telegram: prompt failed for chat %d: %v\n", chatID, err)
 		// Reply with a short error rather than going silent — the user
 		// sent something and deserves an acknowledgment.
-		_ = c.api.SendMessage(ctx, chatID, "(I hit an error responding. Check the agent logs.)")
+		_ = sendTelegramText(ctx, c.api, chatID, "(I hit an error responding. Check the agent logs.)")
 		return
 	}
 	reply := strings.TrimSpace(text)
@@ -256,9 +257,61 @@ func (c *Channel) handleUpdate(ctx context.Context, u Update) {
 		fmt.Fprintf(c.stderr, "telegram: prompt for chat %d produced no text\n", chatID)
 		return
 	}
-	if err := c.api.SendMessage(ctx, chatID, reply); err != nil {
+	if err := sendTelegramText(ctx, c.api, chatID, reply); err != nil {
 		fmt.Fprintf(c.stderr, "telegram: send to chat %d: %v\n", chatID, err)
 	}
+}
+
+func sendTelegramText(ctx context.Context, api *API, chatID int64, text string) error {
+	for _, chunk := range telegramTextChunks(text) {
+		if err := api.SendMessage(ctx, chatID, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func telegramTextChunks(text string) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	chunks := []string{}
+	for len(text) > telegramMessageLimit {
+		cut := telegramTextChunkCut(text, telegramMessageLimit)
+		if cut <= 0 || cut > len(text) {
+			cut = telegramMessageLimit
+		}
+		chunks = append(chunks, text[:cut])
+		text = text[cut:]
+	}
+	if text != "" {
+		chunks = append(chunks, text)
+	}
+	return chunks
+}
+
+func telegramTextChunkCut(text string, limit int) int {
+	if len(text) <= limit {
+		return len(text)
+	}
+	cut := limit
+	for cut > 0 && !utf8.ValidString(text[:cut]) {
+		cut--
+	}
+	if cut == 0 {
+		_, size := utf8.DecodeRuneInString(text)
+		return size
+	}
+	window := text[:cut]
+	floor := cut / 2
+	if idx := strings.LastIndex(window[floor:], "\n"); idx >= 0 {
+		return floor + idx + 1
+	}
+	if idx := strings.LastIndex(window[floor:], " "); idx >= 0 {
+		return floor + idx + 1
+	}
+	return cut
 }
 
 // Compile-time assertion that *Channel satisfies peggy.Channel.

--- a/agents/peggy/channels/telegram/channel_test.go
+++ b/agents/peggy/channels/telegram/channel_test.go
@@ -145,13 +145,17 @@ func (f *telegramFixture) sendCount() int {
 }
 
 func (f *telegramFixture) lastSendText() string {
+	return f.sendText(f.sendCount() - 1)
+}
+
+func (f *telegramFixture) sendText(index int) string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if len(f.sendBodies) == 0 {
+	if index < 0 || index >= len(f.sendBodies) {
 		return ""
 	}
 	var body map[string]any
-	_ = json.Unmarshal(f.sendBodies[len(f.sendBodies)-1], &body)
+	_ = json.Unmarshal(f.sendBodies[index], &body)
 	if s, ok := body["text"].(string); ok {
 		return s
 	}

--- a/agents/peggy/channels/telegram/daemon_client.go
+++ b/agents/peggy/channels/telegram/daemon_client.go
@@ -84,6 +84,7 @@ type daemonPermissionDecision struct {
 const (
 	defaultTelegramMemoryLimit = 10
 	defaultTelegramRecallLimit = 5
+	daemonRunProgressMessage   = "Working on it..."
 )
 
 // ResolveDaemonClientConfig applies metadata and environment fallback rules.
@@ -150,6 +151,7 @@ func (d *DaemonClient) Prompt(ctx context.Context, sessionID, text string, api *
 		return "", errors.New("telegram daemon: client is not configured")
 	}
 	clientID := daemonTelegramClientID(chatID)
+	d.sendProgress(ctx, api, chatID)
 	start, err := d.startRun(ctx, sessionID, daemonStartRunPayload{Text: text, ClientID: clientID})
 	if err != nil {
 		return "", err
@@ -170,6 +172,11 @@ func (d *DaemonClient) Command(ctx context.Context, sessionID, text string, api 
 	token := fields[0]
 	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, token))
 	switch telegramCommandName(token) {
+	case "help", "start":
+		if rest != "" {
+			return "", true, errors.New("usage: /help")
+		}
+		return formatTelegramHelp(), true, nil
 	case "status":
 		if rest != "" {
 			return "", true, errors.New("usage: /status")
@@ -194,6 +201,7 @@ func (d *DaemonClient) Command(ctx context.Context, sessionID, text string, api 
 			return "", true, err
 		}
 		clientID := daemonTelegramClientID(chatID)
+		d.sendProgress(ctx, api, chatID)
 		start, err := d.startRun(ctx, sessionID, daemonStartRunPayload{Text: prompt, Role: role, ClientID: clientID})
 		if err != nil {
 			return "", true, err
@@ -215,6 +223,7 @@ func (d *DaemonClient) Command(ctx context.Context, sessionID, text string, api 
 			return "", true, err
 		}
 		clientID := daemonTelegramClientID(chatID)
+		d.sendProgress(ctx, api, chatID)
 		start, err := d.startRun(ctx, sessionID, daemonStartRunPayload{Skill: name, Arguments: args, ClientID: clientID})
 		if err != nil {
 			return "", true, err
@@ -302,6 +311,15 @@ func (d *DaemonClient) HandleCallback(ctx context.Context, cb CallbackQuery, api
 		answerDaemonCallback(ctx, api, cb.ID, "Denied.")
 	}
 	return true
+}
+
+func (d *DaemonClient) sendProgress(ctx context.Context, api *API, chatID int64) {
+	if api == nil {
+		return
+	}
+	if err := api.SendMessage(ctx, chatID, daemonRunProgressMessage); err != nil {
+		d.print("telegram daemon: progress message failed for chat %d: %v\n", chatID, err)
+	}
 }
 
 func (d *DaemonClient) status(ctx context.Context) (daemonStatus, error) {
@@ -671,6 +689,23 @@ func parseTelegramRoleRun(rest string) (string, string, error) {
 		return "", "", errors.New("/role prompt is required")
 	}
 	return role, prompt, nil
+}
+
+func formatTelegramHelp() string {
+	return strings.Join([]string{
+		"Peggy daemon commands:",
+		"/help - show this help",
+		"/status - show daemon health",
+		"/roles - list workspace roles",
+		"/role <name> <prompt> - run with a role",
+		"/skills - list workspace skills",
+		"/skill <name> [key=value ...] - run a skill",
+		"/memories [limit] - list curated memories",
+		"/recall <query> - search session history",
+		"/recall_memories <query> - search curated memories",
+		"/forget_memory <id> - delete one curated memory",
+		"Send any other message to start a daemon run.",
+	}, "\n")
 }
 
 func formatTelegramStatus(status daemonStatus) string {

--- a/agents/peggy/channels/telegram/daemon_client_test.go
+++ b/agents/peggy/channels/telegram/daemon_client_test.go
@@ -105,8 +105,118 @@ func TestDaemonClientMessageStartsRunAndSendsText(t *testing.T) {
 	if start.Text != "hello" || start.ClientID != "telegram:123" {
 		t.Fatalf("start payload = %+v", start)
 	}
+	if got := tg.sendText(0); got != daemonRunProgressMessage {
+		t.Fatalf("progress reply = %q", got)
+	}
 	if got := tg.lastSendText(); got != "hello from daemon" {
 		t.Fatalf("telegram reply = %q", got)
+	}
+}
+
+func TestDaemonClientMessageSendsProgressBeforeRunCompletes(t *testing.T) {
+	eventsStarted := make(chan struct{})
+	releaseEvents := make(chan struct{})
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/telegram:123/runs":
+			writeJSON(t, w, http.StatusCreated, daemonStartRunResponse{RunID: "run_1", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			close(eventsStarted)
+			select {
+			case <-releaseEvents:
+			case <-r.Context().Done():
+				return
+			}
+			writeSSE(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": "done"}})
+			writeSSE(t, w, daemon.EventEnvelope{Type: "run_done"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ch.handleUpdate(context.Background(), messageUpdate(1, 123, "hello"))
+		close(done)
+	}()
+	select {
+	case <-eventsStarted:
+	case <-time.After(time.Second):
+		t.Fatal("daemon event stream was not opened")
+	}
+	waitForSendCount(t, tg, 1)
+	if got := tg.sendText(0); got != daemonRunProgressMessage {
+		t.Fatalf("progress reply = %q", got)
+	}
+	close(releaseEvents)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleUpdate did not finish")
+	}
+	if got := tg.lastSendText(); got != "done" {
+		t.Fatalf("final reply = %q", got)
+	}
+}
+
+func TestDaemonClientLongReplySplitsMessages(t *testing.T) {
+	long := strings.Repeat("0123456789", 500)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sessions/telegram:123/runs":
+			writeJSON(t, w, http.StatusCreated, daemonStartRunResponse{RunID: "run_1", EventsURL: "/v1/runs/run_1/events"})
+		case "/v1/runs/run_1/events":
+			writeSSE(t, w, daemon.EventEnvelope{Type: "text_delta", Payload: map[string]any{"delta": long}})
+			writeSSE(t, w, daemon.EventEnvelope{Type: "run_done"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "long please"))
+	if tg.sendCount() != 3 {
+		t.Fatalf("send count = %d, want progress plus two reply chunks", tg.sendCount())
+	}
+	if got := tg.sendText(0); got != daemonRunProgressMessage {
+		t.Fatalf("progress reply = %q", got)
+	}
+	first := tg.sendText(1)
+	second := tg.sendText(2)
+	if len(first) > telegramMessageLimit || len(second) > telegramMessageLimit {
+		t.Fatalf("chunk sizes = %d, %d", len(first), len(second))
+	}
+	if got := first + second; got != long {
+		t.Fatalf("reconstructed reply length = %d, want %d", len(got), len(long))
 	}
 }
 
@@ -166,6 +276,39 @@ func TestDaemonClientStatusCommandUsesDaemonWithoutRun(t *testing.T) {
 	for _, want := range []string{"Daemon status: ok", "version: 1", "active_runs: 2", "tools: 7", "roles", "skills"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status reply = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestDaemonClientHelpCommandDoesNotCallDaemon(t *testing.T) {
+	var requests int
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer daemonServer.Close()
+
+	tg := newTelegramFixture(t, nil)
+	dc, err := NewDaemonClient(DaemonClientConfig{BaseURL: daemonServer.URL, Token: "tok"}, daemonServer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := New(Options{
+		Daemon: dc,
+		Config: Config{APIBaseURL: tg.server.URL, AllowChats: []int64{123}},
+		Token:  "telegram-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch.handleUpdate(context.Background(), messageUpdate(1, 123, "/help@PeggyBot"))
+	if requests != 0 {
+		t.Fatalf("daemon requests = %d, want 0", requests)
+	}
+	got := tg.lastSendText()
+	for _, want := range []string{"/status", "/role <name> <prompt>", "/skill <name>", "/recall <query>", "Send any other message"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("help reply = %q, missing %q", got, want)
 		}
 	}
 }
@@ -667,7 +810,7 @@ func TestDaemonClientPermissionCallbackPostsDecision(t *testing.T) {
 		ch.handleUpdate(context.Background(), messageUpdate(1, 123, "write file"))
 		close(done)
 	}()
-	waitForSendCount(t, tg, 1)
+	waitForSendCount(t, tg, 2)
 	ch.handleCallback(context.Background(), CallbackQuery{
 		ID:      "cb_1",
 		Message: &Message{Chat: Chat{ID: 123, Type: "private"}},


### PR DESCRIPTION
## Summary
- add `/help` and `/start` coverage for Telegram daemon-client commands
- send an immediate progress message before daemon prompt, role, and skill runs complete
- split long Telegram replies into multiple messages instead of relying on hard truncation

Closes #256.

## Validation
- `go test ./agents/peggy/channels/telegram -count=1`
- `git diff --check`
- `go test ./agents/peggy/... ./cmd/glue ./daemon -count=1`
- `env -u NVIDIA_API_KEY -u OPENROUTER_API_KEY -u GEMINI_API_KEY go test ./... -count=1`