### PR TITLE
agents/peggy: add memory backup and restore

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -31,6 +31,10 @@ not formally follow SemVer until v1.0.
   authenticated non-secret runtime diagnostics, and `glue connect
   --diagnose` distinguishes missing metadata, stale metadata, bad
   tokens, unreachable daemons, and healthy daemon state.
+- **Memory backup and restore.** `peggy memories export` writes curated
+  memories to a versioned JSON backup, and `peggy memories import`
+  validates, dry-runs, and restores those memories while skipping
+  existing duplicates by id or content.
 - **Telegram daemon status command.** In daemon-client mode,
   allowlisted Telegram chats can use `/status` to check daemon health,
   active runs, tool count, and advertised capabilities without opening

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -120,6 +120,7 @@ glue connect --skill daily_plan --id cli:daily-plan
 glue connect --prompt "Dogfood smoke marker: Peggy daemon is reachable." --id cli:smoke
 glue connect --recall "Dogfood smoke marker"
 peggy sessions --config ~/.config/peggy/settings.json --prefix cli:
+peggy memories export --config ~/.config/peggy/settings.json --output peggy-memories.json
 ```
 
 To reach Peggy from your phone, merge a Telegram channel block into
@@ -736,12 +737,21 @@ Inspect curated memories from the terminal without starting a provider:
 peggy memories --config ~/.config/peggy/settings.json
 peggy memories --config ~/.config/peggy/settings.json --json
 peggy memories --config ~/.config/peggy/settings.json --limit 20
+peggy memories export --config ~/.config/peggy/settings.json --output peggy-memories.json
+peggy memories import --config ~/.config/peggy/settings.json --dry-run peggy-memories.json
 peggy memories forget --config ~/.config/peggy/settings.json mem_123
 ```
 
 Each memory has a stable `id` in human and JSON output. `forget` only
 removes curated `remember` records from the dedicated memory session; it
 does not delete ordinary conversation history.
+
+`peggy memories export` writes a backup envelope containing only curated
+memories, preserving ids, timestamps, content, and tags. `peggy memories
+import` validates that envelope before writing; use `--dry-run` to check
+the file first. Imports skip existing memories by stable id or normalized
+content to avoid accidental duplicates, and they do not import ordinary
+session transcripts.
 
 List recent stored sessions without starting a provider:
 

