### PR TITLE
agents/peggy: run prompts from dashboard

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -39,6 +39,9 @@ not formally follow SemVer until v1.0.
   surface over existing daemon endpoints plus local session listing, so
   dogfood users can inspect health, tools, skills, roles, memories,
   recall, and recent sessions without remembering every CLI command.
+- **Dashboard prompt runs.** The local dashboard can now start a prompt
+  run through the existing daemon SSE endpoint and render the final
+  assistant response without exposing the bearer token in the page.
 - **Telegram daemon status command.** In daemon-client mode,
   allowlisted Telegram chats can use `/status` to check daemon health,
   active runs, tool count, and advertised capabilities without opening

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -459,10 +459,11 @@ SIGINT/SIGTERM.
 `peggy dashboard` starts a local web control surface over the same
 daemon metadata and bearer-token flow. It binds to `127.0.0.1:0` by
 default, fetches daemon status, diagnostics, tools, skills, roles,
-memories, and recall server-side, and reads recent sessions from the
-configured local store. It does not put the bearer token into the HTML.
-Use `--once` to render a single HTML snapshot, or `--allow-nonlocal`
-only when you deliberately want to bind outside loopback.
+memories, and recall server-side, reads recent sessions from the
+configured local store, and can start a prompt run through the existing
+daemon SSE endpoint. It does not put the bearer token into the HTML. Use
+`--once` to render a single HTML snapshot, or `--allow-nonlocal` only
+when you deliberately want to bind outside loopback.
 
 Restart/recovery is intentionally local-first: stop the current
 `peggy serve` process with SIGINT/SIGTERM, start it again, and let it

--- a/agents/peggy/dashboard.go
+++ b/agents/peggy/dashboard.go
@@ -1,6 +1,7 @@
 package peggy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -93,9 +94,25 @@ type dashboardPage struct {
 	RecallQuery string
 	RecallHits  []daemon.RecallHit
 	Sessions    []glue.SessionSummary
+	RunForm     dashboardRunForm
+	RunResult   dashboardRunResult
 	Errors      []string
 	Warnings    []string
 	Limits      dashboardLimits
+}
+
+type dashboardRunForm struct {
+	SessionID string
+	Text      string
+}
+
+type dashboardRunResult struct {
+	Submitted bool
+	OK        bool
+	RunID     string
+	SessionID string
+	Text      string
+	Error     string
 }
 
 type dashboardLimits struct {
@@ -190,18 +207,38 @@ Flags:
 
 func newDashboardHandler(opts dashboardOptions) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
+		switch {
+		case r.URL.Path == "/" && r.Method == http.MethodGet:
+			reqOpts := opts
+			if q := strings.TrimSpace(r.URL.Query().Get("recall")); q != "" {
+				reqOpts.RecallQuery = q
+			}
+			page := loadDashboardPage(r.Context(), reqOpts)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if err := renderDashboardHTML(w, page); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.URL.Path == "/run" && r.Method == http.MethodPost:
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			runForm := dashboardRunForm{
+				SessionID: strings.TrimSpace(r.FormValue("session_id")),
+				Text:      strings.TrimSpace(r.FormValue("prompt")),
+			}
+			result := runDashboardPrompt(r.Context(), opts, runForm)
+			page := loadDashboardPage(r.Context(), opts)
+			page.RunForm = runForm
+			page.RunResult = result
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if err := renderDashboardHTML(w, page); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.URL.Path == "/run":
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		default:
 			http.NotFound(w, r)
-			return
-		}
-		reqOpts := opts
-		if q := strings.TrimSpace(r.URL.Query().Get("recall")); q != "" {
-			reqOpts.RecallQuery = q
-		}
-		page := loadDashboardPage(r.Context(), reqOpts)
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		if err := renderDashboardHTML(w, page); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	})
 }
@@ -215,6 +252,7 @@ func loadDashboardPage(ctx context.Context, opts dashboardOptions) dashboardPage
 			Session: opts.SessionLimit,
 			Recall:  opts.RecallLimit,
 		},
