### PR TITLE
daemon: add ops diagnostics

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -27,6 +27,10 @@ not formally follow SemVer until v1.0.
 - **Session history browser.** `peggy sessions` lists recent stored
   sessions without starting a provider, with prefix filtering and JSON
   output for scriptable local history inspection.
+- **Daemon ops diagnostics.** Peggy daemon mode now advertises
+  authenticated non-secret runtime diagnostics, and `glue connect
+  --diagnose` distinguishes missing metadata, stale metadata, bad
+  tokens, unreachable daemons, and healthy daemon state.
 - **Telegram daemon status command.** In daemon-client mode,
   allowlisted Telegram chats can use `/status` to check daemon health,
   active runs, tool count, and advertised capabilities without opening

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -400,6 +400,7 @@ session history and memory store.
 
 ```sh
 peggy serve --config ~/.config/peggy/settings.json
+glue connect --diagnose
 glue connect --inspect
 glue connect --memories
 glue connect --forget-memory mem_123
@@ -431,20 +432,32 @@ Useful `serve` flags:
   over the daemon protocol for the connected client to answer.
 
 Startup output prints the `base_url` and metadata path, never the
-bearer token. `glue connect --inspect` includes status, tools,
-daemon-advertised skills, daemon-advertised roles, daemon-advertised
-memories, and any daemon-advertised MCP resource/prompt catalogs. Use
-`--memory-limit` to cap the memory section. Use `--skills-json`,
+bearer token. If a client cannot connect, run `glue connect
+--diagnose` first: it reports whether metadata is missing, points at a
+stale daemon, has a bad token, or reaches a healthy daemon, and it
+shows non-secret runtime details such as provider, model, store path,
+listen address, active runs, and recent daemon run errors.
+
+`glue connect --inspect` includes status, tools, daemon-advertised
+skills, daemon-advertised roles, daemon-advertised memories, and any
+daemon-advertised MCP resource/prompt catalogs. Use `--memory-limit` to
+cap the memory section. Use `--diagnose-json`, `--skills-json`,
 `--roles-json`, `--mcp-resources-json`, `--mcp-prompts-json`,
 `--mcp-read-json`, `--mcp-prompt-json`, `--recall-json`, or
-`--memories-json` when another client needs catalog/search payloads as
-data. Use `--forget-memory-json` when another client needs the removed
-memory record as data. Add `--usage` to prompt or skill-mode
+`--memories-json` when another client needs diagnostics/catalog/search
+payloads as data. Use `--forget-memory-json` when another client needs
+the removed memory record as data. Add `--usage` to prompt or skill-mode
 `glue connect` when you want
 provider-reported token usage on stderr. Add
 `--usage-input-price`, `--usage-output-price`, and optional cache price
 flags to estimate USD cost from prices you supply. Stop the daemon with
 SIGINT/SIGTERM.
+
+Restart/recovery is intentionally local-first: stop the current
+`peggy serve` process with SIGINT/SIGTERM, start it again, and let it
+rewrite the metadata file. Existing SQLite sessions, curated memories,
+and persisted permission grants remain on disk; only in-flight daemon
+runs are lost.
 
 Telegram can attach to the same daemon:
 

--- a/agents/peggy/channels/telegram/README.md
+++ b/agents/peggy/channels/telegram/README.md
@@ -66,6 +66,9 @@ peggy-telegram --daemon
 `--daemon-token`, or `--daemon-metadata`; the token also falls back to
 `GLUE_DAEMON_TOKEN`. Telegram still enforces `allow_chats` before any
 daemon request is sent.
+If Telegram cannot reach the daemon, run `glue connect --diagnose`
+from the same shell or host to check metadata, token, and reachability
+without starting a model run.
 
 Daemon-client mode sends an immediate progress reply for daemon runs
 and splits long final answers across Telegram messages. It also

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -2465,10 +2465,25 @@ Flags:
 	defer p.Close()
 
 	handler, err := daemon.New(daemon.Options{
-		Host:              p,
-		Token:             token,
-		PermissionPolicy:  NewDaemonPermissionPolicy(settings.Permissions),
-		PermissionStore:   permissionStore,
+		Host:             p,
+		Token:            token,
+		PermissionPolicy: NewDaemonPermissionPolicy(settings.Permissions),
+		PermissionStore:  permissionStore,
+		Diagnostics: daemon.DiagnosticInfo{
+			Name:                   "peggy",
+			ListenAddr:             *listenAddr,
+			MetadataPath:           *metadataPath,
+			TokenSource:            tokenSource,
+			Provider:               settings.Provider,
+			Model:                  statusModel(settings.Model),
+			StoreType:              settings.Store.Type,
+			StorePath:              settings.Store.Path,
+			SettingsPath:           settingsPath,
+			IdentityPath:           soulPathUsed,
+			CodingEnabled:          settings.Coding.Enabled,
+			CodingWorkDir:          settings.Coding.WorkDir,
+			PermissionRememberPath: settings.Permissions.RememberPath,
+		},
 		PermissionTimeout: *permissionTimeout,
 	})
 	if err != nil {

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/erain/glue"
+	"github.com/erain/glue/daemon"
 	filestore "github.com/erain/glue/stores/file"
 	sqlitestore "github.com/erain/glue/stores/sqlite"
 	toolsmcp "github.com/erain/glue/tools/mcp"
@@ -1366,6 +1368,20 @@ func TestRunServeBuildsPeggyDaemonConfig(t *testing.T) {
 	}, strings.NewReader(""), &out, &errOut, func(_ context.Context, cfg serveConfig, handler http.Handler, _ io.Writer) error {
 		captured = cfg
 		gotHandler = handler != nil
+		req := httptest.NewRequest(http.MethodGet, "/v1/diagnostics", nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("diagnostics status = %d, want 200", rec.Code)
+		}
+		var diag daemon.DiagnosticResponse
+		if err := json.NewDecoder(rec.Body).Decode(&diag); err != nil {
+			t.Fatal(err)
+		}
+		if diag.Runtime.Provider != "openrouter" || diag.Runtime.StoreType != "file" || diag.Runtime.SettingsPath != cfgPath || !diag.Runtime.CodingEnabled {
+			t.Fatalf("diagnostics = %+v", diag.Runtime)
+		}
 		return nil
 	})
 	if code != 0 {

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -172,6 +172,25 @@ type daemonStatus struct {
 	Capabilities []string `json:"capabilities"`
 }
 
+type daemonDiagnostics = daemon.DiagnosticResponse
+
+type daemonDiagnosis struct {
+	OK            bool               `json:"ok"`
+	State         string             `json:"state"`
+	Summary       string             `json:"summary"`
+	MetadataPath  string             `json:"metadata_path,omitempty"`
+	MetadataFound bool               `json:"metadata_found"`
+	MetadataError string             `json:"metadata_error,omitempty"`
+	MetadataPID   int                `json:"metadata_pid,omitempty"`
+	BaseURL       string             `json:"base_url,omitempty"`
+	BaseURLSource string             `json:"base_url_source,omitempty"`
+	TokenSource   string             `json:"token_source,omitempty"`
+	HTTPStatus    int                `json:"http_status,omitempty"`
+	Status        *daemonStatus      `json:"status,omitempty"`
+	Diagnostics   *daemonDiagnostics `json:"diagnostics,omitempty"`
+	Suggestions   []string           `json:"suggestions,omitempty"`
+}
+
 type daemonInspect struct {
 	Status       daemonStatus                     `json:"status"`
 	Tools        []daemonToolCatalogEntry         `json:"tools"`
@@ -356,8 +375,18 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 		return err
 	}
 	handler, err := daemon.New(daemon.Options{
-		Host:              agent,
-		Token:             token,
+		Host:  agent,
+		Token: token,
+		Diagnostics: daemon.DiagnosticInfo{
+			Name:         "glue",
+			ListenAddr:   *listenAddr,
+			MetadataPath: *metadataPath,
+			TokenSource:  tokenSource,
+			Provider:     "gemini",
+			Model:        normalizeModel(*model),
+			StoreType:    "file",
+			StorePath:    *storeDir,
+		},
 		PermissionTimeout: *permissionTimeout,
 	})
 	if err != nil {
@@ -424,6 +453,8 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	forgetPermissionJSON := flags.Bool("forget-permission-json", false, "print --forget-permission output as JSON")
 	showStatus := flags.Bool("status", false, "show daemon status and exit without starting a run")
 	statusJSON := flags.Bool("status-json", false, "print --status output as JSON")
+	showDiagnose := flags.Bool("diagnose", false, "diagnose local daemon connectivity and runtime state without starting a run")
+	diagnoseJSON := flags.Bool("diagnose-json", false, "print --diagnose output as JSON")
 	showInspect := flags.Bool("inspect", false, "show daemon status and tools and exit without starting a run")
 	inspectJSON := flags.Bool("inspect-json", false, "print --inspect output as JSON")
 	var envs envFiles
@@ -462,6 +493,9 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if *statusJSON {
 		*showStatus = true
 	}
+	if *diagnoseJSON {
+		*showDiagnose = true
+	}
 	if *inspectJSON {
 		*showInspect = true
 	}
@@ -478,13 +512,13 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	showForgetMemory := strings.TrimSpace(*forgetMemoryID) != "" || *forgetMemoryJSON
 	showForgetPermission := strings.TrimSpace(*forgetPermissionID) != "" || *forgetPermissionJSON
 	inspectModes := 0
-	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, showForgetMemory, *showPermissions, showForgetPermission, *showStatus, *showInspect} {
+	for _, enabled := range []bool{*showTools, *showSkills, *showRoles, *showMCPResources, *showMCPPrompts, *showMCPRead, *showMCPPrompt, showRecall, *showMemories, showForgetMemory, *showPermissions, showForgetPermission, *showStatus, *showDiagnose, *showInspect} {
 		if enabled {
 			inspectModes++
 		}
 	}
 	if inspectModes > 1 {
-		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --forget-memory, --permissions, --forget-permission, --status, or --inspect")
+		return errors.New("choose only one of --tools, --skills, --roles, --mcp-resources, --mcp-prompts, --mcp-read, --mcp-prompt, --recall, --memories, --forget-memory, --permissions, --forget-permission, --status, --diagnose, or --inspect")
 	}
 	if inspectModes == 0 && strings.TrimSpace(*prompt) == "" && strings.TrimSpace(*skillName) == "" {
 		return errors.New("missing required --prompt or --skill")
@@ -499,7 +533,7 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 	if err != nil {
 		return err
 	}
-	cfg, err := resolveConnectConfig(connectConfig{
+	rawCfg := connectConfig{
 		BaseURL:      *baseURL,
 		Token:        *tokenFlag,
 		MetadataPath: *metadataPath,
@@ -511,7 +545,11 @@ func connectCommand(ctx context.Context, args []string, stdin io.Reader, stdout 
 		Model:        *model,
 		Role:         *role,
 		MaxTurns:     *maxTurns,
-	})
+	}
+	if *showDiagnose {
+		return runConnectDiagnose(ctx, rawCfg, *diagnoseJSON, stdout, client)
+	}
+	cfg, err := resolveConnectConfig(rawCfg)
 	if err != nil {
 		return err
 	}
@@ -844,6 +882,17 @@ func runConnectStatus(ctx context.Context, cfg connectConfig, jsonOutput bool, s
 	return nil
 }
 
+func runConnectDiagnose(ctx context.Context, cfg connectConfig, jsonOutput bool, stdout io.Writer, client httpDoer) error {
+	diagnosis := diagnoseDaemon(ctx, cfg, client)
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(diagnosis)
+	}
+	writeDaemonDiagnosis(stdout, diagnosis)
+	return nil
+}
+
 func runConnectInspect(ctx context.Context, cfg connectConfig, memoryLimit int, jsonOutput bool, stdout io.Writer, client httpDoer) error {
 	if memoryLimit < 0 {
 		return errors.New("--memory-limit must be non-negative")
@@ -929,6 +978,124 @@ func fetchDaemonStatus(ctx context.Context, cfg connectConfig, client httpDoer) 
 	return status, nil
 }
 
+func diagnoseDaemon(ctx context.Context, cfg connectConfig, client httpDoer) daemonDiagnosis {
+	diagnosis := daemonDiagnosis{
+		State:        "unknown",
+		MetadataPath: strings.TrimSpace(cfg.MetadataPath),
+	}
+	var meta daemonMetadata
+	var metadataErr error
+	if diagnosis.MetadataPath != "" {
+		loaded, err := readDaemonMetadata(diagnosis.MetadataPath)
+		if err != nil {
+			metadataErr = err
+			diagnosis.MetadataError = err.Error()
+		} else {
+			meta = loaded
+			diagnosis.MetadataFound = true
+			diagnosis.MetadataPID = meta.PID
+		}
+	}
+
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	switch {
+	case baseURL != "":
+		diagnosis.BaseURLSource = "flag"
+	case strings.TrimSpace(meta.BaseURL) != "":
+		baseURL = strings.TrimRight(strings.TrimSpace(meta.BaseURL), "/")
+		diagnosis.BaseURLSource = "metadata"
+	}
+	diagnosis.BaseURL = baseURL
+
+	token := strings.TrimSpace(cfg.Token)
+	switch {
+	case token != "":
+		diagnosis.TokenSource = "flag"
+	case strings.TrimSpace(meta.Token) != "":
+		token = strings.TrimSpace(meta.Token)
+		diagnosis.TokenSource = "metadata"
+	case strings.TrimSpace(os.Getenv("GLUE_DAEMON_TOKEN")) != "":
+		token = strings.TrimSpace(os.Getenv("GLUE_DAEMON_TOKEN"))
+		diagnosis.TokenSource = "GLUE_DAEMON_TOKEN"
+	default:
+		diagnosis.TokenSource = "missing"
+	}
+
+	if baseURL == "" {
+		if metadataErr != nil {
+			diagnosis.State = "no_metadata"
+			diagnosis.Summary = "daemon metadata is missing or unreadable"
+			diagnosis.Suggestions = []string{"Start Peggy with `peggy serve` or pass --base-url and --token explicitly."}
+			return diagnosis
+		}
+		diagnosis.State = "missing_base_url"
+		diagnosis.Summary = "daemon base URL is not configured"
+		diagnosis.Suggestions = []string{"Start Peggy with `peggy serve` or pass --base-url."}
+		return diagnosis
+	}
+	if token == "" {
+		diagnosis.State = "missing_token"
+		diagnosis.Summary = "daemon bearer token is not configured"
+		diagnosis.Suggestions = []string{"Use daemon metadata, pass --token, or set GLUE_DAEMON_TOKEN."}
+		return diagnosis
+	}
+
+	status, diagnostics, httpStatus, err := requestDaemonDiagnostics(ctx, baseURL, token, client)
+	diagnosis.HTTPStatus = httpStatus
+	if err != nil {
+		diagnosis.Summary = err.Error()
+		switch {
+		case httpStatus == http.StatusUnauthorized:
+			diagnosis.State = "auth_failed"
+			diagnosis.Suggestions = []string{"Use the token from the active metadata file or restart the daemon to refresh metadata."}
+		case httpStatus > 0:
+			diagnosis.State = "unhealthy"
+			diagnosis.Suggestions = []string{"Check daemon logs and restart `peggy serve` if the error persists."}
+		case diagnosis.MetadataFound && strings.TrimSpace(cfg.BaseURL) == "":
+			diagnosis.State = "stale_metadata"
+			diagnosis.Suggestions = []string{"The metadata file points at an unreachable daemon; restart `peggy serve` to refresh it."}
+		default:
+			diagnosis.State = "unreachable"
+			diagnosis.Suggestions = []string{"Check that the daemon is running and the --base-url value is correct."}
+		}
+		return diagnosis
+	}
+	diagnosis.OK = true
+	diagnosis.State = "healthy"
+	diagnosis.Summary = "daemon is reachable and authenticated"
+	diagnosis.Status = &status
+	diagnosis.Diagnostics = &diagnostics
+	return diagnosis
+}
+
+func requestDaemonDiagnostics(ctx context.Context, baseURL, token string, client httpDoer) (daemonStatus, daemonDiagnostics, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/diagnostics", nil)
+	if err != nil {
+		return daemonStatus{}, daemonDiagnostics{}, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonStatus{}, daemonDiagnostics{}, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return daemonStatus{}, daemonDiagnostics{}, resp.StatusCode, fmt.Errorf("daemon diagnostics: %s", httpStatusError(resp))
+	}
+	var diagnostics daemonDiagnostics
+	if err := json.NewDecoder(resp.Body).Decode(&diagnostics); err != nil {
+		return daemonStatus{}, daemonDiagnostics{}, resp.StatusCode, err
+	}
+	status := daemonStatus{
+		OK:           diagnostics.OK,
+		Version:      diagnostics.Version,
+		ActiveRuns:   diagnostics.ActiveRuns,
+		ToolsCount:   diagnostics.ToolsCount,
+		Capabilities: diagnostics.Capabilities,
+	}
+	return status, diagnostics, resp.StatusCode, nil
+}
+
 func writeDaemonStatus(w io.Writer, status daemonStatus) {
 	state := "error"
 	if status.OK {
@@ -940,6 +1107,107 @@ func writeDaemonStatus(w io.Writer, status daemonStatus) {
 	fmt.Fprintf(w, "tools_count: %d\n", status.ToolsCount)
 	if len(status.Capabilities) > 0 {
 		fmt.Fprintf(w, "capabilities: %s\n", strings.Join(status.Capabilities, ", "))
+	}
+}
+
+func writeDaemonDiagnosis(w io.Writer, diagnosis daemonDiagnosis) {
+	state := diagnosis.State
+	if state == "" {
+		state = "unknown"
+	}
+	fmt.Fprintf(w, "daemon: %s\n", state)
+	if diagnosis.Summary != "" {
+		fmt.Fprintf(w, "summary: %s\n", diagnosis.Summary)
+	}
+	if diagnosis.MetadataPath != "" {
+		fmt.Fprintf(w, "metadata: %s", diagnosis.MetadataPath)
+		if diagnosis.MetadataFound {
+			fmt.Fprint(w, " (found)")
+			if diagnosis.MetadataPID != 0 {
+				fmt.Fprintf(w, " pid=%d", diagnosis.MetadataPID)
+			}
+		} else {
+			fmt.Fprint(w, " (missing)")
+		}
+		fmt.Fprintln(w)
+	}
+	if diagnosis.MetadataError != "" {
+		fmt.Fprintf(w, "metadata_error: %s\n", diagnosis.MetadataError)
+	}
+	if diagnosis.BaseURL != "" {
+		fmt.Fprintf(w, "base_url: %s", diagnosis.BaseURL)
+		if diagnosis.BaseURLSource != "" {
+			fmt.Fprintf(w, " (%s)", diagnosis.BaseURLSource)
+		}
+		fmt.Fprintln(w)
+	}
+	if diagnosis.TokenSource != "" {
+		fmt.Fprintf(w, "token: %s\n", diagnosis.TokenSource)
+	}
+	if diagnosis.HTTPStatus != 0 {
+		fmt.Fprintf(w, "http_status: %d\n", diagnosis.HTTPStatus)
+	}
+	if diagnosis.Status != nil {
+		fmt.Fprintf(w, "active_runs: %d\n", diagnosis.Status.ActiveRuns)
+		fmt.Fprintf(w, "tools_count: %d\n", diagnosis.Status.ToolsCount)
+	}
+	if diagnosis.Diagnostics != nil {
+		runtime := diagnosis.Diagnostics.Runtime
+		if runtime.Provider != "" {
+			fmt.Fprintf(w, "provider: %s\n", runtime.Provider)
+		}
+		if runtime.Model != "" {
+			fmt.Fprintf(w, "model: %s\n", runtime.Model)
+		}
+		if runtime.StoreType != "" || runtime.StorePath != "" {
+			fmt.Fprintf(w, "store: %s", runtime.StoreType)
+			if runtime.StorePath != "" {
+				fmt.Fprintf(w, " %s", runtime.StorePath)
+			}
+			fmt.Fprintln(w)
+		}
+		if runtime.ListenAddr != "" {
+			fmt.Fprintf(w, "listen_addr: %s\n", runtime.ListenAddr)
+		}
+		if runtime.MetadataPath != "" {
+			fmt.Fprintf(w, "runtime_metadata: %s\n", runtime.MetadataPath)
+		}
+		if runtime.TokenSource != "" {
+			fmt.Fprintf(w, "runtime_token_source: %s\n", runtime.TokenSource)
+		}
+		if runtime.CodingEnabled {
+			fmt.Fprintf(w, "coding: enabled")
+			if runtime.CodingWorkDir != "" {
+				fmt.Fprintf(w, " %s", runtime.CodingWorkDir)
+			}
+			fmt.Fprintln(w)
+		}
+		if len(diagnosis.Diagnostics.RecentErrors) > 0 {
+			fmt.Fprintln(w, "recent_errors:")
+			for _, entry := range diagnosis.Diagnostics.RecentErrors {
+				timestamp := "unknown"
+				if !entry.Time.IsZero() {
+					timestamp = entry.Time.Format(time.RFC3339)
+				}
+				fmt.Fprintf(w, "  %s %s", timestamp, entry.Error)
+				if entry.RunID != "" {
+					fmt.Fprintf(w, " run=%s", entry.RunID)
+				}
+				if entry.SessionID != "" {
+					fmt.Fprintf(w, " session=%s", entry.SessionID)
+				}
+				if entry.ClientID != "" {
+					fmt.Fprintf(w, " client=%s", entry.ClientID)
+				}
+				fmt.Fprintln(w)
+			}
+		}
+	}
+	if len(diagnosis.Suggestions) > 0 {
+		fmt.Fprintln(w, "suggestions:")
+		for _, suggestion := range diagnosis.Suggestions {
+			fmt.Fprintf(w, "  - %s\n", suggestion)
+		}
 	}
 }
 
@@ -2025,6 +2293,7 @@ func printUsage(w io.Writer) {
   glue connect --skill <name> [--arg key=value] [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --inspect [--inspect-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --status [--status-json] [--metadata <path>] [--base-url <url>] [--token <token>]
+  glue connect --diagnose [--diagnose-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --tools [--tools-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --skills [--skills-json] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --roles [--roles-json] [--metadata <path>] [--base-url <url>] [--token <token>]
@@ -2063,6 +2332,10 @@ Flags:
   --status   Connect mode: show daemon status and exit without starting a run.
   --status-json
              Connect --status mode: print JSON.
+  --diagnose
+             Connect mode: diagnose daemon metadata, auth, reachability, and runtime state.
+  --diagnose-json
+             Connect --diagnose mode: print JSON.
   --tools    Connect mode: list daemon tools and exit without starting a run.
   --tools-json
              Connect --tools mode: print JSON.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -2086,6 +2086,156 @@ func TestRunCLIConnectShowsStatusJSON(t *testing.T) {
 	}
 }
 
+func TestRunCLIConnectDiagnoseHealthyDaemon(t *testing.T) {
+	var sawDiagnostics bool
+	var sawRun bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/diagnostics":
+			sawDiagnostics = true
+			if r.Method != http.MethodGet {
+				t.Fatalf("diagnostics method = %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer secret-token" {
+				t.Fatalf("diagnostics auth = %q", auth)
+			}
+			writeJSONResponse(t, w, http.StatusOK, daemon.DiagnosticResponse{
+				OK:           true,
+				Version:      1,
+				ActiveRuns:   2,
+				ToolsCount:   5,
+				Capabilities: []string{"runs", "status", "diagnostics"},
+				Runtime: daemon.DiagnosticInfo{
+					Name:         "peggy",
+					ListenAddr:   "127.0.0.1:0",
+					MetadataPath: "/tmp/daemon.json",
+					TokenSource:  "generated",
+					Provider:     "codex",
+					Model:        "codex/default",
+					StoreType:    "sqlite",
+					StorePath:    "/tmp/peggy.db",
+				},
+				RecentErrors: []daemon.DiagnosticError{{
+					Time:      time.Date(2026, 5, 25, 14, 0, 0, 0, time.UTC),
+					RunID:     "run_1",
+					SessionID: "default",
+					ClientID:  "cli:test",
+					Error:     "provider failed",
+				}},
+			})
+		case "/v1/sessions/default/runs":
+			sawRun = true
+			http.Error(w, "unexpected run", http.StatusTeapot)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	metadataPath := filepath.Join(t.TempDir(), "daemon.json")
+	if err := writeDaemonMetadata(metadataPath, daemonMetadata{
+		Version: 1,
+		BaseURL: ts.URL,
+		Token:   "secret-token",
+		PID:     123,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--diagnose",
+		"--metadata", metadataPath,
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !sawDiagnostics || sawRun {
+		t.Fatalf("sawDiagnostics=%v sawRun=%v", sawDiagnostics, sawRun)
+	}
+	for _, want := range []string{
+		"daemon: healthy",
+		"metadata: " + metadataPath + " (found) pid=123",
+		"token: metadata",
+		"provider: codex",
+		"store: sqlite /tmp/peggy.db",
+		"recent_errors:",
+		"provider failed run=run_1 session=default client=cli:test",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), want)
+		}
+	}
+	if strings.Contains(stdout.String(), "secret-token") {
+		t.Fatalf("stdout leaked token: %q", stdout.String())
+	}
+}
+
+func TestRunCLIConnectDiagnoseAuthFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/diagnostics" {
+			http.NotFound(w, r)
+			return
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer good-token" {
+			writeJSONResponse(t, w, http.StatusUnauthorized, map[string]any{"error": map[string]any{"code": "unauthorized", "message": "missing or invalid bearer token"}})
+			return
+		}
+		writeJSONResponse(t, w, http.StatusOK, daemon.DiagnosticResponse{OK: true})
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--diagnose",
+		"--base-url", ts.URL,
+		"--token", "bad-token",
+		"--metadata", "",
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "daemon: auth_failed") || !strings.Contains(stdout.String(), "http_status: 401") {
+		t.Fatalf("stdout = %q, want auth failure details", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "bad-token") {
+		t.Fatalf("stdout leaked token: %q", stdout.String())
+	}
+}
+
+func TestRunCLIConnectDiagnoseStaleMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	staleURL := ts.URL
+	ts.Close()
+	metadataPath := filepath.Join(t.TempDir(), "daemon.json")
+	if err := writeDaemonMetadata(metadataPath, daemonMetadata{
+		Version: 1,
+		BaseURL: staleURL,
+		Token:   "tok",
+		PID:     123,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"connect",
+		"--diagnose-json",
+		"--metadata", metadataPath,
+	}, strings.NewReader(""), &stdout, &stderr, fakeFactory(nil), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	var diagnosis daemonDiagnosis
+	if err := json.Unmarshal(stdout.Bytes(), &diagnosis); err != nil {
+		t.Fatalf("decode diagnosis: %v\n%s", err, stdout.String())
+	}
+	if diagnosis.OK || diagnosis.State != "stale_metadata" || !diagnosis.MetadataFound || diagnosis.BaseURL != staleURL {
+		t.Fatalf("diagnosis = %+v", diagnosis)
+	}
+}
+
 func TestRunCLIConnectInspectsDaemon(t *testing.T) {
 	var sawStatus bool
 	var sawTools bool

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -260,6 +260,46 @@ type PermissionStore interface {
 	SavePermissionGrants([]PermissionGrant) error
 }
 
+// DiagnosticInfo describes non-secret runtime configuration that daemon
+// clients can use for local operations troubleshooting.
+type DiagnosticInfo struct {
+	Name                   string    `json:"name,omitempty"`
+	StartedAt              time.Time `json:"started_at,omitempty"`
+	ListenAddr             string    `json:"listen_addr,omitempty"`
+	MetadataPath           string    `json:"metadata_path,omitempty"`
+	TokenSource            string    `json:"token_source,omitempty"`
+	Provider               string    `json:"provider,omitempty"`
+	Model                  string    `json:"model,omitempty"`
+	StoreType              string    `json:"store_type,omitempty"`
+	StorePath              string    `json:"store_path,omitempty"`
+	SettingsPath           string    `json:"settings_path,omitempty"`
+	IdentityPath           string    `json:"identity_path,omitempty"`
+	CodingEnabled          bool      `json:"coding_enabled"`
+	CodingWorkDir          string    `json:"coding_work_dir,omitempty"`
+	PermissionRememberPath string    `json:"permission_remember_path,omitempty"`
+}
+
+// DiagnosticError is one recent daemon runtime error, redacted for
+// operational display.
+type DiagnosticError struct {
+	Time      time.Time `json:"time"`
+	RunID     string    `json:"run_id,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
+	ClientID  string    `json:"client_id,omitempty"`
+	Error     string    `json:"error"`
+}
+
+// DiagnosticResponse is the authenticated daemon diagnostics payload.
+type DiagnosticResponse struct {
+	OK           bool              `json:"ok"`
+	Version      int               `json:"version"`
+	ActiveRuns   int               `json:"active_runs"`
+	ToolsCount   int               `json:"tools_count"`
+	Capabilities []string          `json:"capabilities"`
+	Runtime      DiagnosticInfo    `json:"runtime"`
+	RecentErrors []DiagnosticError `json:"recent_errors,omitempty"`
+}
+
 type filePermissionStore struct {
 	path string
 }
