### PR TITLE
glue: add tools/coding bundle and cmd/glue --coding (closes #270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ This file tracks library-level changes only.
 
 ## Unreleased
 
-- (no library changes since the agent's `v1.0.0` release)
+- Added `tools/coding`, a reusable SDK package that assembles the local
+  coding-agent tool bundle (`read_file`, `write_file`, `shell_exec`,
+  `git_diff_branch`, and `git_log_branch`) over the existing filesystem,
+  shell, git, and `glue.Executor` primitives.
+- Added `cmd/glue` coding-agent mode: `glue run --coding` and
+  `glue serve --coding` now register the SDK coding bundle, with local
+  terminal permission prompts for one-shot runs and daemon-brokered
+  permissions for served runs.
 
 ## Initial bootstrap (pre-1.0)
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Shipped today:
   (OpenAI-compatible, sharing the `providers/openaicompat` core), a
   driver-style registry under `providers/`, and `glue.WithFailover`.
 - Storage: file-backed session store at `stores/file`. Tools: shared
-  `tools/fs` and `tools/git` extension packages. CLI: `cmd/glue` runner
-  plus `cli.RegisterStandardFlags` for downstream agents. Versioned
-  prompts via `prompts.NewCatalog`.
+  `tools/fs`, `tools/git`, `tools/shell`, and `tools/coding` extension
+  packages. CLI: `cmd/glue` runner plus `cli.RegisterStandardFlags` for
+  downstream agents. Versioned prompts via `prompts.NewCatalog`.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for library-level notes.
 
@@ -57,7 +57,8 @@ The module path is `github.com/erain/glue`. Subpackages:
 shared OpenAI-compatible core in `providers/openaicompat` and the
 driver-style registry in `providers/`),
 `github.com/erain/glue/stores/file` (file-backed session store),
-`github.com/erain/glue/tools/{fs,git}` (extension tool packages),
+`github.com/erain/glue/tools/{fs,git,shell,coding}` (extension tool
+packages),
 `github.com/erain/glue/prompts` (versioned-prompt catalog), and
 `github.com/erain/glue/cli` (shared standard flags).
 
@@ -599,6 +600,7 @@ A thin local CLI is built on the same library API:
 
 ```sh
 go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
+go run ./cmd/glue run --coding --work . --prompt "Run the tests and summarize failures."
 ```
 
 `run` flags:
@@ -607,6 +609,15 @@ go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
 - `--prompt` — prompt text (required).
 - `--model` — model id or `gemini/<model>` (default `gemini-2.5-flash`).
 - `--store` — file session store directory (default `.glue/sessions`).
+- `--work` — workspace for `AGENTS.md`, `.agents/skills`, roles, and
+  optional coding tools (default `.`).
+- `--coding` — register Glue's reusable coding tool bundle:
+  `read_file`, `write_file`, `shell_exec`, `git_diff_branch`, and
+  `git_log_branch`.
+- `--allow-binary` — allowed `shell_exec` binary basename when `--coding`
+  is enabled. Repeatable; empty uses the conservative default.
+- `--coding-allow-overwrite` — allow `write_file` to overwrite existing
+  files when the model also passes `overwrite=true` and permission allows.
 - `--usage` — print provider-reported token usage to stderr when available.
 - `--usage-input-price`, `--usage-output-price`,
   `--usage-cache-read-price`, `--usage-cache-write-price` — optional
@@ -616,23 +627,29 @@ go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
   shell environment wins on conflict.
 
 The CLI streams text deltas to stdout, persists sessions through
-`stores/file`, and uses `WorkDir="."` so `AGENTS.md`, `.agents/skills`, and
-`roles/` discovery work from the invocation directory. Errors return a
-non-zero exit code; missing `GEMINI_API_KEY` produces a clear message.
+`stores/file`, and uses the configured workdir so `AGENTS.md`,
+`.agents/skills`, and `roles/` discovery work from the target workspace.
+When `--coding` is enabled, side-effecting coding tools ask for terminal
+permission before running. The default executor is local process execution,
+not a sandbox; VM/container-backed executors are expected to plug in behind
+`glue.Executor`. Errors return a non-zero exit code; missing `GEMINI_API_KEY`
+produces a clear message.
 
 The same binary can also start the local HTTP+SSE daemon described in
 [ADR-0010](docs/adr/0010-daemon-protocol.md):
 
 ```sh
 go run ./cmd/glue serve --store .glue/sessions
+go run ./cmd/glue serve --coding --work . --store .glue/sessions
 ```
 
 `serve` binds to `127.0.0.1:0` by default, generates a bearer token when
 `--token` / `GLUE_DAEMON_TOKEN` are not set, and writes connection metadata
 to `glue/daemon.json` under the user config directory with mode `0600`.
 Startup output prints the effective `base_url` and metadata path but not the
-bearer token. Use `--listen`, `--metadata`, `--work`, and
-`--permission-timeout` to override daemon behavior.
+bearer token. Use `--listen`, `--metadata`, `--work`, `--coding`, and
+`--permission-timeout` to override daemon behavior. Coding-enabled daemon
+runs broker side-effect permission requests through `glue connect`.
 
 Once `serve` is running, `connect` starts one daemon run, streams text
 events, and brokers permission requests in the terminal:
@@ -743,8 +760,10 @@ for the shortest possible runnable implementation.
 P0–P2 are shipped: the reusable loop, public `Agent` / `Session` API,
 file-backed sessions, structured JSON, skills, roles, the CLI runner,
 parallel tool execution, opt-in context compaction, the shell/filesystem
-tool extension packages (`tools/fs`, `tools/git` per
-[`docs/adr/0003-shell-filesystem-tools.md`](docs/adr/0003-shell-filesystem-tools.md)),
+tool extension packages (`tools/fs`, `tools/git`, `tools/shell`, and
+`tools/coding` per
+[`docs/adr/0003-shell-filesystem-tools.md`](docs/adr/0003-shell-filesystem-tools.md)
+and [`docs/adr/0012-sdk-coding-agent-peggy-boundary.md`](docs/adr/0012-sdk-coding-agent-peggy-boundary.md)),
 the provider plugin guide ([`docs/provider-guide.md`](docs/provider-guide.md)),
 and the GitHub issue automation workflow
 ([`docs/issue-automation.md`](docs/issue-automation.md)). The current

--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -8,6 +8,10 @@ not formally follow SemVer until v1.0.
 
 ### Added
 
+- **Reusable coding execution seam.** Peggy now consumes Glue's
+  `tools/coding` SDK bundle and exposes a runtime `CodingExecutor`
+  injection point, so future VM or container-backed execution can plug
+  in without changing Peggy's personal-assistant layer.
 - **Dogfood doctor command.** `peggy doctor` now checks local Peggy
   dogfood readiness without starting a model run, reports required and
   recommended setup state in text or JSON, and exits non-zero when

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -546,7 +546,8 @@ Persistent config for a single trusted workspace:
 }
 ```
 
-Peggy registers these model-callable tools:
+Peggy consumes Glue's reusable coding-tool bundle and registers these
+model-callable tools:
 
 - `read_file` — read UTF-8 text inside the workspace. Read-only, no
   permission prompt.
@@ -695,9 +696,10 @@ that made them, so a Telegram allow does not silently authorize a
 terminal request.
 
 Coding mode is a trusted-local workflow. The tool layer constrains
-paths, binaries, overwrites, output size, and permissions, but Peggy
-uses the host process via `glue.LocalExecutor`; it is not a container
-or VM sandbox.
+paths, binaries, overwrites, output size, and permissions. By default
+Peggy uses the host process via `glue.LocalExecutor`; library callers
+can inject another `glue.Executor`, but Peggy does not yet ship a
+container or VM sandbox.
 
 ### Config resolution
 

--- a/agents/peggy/coding.go
+++ b/agents/peggy/coding.go
@@ -1,94 +1,64 @@
 package peggy
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/erain/glue"
-	toolsfs "github.com/erain/glue/tools/fs"
-	toolsgit "github.com/erain/glue/tools/git"
-	toolsshell "github.com/erain/glue/tools/shell"
+	toolscoding "github.com/erain/glue/tools/coding"
 )
+
+// CodingToolOptions configures Peggy's use of Glue's reusable coding
+// tool bundle. These options are runtime-only; settings.json still owns
+// the persisted workspace and safety policy.
+type CodingToolOptions struct {
+	// Executor runs shell_exec commands. Nil uses glue.LocalExecutor.
+	Executor glue.Executor
+
+	// Env is the exact child environment used for shell_exec.
+	Env []string
+}
+
+// CodingToolOption mutates CodingToolOptions.
+type CodingToolOption func(*CodingToolOptions)
+
+// WithCodingExecutor injects a shell_exec executor for Peggy's coding
+// tools. This is the product seam for future VM or container-backed
+// execution.
+func WithCodingExecutor(executor glue.Executor) CodingToolOption {
+	return func(opts *CodingToolOptions) {
+		opts.Executor = executor
+	}
+}
+
+// WithCodingEnv sets the exact child process environment for shell_exec.
+func WithCodingEnv(env []string) CodingToolOption {
+	return func(opts *CodingToolOptions) {
+		opts.Env = append([]string(nil), env...)
+	}
+}
 
 // CodingTools builds Peggy's local coding tool set for the configured
 // workspace. It returns no tools when settings.Enabled is false.
-func CodingTools(settings CodingSettings) ([]glue.Tool, CodingSettings, error) {
-	if !settings.Enabled {
-		return nil, settings, nil
-	}
-
-	workDir := strings.TrimSpace(settings.WorkDir)
-	if workDir == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, settings, fmt.Errorf("peggy: coding workdir: %w", err)
+func CodingTools(settings CodingSettings, options ...CodingToolOption) ([]glue.Tool, CodingSettings, error) {
+	var runtime CodingToolOptions
+	for _, option := range options {
+		if option != nil {
+			option(&runtime)
 		}
-		workDir = cwd
-	}
-	expanded, err := expandPath(workDir)
-	if err != nil {
-		return nil, settings, err
-	}
-	absWorkDir, err := filepath.Abs(expanded)
-	if err != nil {
-		return nil, settings, fmt.Errorf("peggy: coding workdir: %w", err)
-	}
-	info, err := os.Stat(absWorkDir)
-	if err != nil {
-		return nil, settings, fmt.Errorf("peggy: coding workdir: %w", err)
-	}
-	if !info.IsDir() {
-		return nil, settings, fmt.Errorf("peggy: coding workdir %q is not a directory", absWorkDir)
 	}
 
-	allowed := normalizedAllowedBinaries(settings.AllowedBinaries)
-	if len(allowed) == 0 {
-		allowed = append([]string(nil), DefaultCodingAllowedBinaries...)
-	}
-	settings.WorkDir = absWorkDir
-	settings.AllowedBinaries = allowed
-
-	blocklist := toolsfs.Default()
-	write, err := toolsfs.FileWrite(toolsfs.FileWriteOptions{
-		WorkDir:        absWorkDir,
-		AllowOverwrite: settings.AllowOverwrite,
-		Blocklist:      blocklist,
+	tools, resolved, err := toolscoding.Tools(toolscoding.Options{
+		Enabled:         settings.Enabled,
+		WorkDir:         settings.WorkDir,
+		AllowedBinaries: settings.AllowedBinaries,
+		AllowOverwrite:  settings.AllowOverwrite,
+		Executor:        runtime.Executor,
+		Env:             runtime.Env,
 	})
 	if err != nil {
 		return nil, settings, err
 	}
-	shell, err := toolsshell.Exec(toolsshell.ExecOptions{
-		WorkDir:         absWorkDir,
-		AllowedBinaries: allowed,
-	})
-	if err != nil {
-		return nil, settings, err
+	if settings.Enabled {
+		settings.WorkDir = resolved.WorkDir
+		settings.AllowedBinaries = resolved.AllowedBinaries
 	}
-
-	return []glue.Tool{
-		toolsfs.ReadFileTool(toolsfs.ReadFileOptions{WorkDir: absWorkDir, Blocklist: blocklist}),
-		write,
-		shell,
-		toolsgit.DiffBranchTool(toolsgit.DiffBranchOptions{WorkDir: absWorkDir}),
-		toolsgit.LogBranchTool(toolsgit.LogBranchOptions{WorkDir: absWorkDir}),
-	}, settings, nil
-}
-
-func normalizedAllowedBinaries(in []string) []string {
-	out := make([]string, 0, len(in))
-	seen := map[string]struct{}{}
-	for _, raw := range in {
-		bin := strings.TrimSpace(raw)
-		if bin == "" {
-			continue
-		}
-		if _, ok := seen[bin]; ok {
-			continue
-		}
-		seen[bin] = struct{}{}
-		out = append(out, bin)
-	}
-	return out
+	return tools, settings, nil
 }

--- a/agents/peggy/coding_test.go
+++ b/agents/peggy/coding_test.go
@@ -45,6 +45,16 @@ func (p *recordingPermission) Decide(_ context.Context, req glue.PermissionReque
 	return p.decision, nil
 }
 
+type recordingExecutor struct {
+	commands []glue.ExecCommand
+	result   glue.ExecResult
+}
+
+func (e *recordingExecutor) Run(_ context.Context, cmd glue.ExecCommand) (glue.ExecResult, error) {
+	e.commands = append(e.commands, cmd)
+	return e.result, nil
+}
+
 func toolCallTurn(id, name, args string) []glue.ProviderEvent {
 	return []glue.ProviderEvent{
 		{Type: glue.ProviderEventStart},
@@ -154,6 +164,47 @@ func TestPeggyCodingReadOnlyToolDoesNotAskPermission(t *testing.T) {
 	toolResult := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
 	if toolResult.Role != glue.MessageRoleTool || !strings.Contains(toolResult.Content[0].Text, "hello") {
 		t.Fatalf("tool result = %#v, want read_file content", toolResult)
+	}
+}
+
+func TestPeggyCodingUsesInjectedExecutor(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "shell_exec", `{"argv":["go","version"]}`),
+		peggyTextTurn("done"),
+	}}
+	executor := &recordingExecutor{result: glue.ExecResult{Stdout: []byte("from injected executor\n")}}
+	p, err := New(Options{
+		Settings: Settings{Coding: CodingSettings{
+			Enabled:         true,
+			WorkDir:         workDir,
+			AllowedBinaries: []string{"go"},
+		}},
+		Provider:       provider,
+		Store:          filestore.New(filepath.Join(t.TempDir(), "sessions")),
+		Permission:     glue.AllowAll{},
+		CodingExecutor: executor,
+		CodingEnv:      []string{"A=B"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	if _, err := p.Prompt(context.Background(), "s", "run go version", nil); err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	if len(executor.commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(executor.commands))
+	}
+	if got := strings.Join(executor.commands[0].Argv, " "); got != "go version" {
+		t.Fatalf("argv = %q, want go version", got)
+	}
+	if got := strings.Join(executor.commands[0].Env, ","); got != "A=B" {
+		t.Fatalf("env = %q, want A=B", got)
+	}
+	if !strings.Contains(lastToolText(t, provider.requests[1]), "from injected executor") {
+		t.Fatalf("tool result missing injected executor output: %q", lastToolText(t, provider.requests[1]))
 	}
 }
 

--- a/agents/peggy/peggy.go
+++ b/agents/peggy/peggy.go
@@ -49,6 +49,15 @@ type Options struct {
 	// are enabled.
 	Permission glue.Permission
 
+	// CodingExecutor, when non-nil, runs Peggy's shell_exec tool.
+	// Nil uses glue.LocalExecutor. This is the runtime seam for VM,
+	// container, or remote execution backends.
+	CodingExecutor glue.Executor
+
+	// CodingEnv is the exact child environment used by shell_exec.
+	// Nil means the child inherits no environment.
+	CodingEnv []string
+
 	// Stderr collects diagnostic warnings (missing SOUL.md etc).
 	// Defaults to os.Stderr.
 	Stderr io.Writer
@@ -151,7 +160,11 @@ func New(opts Options) (*Peggy, error) {
 			}
 		}
 	}
-	codingTools, codingSettings, err := CodingTools(settings.Coding)
+	codingTools, codingSettings, err := CodingTools(
+		settings.Coding,
+		WithCodingExecutor(opts.CodingExecutor),
+		WithCodingEnv(opts.CodingEnv),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	toolscoding "github.com/erain/glue/tools/coding"
 )
 
 // ChannelConfig is the raw JSON for one channel's configuration,
@@ -141,7 +143,7 @@ const DefaultProvider = "codex"
 // DefaultCodingAllowedBinaries is the conservative shell_exec allowlist
 // Peggy uses when coding tools are enabled and no explicit list is
 // configured.
-var DefaultCodingAllowedBinaries = []string{"go", "git", "make", "node", "npm", "python", "python3"}
+var DefaultCodingAllowedBinaries = append([]string(nil), toolscoding.DefaultAllowedBinaries...)
 
 // LoadSettings reads and parses settings.json. When path is empty,
 // the loader walks the resolution chain $PEGGY_CONFIG →

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erain/glue/daemon"
 	"github.com/erain/glue/providers/gemini"
 	filestore "github.com/erain/glue/stores/file"
+	toolscoding "github.com/erain/glue/tools/coding"
 )
 
 const defaultModel = "gemini-2.5-flash"
@@ -56,6 +57,21 @@ func (r *repeatedStrings) String() string { return strings.Join(*r, ",") }
 func (r *repeatedStrings) Set(value string) error {
 	*r = append(*r, value)
 	return nil
+}
+
+type codingFlagConfig struct {
+	Enabled         bool
+	WorkDir         string
+	AllowedBinaries []string
+	AllowOverwrite  bool
+}
+
+type agentConfig struct {
+	Model      string
+	StoreDir   string
+	WorkDir    string
+	Tools      []glue.Tool
+	Permission glue.Permission
 }
 
 type serveFunc func(context.Context, serveConfig, http.Handler, io.Writer) error
@@ -243,7 +259,7 @@ func runCLIWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout 
 
 	switch args[0] {
 	case "run":
-		if err := runCommand(ctx, args[1:], stdout, stderr, newProvider); err != nil {
+		if err := runCommand(ctx, args[1:], stdin, stdout, stderr, newProvider); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
@@ -267,7 +283,7 @@ func runCLIWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout 
 	}
 }
 
-func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory) error {
+func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, newProvider providerFactory) error {
 	flags := flag.NewFlagSet("glue run", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 
@@ -275,10 +291,15 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 	prompt := flags.String("prompt", "", "prompt text")
 	model := flags.String("model", defaultModel, "model id or gemini/<model>")
 	storeDir := flags.String("store", ".glue/sessions", "session store directory")
+	workDir := flags.String("work", ".", "working directory for AGENTS.md, skills, roles, and optional coding tools")
+	coding := flags.Bool("coding", false, "enable local coding tools for this run")
+	codingAllowOverwrite := flags.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
 	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
 	usagePricing := registerUsagePricingFlags(flags)
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
+	var allowedBinaries repeatedStrings
+	flags.Var(&allowedBinaries, "allow-binary", "allowed shell_exec binary basename for --coding; repeatable")
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -302,7 +323,28 @@ func runCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.
 		return err
 	}
 
-	agent, err := newAgent(newProvider, *model, *storeDir, ".")
+	tools, _, err := buildCodingTools(codingFlagConfig{
+		Enabled:         *coding,
+		WorkDir:         *workDir,
+		AllowedBinaries: append([]string(nil), allowedBinaries...),
+		AllowOverwrite:  *codingAllowOverwrite,
+	})
+	if err != nil {
+		return err
+	}
+	var permission glue.Permission
+	if *coding {
+		permission = newLocalPromptPermission(stdin, stderr)
+		fmt.Fprintf(stderr, "glue run: coding tools enabled for %s\n", *workDir)
+	}
+
+	agent, err := newAgent(newProvider, agentConfig{
+		Model:      *model,
+		StoreDir:   *storeDir,
+		WorkDir:    *workDir,
+		Tools:      tools,
+		Permission: permission,
+	})
 	if err != nil {
 		return err
 	}
@@ -342,12 +384,16 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 	model := flags.String("model", defaultModel, "model id or gemini/<model>")
 	storeDir := flags.String("store", ".glue/sessions", "session store directory")
 	workDir := flags.String("work", ".", "working directory for AGENTS.md, skills, and roles")
+	coding := flags.Bool("coding", false, "enable local coding tools for daemon runs")
+	codingAllowOverwrite := flags.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and daemon permission approval")
 	listenAddr := flags.String("listen", defaultListenAddr, "local listen address")
 	tokenFlag := flags.String("token", "", "bearer token; defaults to GLUE_DAEMON_TOKEN or a generated token")
 	metadataPath := flags.String("metadata", defaultMetadataPath(), "connection metadata JSON path; empty disables metadata file")
 	permissionTimeout := flags.Duration("permission-timeout", 0, "permission decision timeout; 0 uses daemon default")
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
+	var allowedBinaries repeatedStrings
+	flags.Var(&allowedBinaries, "allow-binary", "allowed shell_exec binary basename for --coding; repeatable")
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -370,7 +416,24 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 	if strings.TrimSpace(*metadataPath) == "" && tokenSource == "generated" {
 		return errors.New("metadata disabled requires --token or GLUE_DAEMON_TOKEN")
 	}
-	agent, err := newAgent(newProvider, *model, *storeDir, *workDir)
+	tools, _, err := buildCodingTools(codingFlagConfig{
+		Enabled:         *coding,
+		WorkDir:         *workDir,
+		AllowedBinaries: append([]string(nil), allowedBinaries...),
+		AllowOverwrite:  *codingAllowOverwrite,
+	})
+	if err != nil {
+		return err
+	}
+	if *coding {
+		fmt.Fprintf(stderr, "glue serve: coding tools enabled for %s\n", *workDir)
+	}
+	agent, err := newAgent(newProvider, agentConfig{
+		Model:    *model,
+		StoreDir: *storeDir,
+		WorkDir:  *workDir,
+		Tools:    tools,
+	})
 	if err != nil {
 		return err
 	}
@@ -2120,6 +2183,89 @@ func writeUsageSummary(w io.Writer, summary usageSummary, pricing usagePricing) 
 	fmt.Fprintf(w, "usage: %s\n", strings.Join(parts, " "))
 }
 
+func buildCodingTools(cfg codingFlagConfig) ([]glue.Tool, toolscoding.Options, error) {
+	return toolscoding.Tools(toolscoding.Options{
+		Enabled:         cfg.Enabled,
+		WorkDir:         cfg.WorkDir,
+		AllowedBinaries: append([]string(nil), cfg.AllowedBinaries...),
+		AllowOverwrite:  cfg.AllowOverwrite,
+	})
+}
+
+type localPromptPermission struct {
+	input         *bufio.Reader
+	stderr        io.Writer
+	sessionAllows map[string]struct{}
+	targetAllows  map[string]struct{}
+	foreverAllows map[string]struct{}
+}
+
+func newLocalPromptPermission(stdin io.Reader, stderr io.Writer) *localPromptPermission {
+	if stdin == nil {
+		stdin = strings.NewReader("")
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	return &localPromptPermission{
+		input:         bufio.NewReader(stdin),
+		stderr:        stderr,
+		sessionAllows: map[string]struct{}{},
+		targetAllows:  map[string]struct{}{},
+		foreverAllows: map[string]struct{}{},
+	}
+}
+
+func (p *localPromptPermission) Decide(ctx context.Context, req glue.PermissionRequest) (glue.PermissionDecision, error) {
+	if p == nil {
+		return glue.PermissionDecision{Allow: false, Reason: "permission denied: no local permission handler"}, nil
+	}
+	if _, ok := p.foreverAllows[localPermissionForeverKey(req)]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberForever}, nil
+	}
+	if _, ok := p.sessionAllows[localPermissionSessionKey(req)]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSession}, nil
+	}
+	if _, ok := p.targetAllows[localPermissionTargetKey(req)]; ok {
+		return glue.PermissionDecision{Allow: true, RememberFor: glue.RememberSessionTarget}, nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return glue.PermissionDecision{}, ctx.Err()
+	default:
+	}
+	decision, err := promptPermission(p.input, p.stderr, connectPermissionPayload{Request: req})
+	if err != nil {
+		return glue.PermissionDecision{}, err
+	}
+	out := glue.PermissionDecision{Allow: decision.Allow, Reason: decision.Reason}
+	switch decision.RememberFor {
+	case "session":
+		out.RememberFor = glue.RememberSession
+		p.sessionAllows[localPermissionSessionKey(req)] = struct{}{}
+	case "session_target":
+		out.RememberFor = glue.RememberSessionTarget
+		p.targetAllows[localPermissionTargetKey(req)] = struct{}{}
+	case "forever":
+		out.RememberFor = glue.RememberForever
+		p.foreverAllows[localPermissionForeverKey(req)] = struct{}{}
+	}
+	return out, nil
+}
+
+func localPermissionSessionKey(req glue.PermissionRequest) string {
+	return req.SessionID + "\x00" + req.Tool + "\x00" + req.Action
+}
+
+func localPermissionTargetKey(req glue.PermissionRequest) string {
+	return localPermissionSessionKey(req) + "\x00" + req.Target
+}
+
+func localPermissionForeverKey(req glue.PermissionRequest) string {
+	return req.Tool + "\x00" + req.Action + "\x00" + req.Target
+}
+
 func promptPermission(input *bufio.Reader, stderr io.Writer, perm connectPermissionPayload) (connectPermissionDecision, error) {
 	req := perm.Request
 	fmt.Fprintf(stderr, "\nPermission requested: %s", req.Tool)
@@ -2144,7 +2290,7 @@ func promptPermission(input *bufio.Reader, stderr io.Writer, perm connectPermiss
 	case "f", "forever":
 		return connectPermissionDecision{Allow: true, RememberFor: "forever"}, nil
 	default:
-		return connectPermissionDecision{Allow: false, Reason: "permission denied by glue connect"}, nil
+		return connectPermissionDecision{Allow: false, Reason: "permission denied by user"}, nil
 	}
 }
 
@@ -2188,16 +2334,18 @@ func cancelDaemonRun(ctx context.Context, cfg connectConfig, runID string, clien
 	return nil
 }
 
-func newAgent(newProvider providerFactory, model, storeDir, workDir string) (*glue.Agent, error) {
+func newAgent(newProvider providerFactory, cfg agentConfig) (*glue.Agent, error) {
 	provider, err := newProvider()
 	if err != nil {
 		return nil, err
 	}
 	return glue.NewAgent(glue.AgentOptions{
-		Provider: provider,
-		Model:    normalizeModel(model),
-		Store:    filestore.New(storeDir),
-		WorkDir:  workDir,
+		Provider:   provider,
+		Model:      normalizeModel(cfg.Model),
+		Tools:      append([]glue.Tool(nil), cfg.Tools...),
+		Store:      filestore.New(cfg.StoreDir),
+		WorkDir:    cfg.WorkDir,
+		Permission: cfg.Permission,
 	}), nil
 }
 
@@ -2287,8 +2435,8 @@ func httpStatusError(resp *http.Response) string {
 
 func printUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
-  glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--env <path>]
-  glue serve [default|gemini] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--env <path>]
+  glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
+  glue serve [default|gemini] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
   glue connect --prompt <text> [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --skill <name> [--arg key=value] [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --inspect [--inspect-json] [--metadata <path>] [--base-url <url>] [--token <token>]
@@ -2308,8 +2456,8 @@ func printUsage(w io.Writer) {
   glue connect --forget-permission <id> [--forget-permission-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
-  run      Run the local Gemini-backed agent.
-  serve    Start a local HTTP+SSE daemon for Glue sessions.
+  run      Run the local Gemini-backed agent, optionally with coding tools.
+  serve    Start a local HTTP+SSE daemon for Glue sessions, optionally with coding tools.
   connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP/recall surfaces.
 
 Flags:
@@ -2318,7 +2466,13 @@ Flags:
   --skill    Connect mode: run one daemon skill instead of --prompt.
   --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
   --store    File session store directory. Defaults to .glue/sessions.
-  --work     Working directory for serve mode. Defaults to ".".
+  --work     Workspace for AGENTS.md, skills, roles, and --coding tools. Defaults to ".".
+  --coding
+             Run/serve mode: register Glue's local coding tool bundle.
+  --allow-binary
+             Run/serve --coding mode: allowed shell_exec binary basename; repeatable.
+  --coding-allow-overwrite
+             Run/serve --coding mode: allow write_file overwrites when the model also sets overwrite=true.
   --listen   Serve listen address. Defaults to 127.0.0.1:0.
   --token    Serve bearer token. Defaults to GLUE_DAEMON_TOKEN or a generated token.
   --metadata Serve connection metadata JSON. Defaults to the user config directory.

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -54,6 +54,14 @@ func textTurn(text string) []glue.ProviderEvent {
 	}
 }
 
+func toolCallTurn(id, name, args string) []glue.ProviderEvent {
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventToolCall, ToolCall: &glue.ToolCall{ID: id, Name: name, Arguments: json.RawMessage(args)}},
+		{Type: glue.ProviderEventDone},
+	}
+}
+
 func writeJSONResponse(t *testing.T, w http.ResponseWriter, status int, value any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
@@ -344,6 +352,75 @@ func TestRunCLIProviderErrorExit(t *testing.T) {
 	}
 }
 
+func TestRunCLICodingToolsPromptAndWrite(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "write_file", `{"path":"note.txt","content":"hello from glue code"}`),
+		textTurn("done"),
+	}}
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"run",
+		"--coding",
+		"--work", workDir,
+		"--prompt", "write a note",
+		"--store", filepath.Join(t.TempDir(), "sessions"),
+	}, strings.NewReader("a\n"), &stdout, &stderr, fakeFactory(provider), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if stdout.String() != "done\n" {
+		t.Fatalf("stdout = %q, want done", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "glue run: coding tools enabled") || !strings.Contains(stderr.String(), "Permission requested: write_file") {
+		t.Fatalf("stderr = %q, want coding notice and permission prompt", stderr.String())
+	}
+	data, err := os.ReadFile(filepath.Join(workDir, "note.txt"))
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if string(data) != "hello from glue code" {
+		t.Fatalf("note.txt = %q", data)
+	}
+	if len(provider.requests) == 0 {
+		t.Fatal("provider not called")
+	}
+	var toolNames []string
+	for _, tool := range provider.requests[0].Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	for _, want := range []string{"read_file", "write_file", "shell_exec", "git_diff_branch", "git_log_branch"} {
+		if !containsString(toolNames, want) {
+			t.Fatalf("tools = %v, missing %s", toolNames, want)
+		}
+	}
+}
+
+func TestRunCLICodingDeniesSideEffectOnDefaultPromptAnswer(t *testing.T) {
+	workDir := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		toolCallTurn("c1", "write_file", `{"path":"note.txt","content":"should not write"}`),
+		textTurn("done"),
+	}}
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithDeps(context.Background(), []string{
+		"run",
+		"--coding",
+		"--work", workDir,
+		"--prompt", "try to write",
+		"--store", filepath.Join(t.TempDir(), "sessions"),
+	}, strings.NewReader("\n"), &stdout, &stderr, fakeFactory(provider), nil, http.DefaultClient)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "note.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("note.txt stat err = %v, want not exist", err)
+	}
+	if !strings.Contains(lastToolText(t, provider.requests[1]), "permission denied by user") {
+		t.Fatalf("tool result = %q, want denial", lastToolText(t, provider.requests[1]))
+	}
+}
+
 func TestRunCLIMissingPrompt(t *testing.T) {
 	t.Parallel()
 
@@ -438,6 +515,57 @@ func TestRunCLIServeBuildsDaemon(t *testing.T) {
 	}
 	if got := provider.requests[0].Model; got != "custom" {
 		t.Fatalf("provider model = %q, want custom", got)
+	}
+}
+
+func TestRunCLIServeCodingAdvertisesTools(t *testing.T) {
+	workDir := t.TempDir()
+	var captured serveConfig
+	serve := func(_ context.Context, cfg serveConfig, handler http.Handler, _ io.Writer) error {
+		captured = cfg
+		req := httptest.NewRequest(http.MethodGet, "/v1/tools", nil)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("tools status = %d body=%s", rec.Code, rec.Body.String())
+		}
+		var catalog daemonToolCatalog
+		if err := json.NewDecoder(rec.Body).Decode(&catalog); err != nil {
+			t.Fatal(err)
+		}
+		var names []string
+		for _, tool := range catalog.Tools {
+			names = append(names, tool.Name)
+			if tool.Name == "shell_exec" && (!tool.RequiresPermission || tool.PermissionAction != "exec") {
+				t.Fatalf("shell_exec permission metadata = %+v", tool)
+			}
+		}
+		for _, want := range []string{"read_file", "write_file", "shell_exec", "git_diff_branch", "git_log_branch"} {
+			if !containsString(names, want) {
+				t.Fatalf("tools = %v, missing %s", names, want)
+			}
+		}
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runCLIWithServe(context.Background(), []string{
+		"serve",
+		"--coding",
+		"--work", workDir,
+		"--allow-binary", "go",
+		"--token", "test-token",
+		"--metadata", filepath.Join(t.TempDir(), "daemon.json"),
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}), serve)
+	if code != 0 {
+		t.Fatalf("code = %d stderr=%q", code, stderr.String())
+	}
+	if captured.WorkDir != workDir {
+		t.Fatalf("workdir = %q, want %q", captured.WorkDir, workDir)
+	}
+	if !strings.Contains(stderr.String(), "glue serve: coding tools enabled") {
+		t.Fatalf("stderr = %q, want coding notice", stderr.String())
 	}
 }
 
@@ -2639,4 +2767,25 @@ func TestRunCLIMissingGeminiAPIKey(t *testing.T) {
 	if !strings.Contains(stderr.String(), "GEMINI_API_KEY") {
 		t.Fatalf("stderr = %q, want GEMINI_API_KEY hint", stderr.String())
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func lastToolText(t *testing.T, req glue.ProviderRequest) string {
+	t.Helper()
+	if len(req.Messages) == 0 {
+		t.Fatal("provider request has no messages")
+	}
+	msg := req.Messages[len(req.Messages)-1]
+	if msg.Role != glue.MessageRoleTool || len(msg.Content) == 0 {
+		t.Fatalf("last message = %#v, want tool result", msg)
+	}
+	return msg.Content[0].Text
 }

--- a/docs/adr/0012-sdk-coding-agent-peggy-boundary.md
+++ b/docs/adr/0012-sdk-coding-agent-peggy-boundary.md
@@ -1,0 +1,69 @@
+# ADR-0012: Glue SDK, Glue Coding Agent, and Peggy Product Boundary
+
+## Status
+
+Accepted.
+
+## Context
+
+Glue now has two consumers with different jobs:
+
+- `cmd/glue` should prove and expose the framework as a local agent
+  harness and coding-agent binary.
+- `agents/peggy` should be an always-on personal assistant product built
+  on top of Glue, not the owner of reusable coding-agent execution logic.
+
+Keeping coding tools inside Peggy creates a product/framework inversion:
+other agents cannot reuse the tool bundle without importing Peggy, and
+Glue's own binary cannot dogfood the coding-agent path directly.
+
+## Decision
+
+Glue owns reusable coding-agent primitives and the default coding-agent
+binary surface:
+
+- `tools/coding` assembles the standard local coding tool bundle over
+  `tools/fs`, `tools/shell`, `tools/git`, and `glue.Executor`.
+- `cmd/glue run --coding` runs the SDK-backed coding agent in one-shot
+  terminal mode with local permission prompts for side effects.
+- `cmd/glue serve --coding` exposes the same coding-agent tool surface
+  through the daemon protocol, where `glue connect` brokers permissions.
+- Peggy consumes `tools/coding` as a product integration detail and may
+  inject a different `glue.Executor`, but it does not own the reusable
+  coding-agent tool assembly.
+
+## Loopholes and Fixes
+
+- **Loophole: SDK package exists but no binary exercises it.**
+  Fixed by wiring `cmd/glue run --coding` and `cmd/glue serve --coding`
+  to `tools/coding`.
+
+- **Loophole: side-effect tools could run locally without an operator
+  decision.**
+  Fixed by giving `glue run --coding` a local terminal permission
+  implementation. Daemon runs already use the daemon permission broker.
+
+- **Loophole: Peggy could drift back into owning coding execution.**
+  Fixed by making Peggy's `CodingTools` a thin adapter over
+  `tools/coding` and documenting the boundary here.
+
+- **Loophole: local execution is not a sandbox.**
+  Not fixed in this ADR. The accepted boundary is permission-gated local
+  execution behind `glue.Executor`; a VM/container executor is the next
+  additive backend.
+
+- **Loophole: the coding tool bundle is not yet Pi-class.**
+  Not fixed in this ADR. `edit`, `grep`, `find`, `ls`, richer patch
+  previews, and session tree UX remain follow-up coding-agent features.
+
+- **Loophole: `cmd/glue` provider UX is still Gemini-shaped.**
+  Not fixed in this ADR. The binary now proves the coding-agent surface,
+  but model/provider selection still needs to move from the historical
+  Gemini runner toward the providers registry used by downstream agents.
+
+## Consequences
+
+Glue can now be evaluated as both a framework and a coding-agent binary
+without importing Peggy. Peggy remains free to focus on always-on
+assistant concerns: identity, memory, channels, reminders, background
+runs, notifications, and product UX.

--- a/tools/coding/coding.go
+++ b/tools/coding/coding.go
@@ -1,0 +1,219 @@
+package coding
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/erain/glue"
+	toolsfs "github.com/erain/glue/tools/fs"
+	toolsgit "github.com/erain/glue/tools/git"
+	toolsshell "github.com/erain/glue/tools/shell"
+)
+
+// DefaultAllowedBinaries is the conservative shell_exec allowlist used
+// when Options.AllowedBinaries is empty.
+var DefaultAllowedBinaries = []string{"go", "git", "make", "node", "npm", "python", "python3"}
+
+// Options configures the reusable coding-agent tool bundle.
+type Options struct {
+	// Enabled gates the whole bundle. Disabled returns no tools and does
+	// not validate the rest of the options.
+	Enabled bool
+
+	// WorkDir is the workspace root for every tool. Empty uses the
+	// process working directory. Leading ~ and $HOME are expanded.
+	WorkDir string
+
+	// AllowedBinaries is the shell_exec basename allowlist. Empty falls
+	// back to DefaultAllowedBinaries.
+	AllowedBinaries []string
+
+	// AllowOverwrite is the host-level write_file overwrite policy.
+	AllowOverwrite bool
+
+	// Executor runs shell_exec commands. Nil uses glue.LocalExecutor.
+	Executor glue.Executor
+
+	// Env is the exact child process environment for shell_exec. Nil
+	// means the child inherits no environment.
+	Env []string
+
+	// Blocklist refuses secret-shaped paths for read_file and write_file.
+	// Nil uses tools/fs.Default().
+	Blocklist toolsfs.Blocklist
+
+	// ReadMaxBytes caps read_file output. Zero uses the fs package default.
+	ReadMaxBytes int
+
+	// WriteMaxBytes caps write_file content. Zero uses the fs package default.
+	WriteMaxBytes int
+
+	// ShellTimeout caps shell_exec calls. Zero uses the shell package default.
+	ShellTimeout time.Duration
+
+	// ShellMaxOutputBytes caps shell_exec stdout and stderr independently.
+	// Zero uses the glue executor default.
+	ShellMaxOutputBytes int
+
+	// GitDefaultBase is the default base ref for git_diff_branch and
+	// git_log_branch. Empty uses the git package default.
+	GitDefaultBase string
+
+	// GitDiffMaxBytes caps git_diff_branch output. Zero uses the git
+	// package default.
+	GitDiffMaxBytes int
+
+	// GitLogLimit caps git_log_branch commit count. Zero uses the git
+	// package default.
+	GitLogLimit int
+
+	// GitTimeout caps each git invocation. Zero uses the git package default.
+	GitTimeout time.Duration
+}
+
+// Tools builds the standard local coding tool bundle:
+// read_file, write_file, shell_exec, git_diff_branch, and git_log_branch.
+//
+// The returned Options contain the resolved absolute WorkDir, normalized
+// AllowedBinaries, copied Env, and effective Blocklist.
+func Tools(opts Options) ([]glue.Tool, Options, error) {
+	if !opts.Enabled {
+		return nil, opts, nil
+	}
+
+	resolved, err := ResolveOptions(opts)
+	if err != nil {
+		return nil, opts, err
+	}
+
+	write, err := toolsfs.FileWrite(toolsfs.FileWriteOptions{
+		WorkDir:        resolved.WorkDir,
+		AllowOverwrite: resolved.AllowOverwrite,
+		MaxBytes:       resolved.WriteMaxBytes,
+		Blocklist:      resolved.Blocklist,
+	})
+	if err != nil {
+		return nil, opts, err
+	}
+	shell, err := toolsshell.Exec(toolsshell.ExecOptions{
+		Executor:        resolved.Executor,
+		WorkDir:         resolved.WorkDir,
+		Env:             resolved.Env,
+		AllowedBinaries: resolved.AllowedBinaries,
+		Timeout:         resolved.ShellTimeout,
+		MaxOutputBytes:  resolved.ShellMaxOutputBytes,
+	})
+	if err != nil {
+		return nil, opts, err
+	}
+
+	return []glue.Tool{
+		toolsfs.ReadFileTool(toolsfs.ReadFileOptions{
+			WorkDir:   resolved.WorkDir,
+			Blocklist: resolved.Blocklist,
+			MaxBytes:  resolved.ReadMaxBytes,
+		}),
+		write,
+		shell,
+		toolsgit.DiffBranchTool(toolsgit.DiffBranchOptions{
+			WorkDir:     resolved.WorkDir,
+			DefaultBase: resolved.GitDefaultBase,
+			MaxBytes:    resolved.GitDiffMaxBytes,
+			Timeout:     resolved.GitTimeout,
+		}),
+		toolsgit.LogBranchTool(toolsgit.LogBranchOptions{
+			WorkDir:      resolved.WorkDir,
+			DefaultBase:  resolved.GitDefaultBase,
+			DefaultLimit: resolved.GitLogLimit,
+			Timeout:      resolved.GitTimeout,
+		}),
+	}, resolved, nil
+}
+
+// ResolveOptions validates and fills defaults for enabled coding tools.
+func ResolveOptions(opts Options) (Options, error) {
+	if !opts.Enabled {
+		return opts, nil
+	}
+
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return Options{}, fmt.Errorf("coding: workdir: %w", err)
+		}
+		workDir = cwd
+	}
+	expanded, err := ExpandPath(workDir)
+	if err != nil {
+		return Options{}, err
+	}
+	absWorkDir, err := filepath.Abs(expanded)
+	if err != nil {
+		return Options{}, fmt.Errorf("coding: workdir: %w", err)
+	}
+	info, err := os.Stat(absWorkDir)
+	if err != nil {
+		return Options{}, fmt.Errorf("coding: workdir: %w", err)
+	}
+	if !info.IsDir() {
+		return Options{}, fmt.Errorf("coding: workdir %q is not a directory", absWorkDir)
+	}
+
+	allowed := NormalizeAllowedBinaries(opts.AllowedBinaries)
+	if len(allowed) == 0 {
+		allowed = append([]string(nil), DefaultAllowedBinaries...)
+	}
+
+	blocklist := opts.Blocklist
+	if blocklist == nil {
+		blocklist = toolsfs.Default()
+	}
+
+	resolved := opts
+	resolved.WorkDir = absWorkDir
+	resolved.AllowedBinaries = allowed
+	resolved.Env = append([]string(nil), opts.Env...)
+	resolved.Blocklist = blocklist
+	return resolved, nil
+}
+
+// NormalizeAllowedBinaries trims, drops empties, and deduplicates a shell
+// binary allowlist while preserving first-seen order.
+func NormalizeAllowedBinaries(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, raw := range in {
+		bin := strings.TrimSpace(raw)
+		if bin == "" {
+			continue
+		}
+		if _, ok := seen[bin]; ok {
+			continue
+		}
+		seen[bin] = struct{}{}
+		out = append(out, bin)
+	}
+	return out
+}
+
+// ExpandPath resolves leading "~" plus "$HOME" and "${HOME}" placeholders.
+// Other environment variables are deliberately left untouched.
+func ExpandPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("coding: resolve ~: %w", err)
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+	}
+	path = strings.ReplaceAll(path, "${HOME}", os.Getenv("HOME"))
+	path = strings.ReplaceAll(path, "$HOME", os.Getenv("HOME"))
+	return path, nil
+}

--- a/tools/coding/coding_test.go
+++ b/tools/coding/coding_test.go
@@ -1,0 +1,153 @@
+package coding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+type fakeExecutor struct {
+	commands []glue.ExecCommand
+	stdin    []string
+}
+
+func (f *fakeExecutor) Run(_ context.Context, cmd glue.ExecCommand) (glue.ExecResult, error) {
+	f.commands = append(f.commands, cmd)
+	if cmd.Stdin != nil {
+		data, _ := io.ReadAll(cmd.Stdin)
+		f.stdin = append(f.stdin, string(data))
+	}
+	return glue.ExecResult{Stdout: []byte("ok\n")}, nil
+}
+
+func TestToolsDisabledDoesNotValidate(t *testing.T) {
+	tools, resolved, err := Tools(Options{WorkDir: "/does/not/exist"})
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if len(tools) != 0 {
+		t.Fatalf("tools = %d, want 0", len(tools))
+	}
+	if resolved.WorkDir != "/does/not/exist" {
+		t.Fatalf("workdir = %q", resolved.WorkDir)
+	}
+}
+
+func TestToolsResolveDefaultsAndRegisterBundle(t *testing.T) {
+	work := t.TempDir()
+	tools, resolved, err := Tools(Options{
+		Enabled:         true,
+		WorkDir:         work,
+		AllowedBinaries: []string{" go ", "", "go", "git"},
+	})
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if !filepath.IsAbs(resolved.WorkDir) {
+		t.Fatalf("workdir = %q, want absolute", resolved.WorkDir)
+	}
+	if !reflect.DeepEqual(resolved.AllowedBinaries, []string{"go", "git"}) {
+		t.Fatalf("allowed binaries = %#v", resolved.AllowedBinaries)
+	}
+	if resolved.Blocklist == nil {
+		t.Fatal("blocklist = nil, want default")
+	}
+
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	want := []string{"git_diff_branch", "git_log_branch", "read_file", "shell_exec", "write_file"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("tool names = %#v, want %#v", names, want)
+	}
+}
+
+func TestToolsUsesInjectedExecutor(t *testing.T) {
+	work := t.TempDir()
+	fake := &fakeExecutor{}
+	tools, _, err := Tools(Options{
+		Enabled:         true,
+		WorkDir:         work,
+		AllowedBinaries: []string{"go"},
+		Executor:        fake,
+		Env:             []string{"A=B"},
+	})
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	shell := findTool(t, tools, "shell_exec")
+	res, err := shell.Execute(context.Background(), glue.ToolCall{
+		Name:      shell.Name,
+		Arguments: json.RawMessage(`{"argv":["go","version"],"stdin":"hello"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("shell_exec error: %s", res.Content[0].Text)
+	}
+	if len(fake.commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(fake.commands))
+	}
+	if !reflect.DeepEqual(fake.commands[0].Argv, []string{"go", "version"}) {
+		t.Fatalf("argv = %#v", fake.commands[0].Argv)
+	}
+	if !reflect.DeepEqual(fake.commands[0].Env, []string{"A=B"}) {
+		t.Fatalf("env = %#v", fake.commands[0].Env)
+	}
+	if fake.stdin[0] != "hello" {
+		t.Fatalf("stdin = %q, want hello", fake.stdin[0])
+	}
+}
+
+func TestResolveOptionsRejectsInvalidWorkspace(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ResolveOptions(Options{Enabled: true, WorkDir: file})
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("ResolveOptions error = %v, want not a directory", err)
+	}
+}
+
+func TestExpandPathExpandsHomeOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	got, err := ExpandPath("~/workspace")
+	if err != nil {
+		t.Fatalf("ExpandPath: %v", err)
+	}
+	if got != filepath.Join(home, "workspace") {
+		t.Fatalf("~ expanded to %q, want home workspace", got)
+	}
+	got, err = ExpandPath("$HOME/workspace/${HOME}")
+	if err != nil {
+		t.Fatalf("ExpandPath HOME: %v", err)
+	}
+	want := home + "/workspace/" + home
+	if got != want {
+		t.Fatalf("HOME expanded to %q, want %q", got, want)
+	}
+}
+
+func findTool(t *testing.T, tools []glue.Tool, name string) glue.Tool {
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("missing tool %q", name)
+	return glue.Tool{}
+}