+		RunForm: dashboardRunForm{SessionID: "dashboard"},
 	}
 	daemonCfg, err := resolveDashboardDaemonConfig(opts)
 	if err != nil {
@@ -270,7 +308,7 @@ func resolveDashboardDaemonConfig(opts dashboardOptions) (dashboardDaemonConfig,
 }
 
 func loadDashboardDaemonData(ctx context.Context, opts dashboardOptions, daemonCfg dashboardDaemonConfig, page *dashboardPage) {
-	client := opts.HTTPClient
+	client := dashboardClient(opts.HTTPClient)
 	if err := dashboardGetJSON(ctx, client, daemonCfg, "/v1/status", &page.Status); err != nil {
 		page.Errors = append(page.Errors, "daemon status: "+err.Error())
 		return
@@ -346,6 +384,199 @@ func loadDashboardSessions(ctx context.Context, opts dashboardOptions, page *das
 		return
 	}
 	page.Sessions = sessions
+}
+
+func runDashboardPrompt(ctx context.Context, opts dashboardOptions, form dashboardRunForm) dashboardRunResult {
+	result := dashboardRunResult{
+		Submitted: true,
+		SessionID: strings.TrimSpace(form.SessionID),
+	}
+	text := strings.TrimSpace(form.Text)
+	if result.SessionID == "" {
+		result.SessionID = "dashboard"
+	}
+	if text == "" {
+		result.Error = "prompt is required"
+		return result
+	}
+	daemonCfg, err := resolveDashboardDaemonConfig(opts)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	client := dashboardClient(opts.HTTPClient)
+	start, err := dashboardStartRun(ctx, client, daemonCfg, result.SessionID, text)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.RunID = start.RunID
+	result.SessionID = start.SessionID
+	out, err := dashboardStreamRun(ctx, client, daemonCfg, start)
+	if err != nil {
+		_ = dashboardCancelRun(context.Background(), client, daemonCfg, start.RunID)
+		result.Error = err.Error()
+		return result
+	}
+	result.OK = true
+	result.Text = out
+	return result
+}
+
+func dashboardClient(client dashboardHTTPDoer) dashboardHTTPDoer {
+	if client != nil {
+		return client
+	}
+	return http.DefaultClient
+}
+
+type dashboardStartRunRequest struct {
+	Text     string `json:"text"`
+	ClientID string `json:"client_id,omitempty"`
+}
+
+type dashboardStartRunResponse struct {
+	RunID     string `json:"run_id"`
+	SessionID string `json:"session_id"`
+	EventsURL string `json:"events_url"`
+}
+
+func dashboardStartRun(ctx context.Context, client dashboardHTTPDoer, cfg dashboardDaemonConfig, sessionID, text string) (dashboardStartRunResponse, error) {
+	payload := dashboardStartRunRequest{
+		Text:     text,
+		ClientID: fmt.Sprintf("dashboard:%d", os.Getpid()),
+	}
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return dashboardStartRunResponse{}, err
+	}
+	path := "/v1/sessions/" + url.PathEscape(sessionID) + "/runs"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.BaseURL+path, &body)
+	if err != nil {
+		return dashboardStartRunResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	var out dashboardStartRunResponse
+	if err := dashboardDoJSON(client, cfg, req, &out); err != nil {
+		return dashboardStartRunResponse{}, fmt.Errorf("start run: %w", err)
+	}
+	if out.RunID == "" || out.EventsURL == "" {
+		return dashboardStartRunResponse{}, errors.New("start run: missing run id or events URL")
+	}
+	return out, nil
+}
+
+func dashboardStreamRun(ctx context.Context, client dashboardHTTPDoer, cfg dashboardDaemonConfig, start dashboardStartRunResponse) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.BaseURL+start.EventsURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("event stream: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var text strings.Builder
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event daemon.EventEnvelope
+		dec := json.NewDecoder(strings.NewReader(strings.TrimPrefix(line, "data: ")))
+		dec.UseNumber()
+		if err := dec.Decode(&event); err != nil {
+			return "", err
+		}
+		switch event.Type {
+		case string(glue.EventTextDelta):
+			if delta := dashboardPayloadString(event.Payload, "delta"); delta != "" {
+				text.WriteString(delta)
+			}
+		case "permission_request":
+			return "", errors.New("run requested tool permission; use glue connect for permission-gated runs")
+		case "run_done":
+			if text.Len() > 0 {
+				return text.String(), nil
+			}
+			done, err := dashboardDecodePayload[dashboardRunDonePayload](event.Payload)
+			if err != nil {
+				return "", err
+			}
+			return done.Text, nil
+		case "run_error":
+			if msg := dashboardPayloadErrorMessage(event.Payload); msg != "" {
+				return "", errors.New(msg)
+			}
+			return "", errors.New("daemon run failed")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("event stream closed before terminal event")
+}
+
+type dashboardRunDonePayload struct {
+	Text string `json:"text"`
+}
+
+func dashboardCancelRun(ctx context.Context, client dashboardHTTPDoer, cfg dashboardDaemonConfig, runID string) error {
+	if strings.TrimSpace(runID) == "" {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, cfg.BaseURL+"/v1/runs/"+url.PathEscape(runID), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func dashboardDecodePayload[T any](payload any) (T, error) {
+	var out T
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return out, err
+	}
+	err = json.Unmarshal(data, &out)
+	return out, err
+}
+
+func dashboardPayloadString(payload any, key string) string {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, _ := m[key].(string)
+	return value
+}
+
+func dashboardPayloadErrorMessage(payload any) string {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return ""
+	}
+	errValue, ok := m["error"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	msg, _ := errValue["message"].(string)
+	return strings.TrimSpace(msg)
 }
 
 func dashboardGetJSON(ctx context.Context, client dashboardHTTPDoer, cfg dashboardDaemonConfig, path string, out any) error {
@@ -644,6 +875,17 @@ input[type="search"] {
   padding: 10px 12px;
   font: inherit;
 }
+textarea, input[type="text"] {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font: inherit;
+}
+textarea {
+  min-height: 112px;
+  resize: vertical;
+}
 button {
   border: 1px solid #0b5f59;
   background: var(--accent);
@@ -681,6 +923,7 @@ footer { padding-top: 18px; color: var(--muted); font-size: 13px; }
 </header>
 <nav>
   <a href="#health">Health</a>
+  <a href="#run">Run</a>
   <a href="#recall">Recall</a>
   <a href="#skills">Skills</a>
   <a href="#roles">Roles</a>
@@ -708,6 +951,27 @@ footer { padding-top: 18px; color: var(--muted); font-size: 13px; }
         <div class="item"><div class="item-title">{{ .Error }}</div><div class="item-meta">{{ formatTime .Time }} {{ .SessionID }} {{ .ClientID }}</div></div>
       {{ end }}
       </div>
+    {{ end }}
+  </section>
+
+  <section id="run" class="band">
+    <h2>Run Prompt</h2>
+    <form method="post" action="/run" style="display:block">
+      <label class="item-meta" for="session_id">Session</label>
+      <input type="text" id="session_id" name="session_id" value="{{ .RunForm.SessionID }}" placeholder="dashboard">
+      <label class="item-meta" for="prompt" style="display:block;margin-top:12px">Prompt</label>
+      <textarea id="prompt" name="prompt" placeholder="Ask Peggy to do something">{{ .RunForm.Text }}</textarea>
+      <button type="submit" style="margin-top:10px">Run</button>
+    </form>
+    {{ if .RunResult.Submitted }}
+      {{ if .RunResult.OK }}
+        <div class="item">
+          <div class="item-title">Run {{ .RunResult.RunID }} · {{ .RunResult.SessionID }}</div>
+          <p style="margin-top:8px;white-space:pre-wrap">{{ .RunResult.Text }}</p>
+        </div>
+      {{ else }}
+        <div class="alert">Run failed: {{ .RunResult.Error }}</div>
+      {{ end }}
     {{ end }}
   </section>
 

--- a/agents/peggy/dashboard_test.go
+++ b/agents/peggy/dashboard_test.go
@@ -3,8 +3,10 @@ package peggy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -112,6 +114,7 @@ func TestRunDashboardOnceRendersDaemonAndLocalState(t *testing.T) {
 	for _, want := range []string{
 		"Peggy Dashboard",
 		"Daemon online",
+		"Run Prompt",
 		"gemini / test-model / sqlite /tmp/peggy.db",
 		"daily_plan",
 		"reviewer",
@@ -123,6 +126,96 @@ func TestRunDashboardOnceRendersDaemonAndLocalState(t *testing.T) {
 		if !strings.Contains(html, want) {
 			t.Fatalf("dashboard HTML missing %q:\n%s", want, html)
 		}
+	}
+}
+
+func TestDashboardPromptRunSubmission(t *testing.T) {
+	const secret = "secret-token-268"
+	var startSeen, streamSeen bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+secret {
+			t.Fatalf("authorization = %q", got)
+		}
+		switch r.URL.Path {
+		case "/v1/status":
+			writeDashboardTestJSON(t, w, dashboardStatus{
+				OK:           true,
+				Version:      1,
+				Capabilities: []string{"diagnostics", "tools", "memories", "recall"},
+			})
+		case "/v1/diagnostics":
+			writeDashboardTestJSON(t, w, daemon.DiagnosticResponse{OK: true, Version: 1})
+		case "/v1/tools":
+			writeDashboardTestJSON(t, w, dashboardToolCatalog{})
+		case "/v1/memories":
+			writeDashboardTestJSON(t, w, daemon.MemoryCatalogResponse{})
+		case "/v1/sessions/dashboard/runs":
+			if r.Method != http.MethodPost {
+				t.Fatalf("start method = %s", r.Method)
+			}
+			var req dashboardStartRunRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode start: %v", err)
+			}
+			if req.Text != "Summarize today" || !strings.HasPrefix(req.ClientID, "dashboard:") {
+				t.Fatalf("start request = %+v", req)
+			}
+			startSeen = true
+			w.WriteHeader(http.StatusCreated)
+			writeDashboardTestJSON(t, w, dashboardStartRunResponse{
+				RunID:     "run_1",
+				SessionID: "dashboard",
+				EventsURL: "/v1/runs/run_1/events",
+			})
+		case "/v1/runs/run_1/events":
+			if r.Method != http.MethodGet {
+				t.Fatalf("events method = %s", r.Method)
+			}
+			streamSeen = true
+			w.Header().Set("Content-Type", "text/event-stream")
+			writeDashboardSSE(t, w, daemon.EventEnvelope{Type: string(glue.EventTextDelta), Payload: map[string]any{"delta": "Hello "}})
+			writeDashboardSSE(t, w, daemon.EventEnvelope{Type: string(glue.EventTextDelta), Payload: map[string]any{"delta": "from Peggy."}})
+			writeDashboardSSE(t, w, daemon.EventEnvelope{Type: "run_done", Payload: map[string]any{"text": "ignored because deltas won"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	cfgPath := seedDashboardSessionConfig(t)
+	handler := newDashboardHandler(dashboardOptions{
+		ConfigPath:   cfgPath,
+		BaseURL:      ts.URL,
+		Token:        secret,
+		MemoryLimit:  10,
+		SessionLimit: 10,
+		RecallLimit:  5,
+		HTTPClient:   ts.Client(),
+		MetadataPath: "",
+		ListenAddr:   defaultDashboardListenAddr,
+	})
+	form := url.Values{}
+	form.Set("session_id", "dashboard")
+	form.Set("prompt", "Summarize today")
+	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !startSeen || !streamSeen {
+		t.Fatalf("startSeen=%v streamSeen=%v", startSeen, streamSeen)
+	}
+	html := rec.Body.String()
+	for _, want := range []string{"Run run_1", "Hello from Peggy.", "dashboard"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("dashboard response missing %q:\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, secret) {
+		t.Fatalf("dashboard leaked bearer token in HTML:\n%s", html)
 	}
 }
 
@@ -184,5 +277,16 @@ func writeDashboardTestJSON(t *testing.T, w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		t.Fatalf("encode JSON: %v", err)
+	}
+}
+
+func writeDashboardSSE(t *testing.T, w http.ResponseWriter, event daemon.EventEnvelope) {
+	t.Helper()
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal SSE: %v", err)
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		t.Fatalf("write SSE: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #268.

## Summary
- add a dashboard prompt form that starts runs through the existing authenticated daemon run endpoint
- consume daemon SSE events server-side and render the final assistant result or run error in the local dashboard
- keep bearer tokens out of generated HTML and document the new dashboard control action

## Validation
- `go test ./agents/peggy -count=1`
- `env -u NVIDIA_API_KEY -u OPENROUTER_API_KEY -u GEMINI_API_KEY go test ./... -count=1`
- `git diff --check`