@@ -348,6 +388,10 @@ type Options struct {
 	// across daemon restarts.
 	PermissionStore PermissionStore
 
+	// Diagnostics carries non-secret host/runtime details for
+	// authenticated ops tooling.
+	Diagnostics DiagnosticInfo
+
 	// Now supplies event timestamps. Nil uses time.Now.
 	Now func() time.Time
 
@@ -410,12 +454,16 @@ type Server struct {
 	token             string
 	permissionPolicy  PermissionPolicy
 	permissionStore   PermissionStore
+	diagnostics       DiagnosticInfo
 	now               func() time.Time
 	newID             func(prefix string) string
 	permissionTimeout time.Duration
 
 	mu   sync.Mutex
 	runs map[string]*run
+
+	diagMu       sync.Mutex
+	recentErrors []DiagnosticError
 
 	permMu        sync.Mutex
 	sessionAllows map[string]PermissionGrant
@@ -537,11 +585,16 @@ func New(opts Options) (*Server, error) {
 	if permissionTimeout <= 0 {
 		permissionTimeout = defaultPermissionTimeout
 	}
+	diagnostics := opts.Diagnostics
+	if diagnostics.StartedAt.IsZero() {
+		diagnostics.StartedAt = now().UTC()
+	}
 	s := &Server{
 		host:              opts.Host,
 		token:             token,
 		permissionPolicy:  opts.PermissionPolicy,
 		permissionStore:   opts.PermissionStore,
+		diagnostics:       diagnostics,
 		now:               now,
 		newID:             newID,
 		permissionTimeout: permissionTimeout,
@@ -581,6 +634,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleStatus(w, r)
+		return
+	}
+
+	if r.URL.Path == "/v1/diagnostics" {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", false)
+			return
+		}
+		s.handleDiagnostics(w, r)
 		return
 	}
 
@@ -738,6 +800,10 @@ func (s *Server) authorized(r *http.Request) bool {
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.statusResponse())
+}
+
+func (s *Server) statusResponse() statusResponse {
 	toolsCount := 0
 	if host, ok := s.host.(ToolCatalogHost); ok {
 		toolsCount = len(host.ToolCatalog())
@@ -749,6 +815,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 		"permission_grants",
 		"tools",
 		"status",
+		"diagnostics",
 	}
 	if _, ok := s.host.(MCPResourceCatalogHost); ok {
 		capabilities = append(capabilities, "mcp_resources")
@@ -777,12 +844,28 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	if _, ok := s.host.(MemoryForgetHost); ok {
 		capabilities = append(capabilities, "memory_forget")
 	}
-	writeJSON(w, http.StatusOK, statusResponse{
+	return statusResponse{
 		OK:           true,
 		Version:      protocolVersion,
 		ActiveRuns:   s.activeRunCount(),
 		ToolsCount:   toolsCount,
 		Capabilities: capabilities,
+	}
+}
+
+func (s *Server) handleDiagnostics(w http.ResponseWriter, _ *http.Request) {
+	status := s.statusResponse()
+	s.diagMu.Lock()
+	recentErrors := append([]DiagnosticError(nil), s.recentErrors...)
+	s.diagMu.Unlock()
+	writeJSON(w, http.StatusOK, DiagnosticResponse{
+		OK:           status.OK,
+		Version:      status.Version,
+		ActiveRuns:   status.ActiveRuns,
+		ToolsCount:   status.ToolsCount,
+		Capabilities: append([]string(nil), status.Capabilities...),
+		Runtime:      s.diagnostics,
+		RecentErrors: recentErrors,
 	})
 }
 
@@ -1107,7 +1190,15 @@ func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, 
 		result, err = session.Prompt(ctx, req.Text, options...)
 	}
 	if err != nil {
-		r.emit("run_error", map[string]any{"error": errorFor(err)})
+		protocolErr := errorFor(err)
+		s.recordError(DiagnosticError{
+			Time:      s.now().UTC(),
+			RunID:     r.id,
+			SessionID: r.sessionID,
+			ClientID:  r.clientID,
+			Error:     protocolErr.Message,
+		})
+		r.emit("run_error", map[string]any{"error": protocolErr})
 		r.finish()
 		return
 	}
@@ -1117,6 +1208,23 @@ func (s *Server) executeRun(ctx context.Context, r *run, session *glue.Session, 
 		"new_messages": result.NewMessages,
 	})
 	r.finish()
+}
+
+func (s *Server) recordError(entry DiagnosticError) {
+	entry.Error = strings.TrimSpace(entry.Error)
+	if entry.Error == "" {
+		return
+	}
+	if entry.Time.IsZero() {
+		entry.Time = s.now().UTC()
+	}
+	s.diagMu.Lock()
+	defer s.diagMu.Unlock()
+	s.recentErrors = append([]DiagnosticError{entry}, s.recentErrors...)
+	const maxRecentErrors = 10
+	if len(s.recentErrors) > maxRecentErrors {
+		s.recentErrors = s.recentErrors[:maxRecentErrors]
+	}
 }
 
 func (s *Server) handleRunEvents(w http.ResponseWriter, r *http.Request, runID string) {

--- a/daemon/server_test.go
+++ b/daemon/server_test.go
@@ -249,6 +249,56 @@ func TestServerAuthAndHealth(t *testing.T) {
 	}
 }
 
+func TestServerDiagnostics(t *testing.T) {
+	agent := glue.NewAgent(glue.AgentOptions{Provider: scriptedProvider{}})
+	startedAt := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC)
+	srv, err := New(Options{
+		Host:  agent,
+		Token: "token",
+		Now:   func() time.Time { return startedAt },
+		Diagnostics: DiagnosticInfo{
+			Name:         "peggy",
+			ListenAddr:   "127.0.0.1:0",
+			MetadataPath: "/tmp/daemon.json",
+			TokenSource:  "generated",
+			Provider:     "codex",
+			Model:        "codex/default",
+			StoreType:    "sqlite",
+			StorePath:    "/tmp/peggy.db",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/diagnostics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated diagnostics status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp = getJSON(t, ts.URL+"/v1/diagnostics", "token")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("diagnostics status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var diag DiagnosticResponse
+	if err := json.NewDecoder(resp.Body).Decode(&diag); err != nil {
+		t.Fatal(err)
+	}
+	if !diag.OK || diag.Version != protocolVersion || diag.Runtime.Provider != "codex" || diag.Runtime.StorePath != "/tmp/peggy.db" {
+		t.Fatalf("diagnostics = %+v", diag)
+	}
+	if !contains(diag.Capabilities, "diagnostics") {
+		t.Fatalf("capabilities = %v, missing diagnostics", diag.Capabilities)
+	}
+}
+
 func TestServerToolsCatalog(t *testing.T) {
 	agent := glue.NewAgent(glue.AgentOptions{
 		Provider: scriptedProvider{},


### PR DESCRIPTION
## Summary
- add authenticated daemon diagnostics with non-secret runtime metadata and recent run errors
- expose `glue connect --diagnose` / `--diagnose-json` for healthy, stale metadata, bad token, and unreachable daemon states
- populate Peggy daemon diagnostics with provider, model, store, metadata, coding, and permission persistence details

Closes #258.

## Validation
- `go test ./daemon ./cmd/glue ./agents/peggy -count=1`
- `git diff --check`
- `env -u NVIDIA_API_KEY -u OPENROUTER_API_KEY -u GEMINI_API_KEY go test ./... -count=1`