--- a/agents/peggy/memory_backup.go
+++ b/agents/peggy/memory_backup.go
@@ -1,0 +1,289 @@
+package peggy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+const (
+	// MemoryBackupKind identifies Peggy curated-memory backup files.
+	MemoryBackupKind = "peggy.memories"
+
+	// MemoryBackupVersion is the JSON backup format version.
+	MemoryBackupVersion = 1
+)
+
+// MemoryBackup is the JSON envelope used for curated-memory export/import.
+// It intentionally contains only the __memories__ session, not ordinary
+// conversation history.
+type MemoryBackup struct {
+	Version    int       `json:"version"`
+	Kind       string    `json:"kind"`
+	ExportedAt time.Time `json:"exported_at"`
+	Memories   []Memory  `json:"memories"`
+}
+
+// MemoryImportOptions controls backup import behavior.
+type MemoryImportOptions struct {
+	DryRun bool
+}
+
+// MemoryImportReport summarizes a backup import or dry-run validation.
+type MemoryImportReport struct {
+	DryRun      bool                `json:"dry_run"`
+	WouldImport int                 `json:"would_import,omitempty"`
+	Imported    int                 `json:"imported"`
+	Skipped     int                 `json:"skipped"`
+	Entries     []MemoryImportEntry `json:"entries"`
+}
+
+// MemoryImportEntry records the import decision for one backup memory.
+type MemoryImportEntry struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// ExportMemoryBackup returns a JSON-ready curated-memory backup.
+func (p *Peggy) ExportMemoryBackup(ctx context.Context) (MemoryBackup, error) {
+	memories, err := p.ListMemories(ctx)
+	if err != nil {
+		return MemoryBackup{}, err
+	}
+	sort.SliceStable(memories, func(i, j int) bool {
+		if memories[i].Timestamp.Equal(memories[j].Timestamp) {
+			return memories[i].ID < memories[j].ID
+		}
+		return memories[i].Timestamp.Before(memories[j].Timestamp)
+	})
+	return MemoryBackup{
+		Version:    MemoryBackupVersion,
+		Kind:       MemoryBackupKind,
+		ExportedAt: time.Now().UTC(),
+		Memories:   memories,
+	}, nil
+}
+
+// DecodeMemoryBackup reads either the Peggy backup envelope or the older
+// raw []Memory JSON shape produced by `peggy memories --json`.
+func DecodeMemoryBackup(r io.Reader) (MemoryBackup, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return MemoryBackup{}, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return MemoryBackup{}, errors.New("memory backup is empty")
+	}
+	switch bytes.TrimSpace(data)[0] {
+	case '[':
+		var memories []Memory
+		if err := decodeStrictJSON(data, &memories); err != nil {
+			return MemoryBackup{}, fmt.Errorf("decode memory list: %w", err)
+		}
+		return MemoryBackup{
+			Version:  MemoryBackupVersion,
+			Kind:     MemoryBackupKind,
+			Memories: memories,
+		}, nil
+	default:
+		var backup MemoryBackup
+		if err := decodeStrictJSON(data, &backup); err != nil {
+			return MemoryBackup{}, fmt.Errorf("decode memory backup: %w", err)
+		}
+		return backup, nil
+	}
+}
+
+// ImportMemoryBackup validates and imports curated memories. Existing
+// memories are never overwritten; duplicates by stable id or normalized
+// content are skipped.
+func (p *Peggy) ImportMemoryBackup(ctx context.Context, backup MemoryBackup, opts MemoryImportOptions) (MemoryImportReport, error) {
+	if p == nil || p.store == nil {
+		return MemoryImportReport{}, errors.New("peggy: ImportMemoryBackup: not initialised")
+	}
+	memories, err := ValidateMemoryBackup(backup)
+	if err != nil {
+		return MemoryImportReport{}, err
+	}
+
+	memoryWriteMu.Lock()
+	defer memoryWriteMu.Unlock()
+
+	state, _, err := p.store.Load(ctx, MemoriesSessionID)
+	if err != nil {
+		return MemoryImportReport{}, fmt.Errorf("peggy: load memories: %w", err)
+	}
+	now := time.Now().UTC()
+	if state.ID == "" {
+		state.ID = MemoriesSessionID
+	}
+	if state.Version == 0 {
+		state.Version = glue.SessionStateVersion
+	}
+	if state.CreatedAt.IsZero() {
+		state.CreatedAt = firstMemoryTimestamp(memories, now)
+	}
+
+	existingIDs := map[string]struct{}{}
+	existingContents := map[string]struct{}{}
+	for _, msg := range state.Messages {
+		mem, ok := memoryFromMessage(msg)
+		if !ok {
+			continue
+		}
+		existingIDs[mem.ID] = struct{}{}
+		existingContents[normalizedMemoryContent(mem.Content)] = struct{}{}
+	}
+
+	report := MemoryImportReport{DryRun: opts.DryRun, Entries: make([]MemoryImportEntry, 0, len(memories))}
+	for _, mem := range memories {
+		entry := MemoryImportEntry{ID: mem.ID}
+		contentKey := normalizedMemoryContent(mem.Content)
+		if _, exists := existingIDs[mem.ID]; exists {
+			entry.Status = "skipped"
+			entry.Reason = "duplicate_id"
+			report.Skipped++
+			report.Entries = append(report.Entries, entry)
+			continue
+		}
+		if _, exists := existingContents[contentKey]; exists {
+			entry.Status = "skipped"
+			entry.Reason = "duplicate_content"
+			report.Skipped++
+			report.Entries = append(report.Entries, entry)
+			continue
+		}
+		if opts.DryRun {
+			entry.Status = "would_import"
+			report.WouldImport++
+		} else {
+			entry.Status = "imported"
+			report.Imported++
+			state.Messages = append(state.Messages, memoryMessage(mem))
+		}
+		existingIDs[mem.ID] = struct{}{}
+		existingContents[contentKey] = struct{}{}
+		report.Entries = append(report.Entries, entry)
+	}
+
+	if !opts.DryRun && report.Imported > 0 {
+		state.UpdatedAt = now
+		if err := p.store.Save(ctx, MemoriesSessionID, state); err != nil {
+			return MemoryImportReport{}, fmt.Errorf("peggy: save memories: %w", err)
+		}
+	}
+	return report, nil
+}
+
+// ValidateMemoryBackup validates backup shape and returns normalized memories.
+func ValidateMemoryBackup(backup MemoryBackup) ([]Memory, error) {
+	if backup.Version != MemoryBackupVersion {
+		return nil, fmt.Errorf("unsupported memory backup version %d", backup.Version)
+	}
+	if backup.Kind != MemoryBackupKind {
+		return nil, fmt.Errorf("unsupported memory backup kind %q", backup.Kind)
+	}
+	memories := make([]Memory, 0, len(backup.Memories))
+	seenIDs := map[string]struct{}{}
+	for i, mem := range backup.Memories {
+		mem.Content = strings.TrimSpace(mem.Content)
+		if mem.Content == "" {
+			return nil, fmt.Errorf("memory %d: content is required", i)
+		}
+		if mem.Timestamp.IsZero() {
+			return nil, fmt.Errorf("memory %d: timestamp is required", i)
+		}
+		mem.Timestamp = mem.Timestamp.UTC()
+		mem.ID = strings.TrimSpace(mem.ID)
+		if mem.ID == "" {
+			mem.ID = memoryID(mem.Timestamp, mem.Content)
+		}
+		if _, ok := seenIDs[mem.ID]; ok {
+			return nil, fmt.Errorf("memory %d: duplicate id %q", i, mem.ID)
+		}
+		seenIDs[mem.ID] = struct{}{}
+		mem.Tags = cleanMemoryTags(mem.Tags)
+		memories = append(memories, mem)
+	}
+	return memories, nil
+}
+
+func decodeStrictJSON(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		return errors.New("trailing JSON data")
+	}
+	return nil
+}
+
+func firstMemoryTimestamp(memories []Memory, fallback time.Time) time.Time {
+	first := fallback
+	found := false
+	for _, mem := range memories {
+		if mem.Timestamp.IsZero() {
+			continue
+		}
+		if !found || mem.Timestamp.Before(first) {
+			first = mem.Timestamp
+			found = true
+		}
+	}
+	return first
+}
+
+func memoryMessage(mem Memory) glue.Message {
+	metadata := map[string]any{
+		"id":     mem.ID,
+		"memory": true,
+	}
+	if len(mem.Tags) > 0 {
+		metadata["tags"] = append([]string(nil), mem.Tags...)
+	}
+	return glue.Message{
+		Role:      glue.MessageRoleAssistant,
+		Content:   []glue.ContentPart{{Type: glue.ContentTypeText, Text: mem.Content}},
+		Metadata:  metadata,
+		CreatedAt: mem.Timestamp,
+	}
+}
+
+func normalizedMemoryContent(content string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(content))), " ")
+}
+
+func cleanMemoryTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tags))
+	seen := map[string]struct{}{}
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		seen[tag] = struct{}{}
+		out = append(out, tag)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/agents/peggy/memory_backup_test.go
+++ b/agents/peggy/memory_backup_test.go
@@ -1,0 +1,169 @@
+package peggy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+func TestExportMemoryBackupContainsOnlyCuratedMemories(t *testing.T) {
+	p := newFileBackedPeggy(t)
+	ctx := context.Background()
+	mem, err := p.AddMemory(ctx, "User's Aussie is named Inkblot.", []string{"pet"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if err := p.store.Save(ctx, "ordinary", glue.SessionState{
+		ID: "ordinary",
+		Messages: []glue.Message{{
+			Role:    glue.MessageRoleAssistant,
+			Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "ordinary conversation"}},
+		}},
+	}); err != nil {
+		t.Fatalf("save ordinary session: %v", err)
+	}
+
+	backup, err := p.ExportMemoryBackup(ctx)
+	if err != nil {
+		t.Fatalf("ExportMemoryBackup: %v", err)
+	}
+	if backup.Version != MemoryBackupVersion || backup.Kind != MemoryBackupKind {
+		t.Fatalf("backup metadata = %+v", backup)
+	}
+	if len(backup.Memories) != 1 || backup.Memories[0].ID != mem.ID {
+		t.Fatalf("backup memories = %+v, want only %s", backup.Memories, mem.ID)
+	}
+	if strings.Contains(backup.Memories[0].Content, "ordinary") {
+		t.Fatalf("ordinary session leaked into backup: %+v", backup.Memories)
+	}
+}
+
+func TestImportMemoryBackupPreservesIDsAndSkipsDuplicateIDs(t *testing.T) {
+	source := newFileBackedPeggy(t)
+	ctx := context.Background()
+	if _, err := source.AddMemory(ctx, "User prefers terse responses.", []string{"preference"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := source.AddMemory(ctx, "User's Aussie is named Inkblot.", []string{"pet"}); err != nil {
+		t.Fatalf("AddMemory 2: %v", err)
+	}
+	backup, err := source.ExportMemoryBackup(ctx)
+	if err != nil {
+		t.Fatalf("ExportMemoryBackup: %v", err)
+	}
+
+	target := newFileBackedPeggy(t)
+	report, err := target.ImportMemoryBackup(ctx, backup, MemoryImportOptions{})
+	if err != nil {
+		t.Fatalf("ImportMemoryBackup: %v", err)
+	}
+	if report.Imported != 2 || report.Skipped != 0 {
+		t.Fatalf("report = %+v, want two imported", report)
+	}
+	imported, err := target.ListMemories(ctx)
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	gotIDs := map[string]bool{}
+	for _, mem := range imported {
+		gotIDs[mem.ID] = true
+	}
+	for _, mem := range backup.Memories {
+		if !gotIDs[mem.ID] {
+			t.Fatalf("imported IDs = %+v, missing %s", imported, mem.ID)
+		}
+	}
+
+	report, err = target.ImportMemoryBackup(ctx, backup, MemoryImportOptions{})
+	if err != nil {
+		t.Fatalf("second ImportMemoryBackup: %v", err)
+	}
+	if report.Imported != 0 || report.Skipped != 2 {
+		t.Fatalf("second report = %+v, want duplicate skips", report)
+	}
+	for _, entry := range report.Entries {
+		if entry.Status != "skipped" || entry.Reason != "duplicate_id" {
+			t.Fatalf("entry = %+v, want duplicate_id skip", entry)
+		}
+	}
+}
+
+func TestImportMemoryBackupDryRunAndContentDuplicate(t *testing.T) {
+	ctx := context.Background()
+	target := newFileBackedPeggy(t)
+	if _, err := target.AddMemory(ctx, "User likes green tea.", []string{"preference"}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	backup := MemoryBackup{
+		Version: MemoryBackupVersion,
+		Kind:    MemoryBackupKind,
+		Memories: []Memory{{
+			ID:        "mem_external",
+			Content:   " user   likes GREEN tea. ",
+			Timestamp: time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC),
+		}},
+	}
+	report, err := target.ImportMemoryBackup(ctx, backup, MemoryImportOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("ImportMemoryBackup dry-run: %v", err)
+	}
+	if report.WouldImport != 0 || report.Imported != 0 || report.Skipped != 1 || report.Entries[0].Reason != "duplicate_content" {
+		t.Fatalf("report = %+v, want duplicate content dry-run", report)
+	}
+	memories, err := target.ListMemories(ctx)
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(memories) != 1 {
+		t.Fatalf("dry-run wrote memories: %+v", memories)
+	}
+}
+
+func TestValidateMemoryBackupErrors(t *testing.T) {
+	_, err := ValidateMemoryBackup(MemoryBackup{
+		Version: MemoryBackupVersion,
+		Kind:    MemoryBackupKind,
+		Memories: []Memory{{
+			ID:      "mem_bad",
+			Content: "   ",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "content is required") {
+		t.Fatalf("err = %v, want content validation", err)
+	}
+
+	_, err = ValidateMemoryBackup(MemoryBackup{
+		Version: 99,
+		Kind:    MemoryBackupKind,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported memory backup version") {
+		t.Fatalf("err = %v, want version validation", err)
+	}
+}
+
+func TestDecodeMemoryBackupAcceptsRawMemoryArray(t *testing.T) {
+	ts := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	raw, err := json.Marshal([]Memory{{
+		Content:   "User likes tea.",
+		Timestamp: ts,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backup, err := DecodeMemoryBackup(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("DecodeMemoryBackup: %v", err)
+	}
+	memories, err := ValidateMemoryBackup(backup)
+	if err != nil {
+		t.Fatalf("ValidateMemoryBackup: %v", err)
+	}
+	if len(memories) != 1 || memories[0].ID == "" {
+		t.Fatalf("memories = %+v, want synthesized id", memories)
+	}
+}

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -202,6 +202,8 @@ Examples:
   peggy skills --config ~/.config/peggy/settings.json
   peggy roles --config ~/.config/peggy/settings.json
   peggy memories --config ~/.config/peggy/settings.json
+  peggy memories export --config ~/.config/peggy/settings.json --output peggy-memories.json
+  peggy memories import --config ~/.config/peggy/settings.json --dry-run peggy-memories.json
   peggy sessions --config ~/.config/peggy/settings.json --prefix telegram:
   peggy recall --config ~/.config/peggy/settings.json "Australian Shepherd"
   peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
@@ -715,8 +717,15 @@ func writeRoleCatalog(w io.Writer, catalog []roleCatalogEntry) {
 }
 
 func runMemories(ctx context.Context, args []string, stdout, stderr io.Writer) int {
-	if len(args) > 0 && args[0] == "forget" {
-		return runMemoriesForget(ctx, args[1:], stdout, stderr)
+	if len(args) > 0 {
+		switch args[0] {
+		case "export":
+			return runMemoriesExport(ctx, args[1:], stdout, stderr)
+		case "import":
+			return runMemoriesImport(ctx, args[1:], stdout, stderr)
+		case "forget":
+			return runMemoriesForget(ctx, args[1:], stdout, stderr)
+		}
 	}
 	fs := flag.NewFlagSet("peggy memories", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -735,6 +744,8 @@ Examples:
   peggy memories --config ~/.config/peggy/settings.json
   peggy memories --config ~/.config/peggy/settings.json --json
   peggy memories --limit 20
+  peggy memories export --output peggy-memories.json
+  peggy memories import --dry-run peggy-memories.json
   peggy memories forget <id>
 
 Flags:
@@ -787,6 +798,129 @@ Flags:
 		return 0
 	}
 	writeMemories(stdout, memories)
+	return 0
+}
+
+func runMemoriesExport(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy memories export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		outputPath = fs.String("output", "", "write backup JSON to this path instead of stdout")
+		force      = fs.Bool("force", false, "overwrite --output if it already exists")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy memories export - export curated memories to backup JSON.
+
+Usage:
+  peggy memories export [flags]
+
+Examples:
+  peggy memories export --config ~/.config/peggy/settings.json > peggy-memories.json
+  peggy memories export --config ~/.config/peggy/settings.json --output peggy-memories.json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy memories export: positional args not supported")
+		return 2
+	}
+	store, missingSettings, err := openStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories export: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy memories export: no settings.json found; using built-in defaults")
+	}
+	if closer, ok := store.(io.Closer); ok {
+		defer closer.Close()
+	}
+	p := &Peggy{store: store}
+	backup, err := p.ExportMemoryBackup(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories export: %v\n", err)
+		return 1
+	}
+	if err := writeMemoryBackupJSON(stdout, *outputPath, *force, backup); err != nil {
+		fmt.Fprintf(stderr, "peggy memories export: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runMemoriesImport(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy memories import", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		dryRun     = fs.Bool("dry-run", false, "validate and report import decisions without writing")
+		jsonOutput = fs.Bool("json", false, "print machine-readable import report")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy memories import - import curated memories from backup JSON.
+
+Usage:
+  peggy memories import [flags] <backup.json>
+
+Examples:
+  peggy memories import --config ~/.config/peggy/settings.json --dry-run peggy-memories.json
+  peggy memories import --config ~/.config/peggy/settings.json peggy-memories.json
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "peggy memories import: exactly one backup path is required")
+		return 2
+	}
+	backup, err := readMemoryBackupPath(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories import: %v\n", err)
+		return 1
+	}
+	store, missingSettings, err := openStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories import: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy memories import: no settings.json found; using built-in defaults")
+	}
+	if closer, ok := store.(io.Closer); ok {
+		defer closer.Close()
+	}
+	p := &Peggy{store: store}
+	report, err := p.ImportMemoryBackup(ctx, backup, MemoryImportOptions{DryRun: *dryRun})
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy memories import: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintf(stderr, "peggy memories import: encode report: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeMemoryImportReport(stdout, report)
 	return 0
 }
 
@@ -902,6 +1036,60 @@ func writeMemories(w io.Writer, memories []Memory) {
 		if len(memory.Tags) > 0 {
 			fmt.Fprintf(w, "  tags: %s\n", strings.Join(memory.Tags, ", "))
 		}
+	}
+}
+
+func writeMemoryBackupJSON(stdout io.Writer, outputPath string, force bool, backup MemoryBackup) error {
+	if strings.TrimSpace(outputPath) == "" {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(backup)
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if force {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+	file, err := os.OpenFile(outputPath, flags, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("%s already exists; use --force to overwrite", outputPath)
+		}
+		return err
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	return enc.Encode(backup)
+}
+
+func readMemoryBackupPath(path string) (MemoryBackup, error) {
+	if path == "-" {
+		return DecodeMemoryBackup(os.Stdin)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return MemoryBackup{}, err
+	}
+	return DecodeMemoryBackup(bytes.NewReader(data))
+}
+
+func writeMemoryImportReport(w io.Writer, report MemoryImportReport) {
+	if report.DryRun {
+		fmt.Fprintf(w, "would import %d memories; skipped %d duplicates\n", report.WouldImport, report.Skipped)
+	} else {
+		fmt.Fprintf(w, "imported %d memories; skipped %d duplicates\n", report.Imported, report.Skipped)
+	}
+	for _, entry := range report.Entries {
+		if entry.Status != "skipped" {
+			continue
+		}
+		reason := entry.Reason
+		if reason == "" {
+			reason = "duplicate"
+		}
+		fmt.Fprintf(w, "  skipped %s: %s\n", entry.ID, reason)
 	}
 }
 

--- a/agents/peggy/runner_test.go
+++ b/agents/peggy/runner_test.go
@@ -524,6 +524,104 @@ func TestRunMemoriesJSONAndLimit(t *testing.T) {
 	}
 }
 
+func TestRunMemoriesExportImportRoundTrip(t *testing.T) {
+	sourceStorePath := seedRunnerMemories(t)
+	sourceCfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": sourceStorePath,
+		},
+	})
+	backupPath := filepath.Join(t.TempDir(), "peggy-memories.json")
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "export", "--config", sourceCfgPath, "--output", backupPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("export exit = %d stderr=%q", code, errOut.String())
+	}
+	data, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	backup, err := DecodeMemoryBackup(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode backup: %v", err)
+	}
+	if len(backup.Memories) != 2 {
+		t.Fatalf("backup memories = %+v, want two", backup.Memories)
+	}
+
+	targetStorePath := filepath.Join(t.TempDir(), "sessions")
+	targetCfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": targetStorePath,
+		},
+	})
+	out.Reset()
+	errOut.Reset()
+	code = Run(context.Background(), []string{"memories", "import", "--config", targetCfgPath, "--dry-run", "--json", backupPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("dry-run exit = %d stderr=%q", code, errOut.String())
+	}
+	var report MemoryImportReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("decode dry-run report: %v\n%s", err, out.String())
+	}
+	if !report.DryRun || report.WouldImport != 2 || report.Imported != 0 {
+		t.Fatalf("dry-run report = %+v, want two candidates", report)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = Run(context.Background(), []string{"memories", "import", "--config", targetCfgPath, backupPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("import exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "imported 2 memories") {
+		t.Fatalf("import stdout = %q", out.String())
+	}
+	imported := readRunnerMemoriesJSON(t, targetCfgPath)
+	if len(imported) != 2 {
+		t.Fatalf("imported memories = %+v, want two", imported)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	code = Run(context.Background(), []string{"memories", "import", "--config", targetCfgPath, backupPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("duplicate import exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "skipped 2 duplicates") {
+		t.Fatalf("duplicate import stdout = %q", out.String())
+	}
+}
+
+func TestRunMemoriesImportRejectsInvalidBackup(t *testing.T) {
+	cfgPath := writeRunnerConfig(t, map[string]any{
+		"provider": "bogus-provider",
+		"store": map[string]any{
+			"type": "file",
+			"path": filepath.Join(t.TempDir(), "sessions"),
+		},
+	})
+	backupPath := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(backupPath, []byte(`{"version":1,"kind":"peggy.memories","memories":[{"id":"mem_bad","content":" ","timestamp":"2026-05-25T12:00:00Z"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	code := Run(context.Background(), []string{"memories", "import", "--config", cfgPath, backupPath}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("exit = %d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "content is required") {
+		t.Fatalf("stderr = %q", errOut.String())
+	}
+}
+
 func TestRunMemoriesForgetDeletesWithoutProvider(t *testing.T) {
 	storePath := seedRunnerMemories(t)
 	cfgPath := writeRunnerConfig(t, map[string]any{


### PR DESCRIPTION
Closes #259.

## Summary
- add a versioned Peggy curated-memory backup envelope with validation and strict JSON decoding
- add `peggy memories export` and `peggy memories import` with dry-run, JSON report output, duplicate skipping, and safe output overwrite behavior
- document the backup/restore dogfood path and cover export/import validation in tests

## Validation
- `go test ./agents/peggy -count=1`
- `env -u NVIDIA_API_KEY -u OPENROUTER_API_KEY -u GEMINI_API_KEY go test ./... -count=1`
- `git diff --check`