### PR TITLE
peggy: add session history listing

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -24,6 +24,9 @@ not formally follow SemVer until v1.0.
   an immediate progress message, split long final replies into multiple
   Telegram messages instead of truncating them, and expose `/help` for
   daemon chat commands.
+- **Session history browser.** `peggy sessions` lists recent stored
+  sessions without starting a provider, with prefix filtering and JSON
+  output for scriptable local history inspection.
 - **Telegram daemon status command.** In daemon-client mode,
   allowlisted Telegram chats can use `/status` to check daemon health,
   active runs, tool count, and advertised capabilities without opening

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -119,6 +119,7 @@ glue connect --skills
 glue connect --skill daily_plan --id cli:daily-plan
 glue connect --prompt "Dogfood smoke marker: Peggy daemon is reachable." --id cli:smoke
 glue connect --recall "Dogfood smoke marker"
+peggy sessions --config ~/.config/peggy/settings.json --prefix cli:
 ```
 
 To reach Peggy from your phone, merge a Telegram channel block into
@@ -252,6 +253,7 @@ peggy skill [flags] <name>
 peggy skills [flags]
 peggy roles [flags]
 peggy memories [flags]
+peggy sessions [flags]
 peggy recall [flags] <query>
 peggy doctor [flags]
 peggy mcp prompt [flags]
@@ -727,6 +729,18 @@ peggy memories forget --config ~/.config/peggy/settings.json mem_123
 Each memory has a stable `id` in human and JSON output. `forget` only
 removes curated `remember` records from the dedicated memory session; it
 does not delete ordinary conversation history.
+
+List recent stored sessions without starting a provider:
+
+```sh
+peggy sessions --config ~/.config/peggy/settings.json
+peggy sessions --config ~/.config/peggy/settings.json --prefix telegram:
+peggy sessions --config ~/.config/peggy/settings.json --json --limit 20
+```
+
+Session listings are ordered by recent activity and include stable JSON
+fields for the session id, created/updated timestamps, and user,
+assistant, and total message counts.
 
 When Peggy is already running as a daemon, connected clients can list
 the same curated memory catalog:

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -151,6 +151,8 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 			return runRoles(args[1:], stdout, stderr)
 		case "memories":
 			return runMemories(ctx, args[1:], stdout, stderr)
+		case "sessions":
+			return runSessions(ctx, args[1:], stdout, stderr)
 		case "recall":
 			return runRecall(ctx, args[1:], stdout, stderr)
 		case "status":
@@ -184,6 +186,7 @@ Usage:
   peggy skills [flags]
   peggy roles [flags]
   peggy memories [flags]
+  peggy sessions [flags]
   peggy recall [flags] <query>
   peggy status [flags]
   peggy doctor [flags]
@@ -199,6 +202,7 @@ Examples:
   peggy skills --config ~/.config/peggy/settings.json
   peggy roles --config ~/.config/peggy/settings.json
   peggy memories --config ~/.config/peggy/settings.json
+  peggy sessions --config ~/.config/peggy/settings.json --prefix telegram:
   peggy recall --config ~/.config/peggy/settings.json "Australian Shepherd"
   peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
   peggy status --config ~/.config/peggy/settings.json
@@ -898,6 +902,110 @@ func writeMemories(w io.Writer, memories []Memory) {
 		if len(memory.Tags) > 0 {
 			fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
 		}
+	}
+}
+
+func runSessions(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy sessions", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+		prefix     = fs.String("prefix", "", "only list session ids with this prefix, such as telegram:")
+		limit      = fs.Int("limit", 50, "maximum sessions to return; 0 uses the store default")
+		offset     = fs.Int("offset", 0, "number of matching sessions to skip")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy sessions - list recent Peggy sessions without starting a model run.
+
+Usage:
+  peggy sessions [flags]
+
+Examples:
+  peggy sessions --config ~/.config/peggy/settings.json
+  peggy sessions --config ~/.config/peggy/settings.json --prefix telegram:
+  peggy sessions --config ~/.config/peggy/settings.json --json --limit 20
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy sessions: positional args not supported")
+		return 2
+	}
+	if *limit < 0 {
+		fmt.Fprintln(stderr, "peggy sessions: --limit must be non-negative")
+		return 2
+	}
+	if *offset < 0 {
+		fmt.Fprintln(stderr, "peggy sessions: --offset must be non-negative")
+		return 2
+	}
+	store, missingSettings, err := openStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy sessions: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy sessions: no settings.json found; using built-in defaults")
+	}
+	if closer, ok := store.(io.Closer); ok {
+		defer closer.Close()
+	}
+	lister, ok := store.(glue.SessionLister)
+	if !ok {
+		fmt.Fprintln(stderr, "peggy sessions: configured store does not support session listing")
+		return 1
+	}
+	sessions, err := lister.ListSessions(ctx, glue.ListSessionsOptions{
+		Prefix: *prefix,
+		Limit:  *limit,
+		Offset: *offset,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy sessions: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(sessions); err != nil {
+			fmt.Fprintf(stderr, "peggy sessions: encode sessions: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeSessions(stdout, sessions)
+	return 0
+}
+
+func writeSessions(w io.Writer, sessions []glue.SessionSummary) {
+	if len(sessions) == 0 {
+		fmt.Fprintln(w, "No sessions found.")
+		return
+	}
+	for i, session := range sessions {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		updatedAt := "unknown"
+		if !session.UpdatedAt.IsZero() {
+			updatedAt = session.UpdatedAt.Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%s %s\n", updatedAt, session.ID)
+		if !session.CreatedAt.IsZero() {
+			fmt.Fprintf(w, "  created_at: %s\n", session.CreatedAt.Format(time.RFC3339))
+		}
+		fmt.Fprintf(w, "  messages: %d\n", session.Messages)
+		fmt.Fprintf(w, "  user_messages: %d\n", session.UserMessages)
+		fmt.Fprintf(w, "  assistant_messages: %d\n", session.AssistantMessages)
 	}
 }
 

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -611,6 +611,92 @@ func TestRunMemoriesRejectsNegativeLimit(t *testing.T) {
 	}
 }
 
+func TestRunSessionsListsSQLiteHistory(t *testing.T) {
+	cfgPath := seedRunnerSessionStore(t)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"sessions", "--config", cfgPath, "--prefix", "telegram:", "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	var sessions []glue.SessionSummary
+	if err := json.Unmarshal(out.Bytes(), &sessions); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, out.String())
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %+v, want one telegram session", sessions)
+	}
+	got := sessions[0]
+	if got.ID != "telegram:123" || got.Messages != 3 || got.UserMessages != 2 || got.AssistantMessages != 1 {
+		t.Fatalf("session summary = %+v", got)
+	}
+}
+
+func TestRunSessionsNoResults(t *testing.T) {
+	cfgPath := seedRunnerSessionStore(t)
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"sessions", "--config", cfgPath, "--prefix", "missing:"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if got, want := out.String(), "No sessions found.\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func seedRunnerSessionStore(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "peggy.db")
+	store, err := sqlitestore.Open(sqlitestore.Options{Path: dbPath})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer store.Close()
+
+	base := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	states := map[string]glue.SessionState{
+		"telegram:123": {
+			ID:        "telegram:123",
+			CreatedAt: base,
+			UpdatedAt: base.Add(3 * time.Hour),
+			Messages: []glue.Message{
+				runnerTextMessage(glue.MessageRoleUser, "hello from telegram"),
+				runnerTextMessage(glue.MessageRoleAssistant, "hello back"),
+				runnerTextMessage(glue.MessageRoleUser, "second prompt"),
+			},
+		},
+		"cli:dev": {
+			ID:        "cli:dev",
+			CreatedAt: base.Add(time.Hour),
+			UpdatedAt: base.Add(2 * time.Hour),
+			Messages: []glue.Message{
+				runnerTextMessage(glue.MessageRoleUser, "cli prompt"),
+				runnerTextMessage(glue.MessageRoleAssistant, "cli answer"),
+			},
+		},
+	}
+	for id, state := range states {
+		if err := store.Save(context.Background(), id, state); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	return writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "sqlite",
+			"path": dbPath,
+		},
+	})
+}
+
+func runnerTextMessage(role glue.MessageRole, body string) glue.Message {
+	return glue.Message{
+		Role:    role,
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: body}},
+	}
+}
+
 func seedRunnerMemories(t *testing.T) string {
 	t.Helper()
 	storePath := filepath.Join(t.TempDir(), "sessions")

--- a/store.go
+++ b/store.go
@@ -21,6 +21,35 @@ type Store interface {
 	Delete(ctx context.Context, id string) error
 }
 
+// SessionLister is an optional store capability for provider-free session
+// history browsers.
+type SessionLister interface {
+	ListSessions(ctx context.Context, opts ListSessionsOptions) ([]SessionSummary, error)
+}
+
+// ListSessionsOptions filters and pages a session history listing.
+type ListSessionsOptions struct {
+	// Prefix restricts results to session ids beginning with Prefix.
+	Prefix string
+
+	// Limit caps returned rows. Non-positive values use the store default.
+	Limit int
+
+	// Offset skips rows after filtering and ordering. Negative values are
+	// treated as zero.
+	Offset int
+}
+
+// SessionSummary is provider-free metadata about one stored session.
+type SessionSummary struct {
+	ID                string    `json:"id"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	Messages          int       `json:"messages"`
+	UserMessages      int       `json:"user_messages"`
+	AssistantMessages int       `json:"assistant_messages"`
+}
+
 // SessionState is the durable representation of a session.
 type SessionState struct {
 	Version   int            `json:"version"`

--- a/stores/file/store.go
+++ b/stores/file/store.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -118,6 +119,85 @@ func (s *Store) Delete(_ context.Context, id string) error {
 	return nil
 }
 
+// ListSessions implements glue.SessionLister by scanning JSON session files.
+func (s *Store) ListSessions(ctx context.Context, opts glue.ListSessionsOptions) ([]glue.SessionSummary, error) {
+	if s == nil {
+		return nil, errors.New("file store: nil store")
+	}
+	if strings.TrimSpace(s.dir) == "" {
+		return nil, errors.New("file store: directory is required")
+	}
+	entries, err := os.ReadDir(s.dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return []glue.SessionSummary{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	prefix := strings.TrimSpace(opts.Prefix)
+	summaries := make([]glue.SessionSummary, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id, err := url.PathUnescape(strings.TrimSuffix(entry.Name(), ".json"))
+		if err != nil {
+			return nil, fmt.Errorf("file store: decode session file %s: %w", entry.Name(), err)
+		}
+		if prefix != "" && !strings.HasPrefix(id, prefix) {
+			continue
+		}
+		state, found, err := s.Load(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		summaries = append(summaries, sessionSummaryFromState(state))
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if !summaries[i].UpdatedAt.Equal(summaries[j].UpdatedAt) {
+			return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt)
+		}
+		return summaries[i].ID < summaries[j].ID
+	})
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(summaries) {
+		return []glue.SessionSummary{}, nil
+	}
+	summaries = summaries[offset:]
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if len(summaries) > limit {
+		summaries = summaries[:limit]
+	}
+	return summaries, nil
+}
+
+func sessionSummaryFromState(state glue.SessionState) glue.SessionSummary {
+	summary := glue.SessionSummary{
+		ID:        state.ID,
+		CreatedAt: state.CreatedAt,
+		UpdatedAt: state.UpdatedAt,
+		Messages:  len(state.Messages),
+	}
+	for _, message := range state.Messages {
+		switch message.Role {
+		case glue.MessageRoleUser:
+			summary.UserMessages++
+		case glue.MessageRoleAssistant:
+			summary.AssistantMessages++
+		}
+	}
+	return summary
+}
+
 // Path returns the JSON file path for a session id. It is exposed for tests
 // and debugging; production code should not rely on it.
 func (s *Store) Path(id string) (string, error) {
@@ -136,3 +216,5 @@ func (s *Store) path(id string) (string, error) {
 	}
 	return filepath.Join(s.dir, url.PathEscape(id)+".json"), nil
 }
+
+var _ glue.SessionLister = (*Store)(nil)

--- a/stores/sqlite/sqlite.go
+++ b/stores/sqlite/sqlite.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	_ "modernc.org/sqlite" // registers the "sqlite" driver
 	"github.com/erain/glue"
+	_ "modernc.org/sqlite" // registers the "sqlite" driver
 )
 
 // Options configures a Store.
@@ -25,6 +25,7 @@ type Options struct {
 }
 
 const defaultTimeout = 5 * time.Second
+const defaultSessionListLimit = 50
 
 // Store implements glue.Store against a SQLite file with FTS5 over
 // message text.
@@ -251,6 +252,67 @@ func (s *Store) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+// ListSessions implements glue.SessionLister.
+func (s *Store) ListSessions(ctx context.Context, opts glue.ListSessionsOptions) ([]glue.SessionSummary, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("sqlite: nil store")
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultSessionListLimit
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	prefix := strings.TrimSpace(opts.Prefix)
+	likePrefix := escapeSQLiteLike(prefix) + "%"
+	rows, err := s.db.QueryContext(ctx, `
+SELECT s.id,
+       s.created_at,
+       s.updated_at,
+       COUNT(m.rowid) AS messages,
+       COALESCE(SUM(CASE WHEN m.role = ? THEN 1 ELSE 0 END), 0) AS user_messages,
+       COALESCE(SUM(CASE WHEN m.role = ? THEN 1 ELSE 0 END), 0) AS assistant_messages
+  FROM sessions s
+  LEFT JOIN messages m ON m.session_id = s.id
+ WHERE (? = '' OR s.id LIKE ? ESCAPE '\')
+ GROUP BY s.id, s.created_at, s.updated_at
+ ORDER BY s.updated_at DESC, s.id ASC
+ LIMIT ? OFFSET ?
+`, string(glue.MessageRoleUser), string(glue.MessageRoleAssistant), prefix, likePrefix, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list sessions: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]glue.SessionSummary, 0, limit)
+	for rows.Next() {
+		var (
+			summary   glue.SessionSummary
+			createdUx int64
+			updatedUx int64
+		)
+		if err := rows.Scan(
+			&summary.ID,
+			&createdUx,
+			&updatedUx,
+			&summary.Messages,
+			&summary.UserMessages,
+			&summary.AssistantMessages,
+		); err != nil {
+			return nil, fmt.Errorf("sqlite: scan session summary: %w", err)
+		}
+		summary.CreatedAt = time.Unix(createdUx, 0).UTC()
+		summary.UpdatedAt = time.Unix(updatedUx, 0).UTC()
+		out = append(out, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // textForFTS concatenates the text content of a message's parts with
 // "\n" separators. Tool calls, tool-call args, image content, and
 // thinking are intentionally excluded from the FTS index — searches
@@ -269,6 +331,15 @@ func textForFTS(parts []glue.ContentPart) string {
 	}
 	return b.String()
 }
+
+func escapeSQLiteLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
+var _ glue.SessionLister = (*Store)(nil)
 
 // DB returns the underlying *sql.DB for tests and future Searcher
 // implementations that need direct query access. Public consumers


### PR DESCRIPTION
## Summary
- add an optional `glue.SessionLister` store capability with stable session summaries
- implement session listing for SQLite and file-backed stores
- add `peggy sessions` with prefix filtering, limit/offset, text output, and JSON output

Closes #257.

## Validation
- `go test ./stores/sqlite ./stores/file ./agents/peggy -count=1`
- `git diff --check`
- `env -u NVIDIA_API_KEY -u OPENROUTER_API_KEY -u GEMINI_API_KEY go test ./... -count=1`