--- a/tools/coding/doc.go
+++ b/tools/coding/doc.go
@@ -1,0 +1,7 @@
+// Package coding assembles the reusable local coding-agent tool bundle.
+//
+// The package is intentionally a thin SDK layer over the lower-level
+// filesystem, shell, git, and executor primitives. Products such as Peggy
+// should configure this package instead of owning coding-agent tool wiring
+// directly.
+package coding


### PR DESCRIPTION
## Summary

Extracts the reusable local coding-agent tool bundle into a new
`tools/coding` package and wires it into the `cmd/glue` binary, so Glue
can be dogfooded as a coding agent without importing Peggy. Peggy becomes
a thin consumer of the bundle with a runtime executor injection seam.

- `tools/coding.Tools` assembles `read_file`, `write_file`, `shell_exec`,
  `git_diff_branch`, and `git_log_branch` over `tools/fs`, `tools/git`,
  `tools/shell`, and `glue.Executor`, returning resolved/validated options.
- `glue run --coding` runs the bundle one-shot with local terminal
  permission prompts; `glue serve --coding` brokers permissions over the
  daemon protocol.
- `agents/peggy` `CodingTools` now adapts `tools/coding` and exposes
  `CodingExecutor` / `CodingEnv` for future VM/container backends.

The framework/coding-agent/Peggy boundary is recorded in ADR-0012.

Closes #270

## Verification

```
go build ./...        # ok
go vet ./...          # ok
go test ./tools/coding/ ./agents/peggy/ ./cmd/glue/   # all ok
```

Full `go test ./...` is green except the env-gated live smoke test in
`agents/glue-review` (`TestLiveReviewSmoke`), which is unrelated to this
change and does not run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
