### PR TITLE
cmd/glue: select provider from registry, support codex coding agent (closes #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ This file tracks library-level changes only.
   `glue serve --coding` now register the SDK coding bundle, with local
   terminal permission prompts for one-shot runs and daemon-brokered
   permissions for served runs.
+- Added `cmd/glue --provider`: `run` and `serve` now select any
+  registered provider (`codex`, `gemini`, `nvidia`, `openrouter`) through
+  the `providers` registry instead of being hardwired to Gemini, so the
+  binary can run as a coding agent on a ChatGPT subscription
+  (`glue run --provider codex --coding`). `--model` now defaults to the
+  selected provider's registry default model.
 
 ## Initial bootstrap (pre-1.0)
 

--- a/README.md
+++ b/README.md
@@ -601,13 +601,19 @@ A thin local CLI is built on the same library API:
 ```sh
 go run ./cmd/glue run --prompt "Say hi" --id local-dev --store .glue/sessions
 go run ./cmd/glue run --coding --work . --prompt "Run the tests and summarize failures."
+go run ./cmd/glue run --provider codex --coding --work . --prompt "Fix the failing test."
 ```
 
 `run` flags:
 
 - `--id` — session id (default `"default"`).
 - `--prompt` — prompt text (required).
-- `--model` — model id or `gemini/<model>` (default `gemini-2.5-flash`).
+- `--provider` — provider name from the registry: `codex`, `gemini`,
+  `nvidia`, or `openrouter` (default `gemini`). Use `--provider codex`
+  for a ChatGPT-subscription coding agent (run `codex login` first; no
+  per-token bill).
+- `--model` — model id (default: the selected provider's default model).
+  `gemini/<model>` is accepted for the gemini provider.
 - `--store` — file session store directory (default `.glue/sessions`).
 - `--work` — workspace for `AGENTS.md`, `.agents/skills`, roles, and
   optional coding tools (default `.`).
@@ -623,8 +629,10 @@ go run ./cmd/glue run --coding --work . --prompt "Run the tests and summarize fa
   `--usage-cache-read-price`, `--usage-cache-write-price` — optional
   USD-per-1M-token prices used to append `cost_usd=...` to `--usage`
   output. Glue does not ship provider price tables.
-- `--env` — `.env` file to load before reading `GEMINI_API_KEY`. Repeatable;
-  shell environment wins on conflict.
+- `--env` — `.env` file to load before reading the provider's API key
+  (e.g. `GEMINI_API_KEY`). Repeatable; shell environment wins on conflict.
+  Subscription-auth providers like `codex` read `codex login` credentials
+  instead of an env key.
 
 The CLI streams text deltas to stdout, persists sessions through
 `stores/file`, and uses the configured workdir so `AGENTS.md`,
@@ -647,7 +655,8 @@ go run ./cmd/glue serve --coding --work . --store .glue/sessions
 `--token` / `GLUE_DAEMON_TOKEN` are not set, and writes connection metadata
 to `glue/daemon.json` under the user config directory with mode `0600`.
 Startup output prints the effective `base_url` and metadata path but not the
-bearer token. Use `--listen`, `--metadata`, `--work`, `--coding`, and
+bearer token. Use `--provider`, `--listen`, `--metadata`, `--work`,
+`--coding`, and
 `--permission-timeout` to override daemon behavior. Coding-enabled daemon
 runs broker side-effect permission requests through `glue connect`.
 

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -27,19 +27,28 @@ import (
 
 	"github.com/erain/glue"
 	"github.com/erain/glue/daemon"
-	"github.com/erain/glue/providers/gemini"
+	"github.com/erain/glue/providers"
 	filestore "github.com/erain/glue/stores/file"
 	toolscoding "github.com/erain/glue/tools/coding"
+
+	// Register the shipped providers so they resolve through the
+	// providers registry by name (--provider). Importing for side
+	// effects only; the binary selects providers at runtime.
+	_ "github.com/erain/glue/providers/codex"
+	_ "github.com/erain/glue/providers/gemini"
+	_ "github.com/erain/glue/providers/nvidia"
+	_ "github.com/erain/glue/providers/openrouter"
 )
 
-const defaultModel = "gemini-2.5-flash"
+const defaultProvider = "gemini"
 const defaultListenAddr = "127.0.0.1:0"
 const defaultShutdownTimeout = 5 * time.Second
 
-// providerFactory returns a [glue.Provider] or an error. The error is the
-// hook the default factory uses to surface "GEMINI_API_KEY missing"
-// before any API call is attempted.
-type providerFactory func() (glue.Provider, error)
+// providerFactory constructs a [glue.Provider] for the named provider, or
+// returns an error. The error is the hook the default factory uses to
+// surface a missing API key before any API call is attempted. Tests inject
+// a factory that returns a canned provider and ignores the name.
+type providerFactory func(name string) (glue.Provider, error)
 
 type envFiles []string
 
@@ -67,6 +76,7 @@ type codingFlagConfig struct {
 }
 
 type agentConfig struct {
+	Provider   string
 	Model      string
 	StoreDir   string
 	WorkDir    string
@@ -233,14 +243,23 @@ type connectPermissionDecision struct {
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	os.Exit(runCLI(ctx, os.Args[1:], os.Stdout, os.Stderr, defaultGeminiFactory))
+	os.Exit(runCLI(ctx, os.Args[1:], os.Stdout, os.Stderr, defaultProviderFactory))
 }
 
-func defaultGeminiFactory() (glue.Provider, error) {
-	if strings.TrimSpace(os.Getenv("GEMINI_API_KEY")) == "" {
-		return nil, errors.New("GEMINI_API_KEY is required (set in shell or pass --env <file>)")
+// defaultProviderFactory resolves a provider from the registry by name.
+// For providers that authenticate through an environment variable, it
+// surfaces a missing-key error before any API call. Subscription-auth
+// providers (e.g. codex) carry no env key and validate their own auth at
+// request time.
+func defaultProviderFactory(name string) (glue.Provider, error) {
+	provider, _, envKey, err := providers.New(name)
+	if err != nil {
+		return nil, err
 	}
-	return gemini.New(gemini.Options{}), nil
+	if envKey != "" && strings.TrimSpace(os.Getenv(envKey)) == "" {
+		return nil, fmt.Errorf("%s is required for provider %q (set in shell or pass --env <file>)", envKey, name)
+	}
+	return provider, nil
 }
 
 func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory) int {
@@ -289,7 +308,8 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 
 	id := flags.String("id", "default", "session id")
 	prompt := flags.String("prompt", "", "prompt text")
-	model := flags.String("model", defaultModel, "model id or gemini/<model>")
+	provider := flags.String("provider", defaultProvider, "provider name: codex, gemini, nvidia, or openrouter")
+	model := flags.String("model", "", "model id (default: the provider's default model); gemini/<model> accepted")
 	storeDir := flags.String("store", ".glue/sessions", "session store directory")
 	workDir := flags.String("work", ".", "working directory for AGENTS.md, skills, roles, and optional coding tools")
 	coding := flags.Bool("coding", false, "enable local coding tools for this run")
@@ -319,6 +339,10 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 	if strings.TrimSpace(*prompt) == "" {
 		return errors.New("missing required --prompt")
 	}
+	providerName, effectiveModel, err := resolveProvider(*provider, *model)
+	if err != nil {
+		return err
+	}
 	if err := loadEnvFiles(envs); err != nil {
 		return err
 	}
@@ -339,7 +363,8 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 	}
 
 	agent, err := newAgent(newProvider, agentConfig{
-		Model:      *model,
+		Provider:   providerName,
+		Model:      effectiveModel,
 		StoreDir:   *storeDir,
 		WorkDir:    *workDir,
 		Tools:      tools,
@@ -381,7 +406,8 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 	flags := flag.NewFlagSet("glue serve", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 
-	model := flags.String("model", defaultModel, "model id or gemini/<model>")
+	provider := flags.String("provider", defaultProvider, "provider name: codex, gemini, nvidia, or openrouter")
+	model := flags.String("model", "", "model id (default: the provider's default model); gemini/<model> accepted")
 	storeDir := flags.String("store", ".glue/sessions", "session store directory")
 	workDir := flags.String("work", ".", "working directory for AGENTS.md, skills, and roles")
 	coding := flags.Bool("coding", false, "enable local coding tools for daemon runs")
@@ -406,6 +432,10 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 	if agentName != "default" && agentName != "gemini" {
 		return fmt.Errorf("unknown agent %q; only 'default' is available in this runner", agentName)
 	}
+	providerName, effectiveModel, err := resolveProvider(*provider, *model)
+	if err != nil {
+		return err
+	}
 	if err := loadEnvFiles(envs); err != nil {
 		return err
 	}
@@ -429,7 +459,8 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 		fmt.Fprintf(stderr, "glue serve: coding tools enabled for %s\n", *workDir)
 	}
 	agent, err := newAgent(newProvider, agentConfig{
-		Model:    *model,
+		Provider: providerName,
+		Model:    effectiveModel,
 		StoreDir: *storeDir,
 		WorkDir:  *workDir,
 		Tools:    tools,
@@ -445,8 +476,8 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 			ListenAddr:   *listenAddr,
 			MetadataPath: *metadataPath,
 			TokenSource:  tokenSource,
-			Provider:     "gemini",
-			Model:        normalizeModel(*model),
+			Provider:     providerName,
+			Model:        normalizeModel(effectiveModel),
 			StoreType:    "file",
 			StorePath:    *storeDir,
 		},
@@ -460,7 +491,7 @@ func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr i
 		Token:             token,
 		TokenSource:       tokenSource,
 		MetadataPath:      *metadataPath,
-		Model:             normalizeModel(*model),
+		Model:             normalizeModel(effectiveModel),
 		StoreDir:          *storeDir,
 		WorkDir:           *workDir,
 		PermissionTimeout: *permissionTimeout,
@@ -2334,8 +2365,26 @@ func cancelDaemonRun(ctx context.Context, cfg connectConfig, runID string, clien
 	return nil
 }
 
+// resolveProvider validates the provider name against the registry and
+// resolves the effective model: an explicit --model wins, otherwise the
+// provider's registry default model is used.
+func resolveProvider(name, model string) (string, string, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		name = defaultProvider
+	}
+	factory, ok := providers.Lookup(name)
+	if !ok {
+		return "", "", fmt.Errorf("unknown provider %q (known: %s)", name, strings.Join(providers.Known(), ", "))
+	}
+	if strings.TrimSpace(model) == "" {
+		model = factory.DefaultModel
+	}
+	return name, model, nil
+}
+
 func newAgent(newProvider providerFactory, cfg agentConfig) (*glue.Agent, error) {
-	provider, err := newProvider()
+	provider, err := newProvider(cfg.Provider)
 	if err != nil {
 		return nil, err
 	}
@@ -2435,8 +2484,8 @@ func httpStatusError(resp *http.Response) string {
 
 func printUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
-  glue run [default|gemini] --prompt <text> [--id <id>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
-  glue serve [default|gemini] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
+  glue run --prompt <text> [--provider <name>] [--id <id>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
+  glue serve [--provider <name>] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
   glue connect --prompt <text> [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --skill <name> [--arg key=value] [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --inspect [--inspect-json] [--metadata <path>] [--base-url <url>] [--token <token>]
@@ -2456,7 +2505,7 @@ func printUsage(w io.Writer) {
   glue connect --forget-permission <id> [--forget-permission-json] [--metadata <path>] [--base-url <url>] [--token <token>]
 
 Commands:
-  run      Run the local Gemini-backed agent, optionally with coding tools.
+  run      Run a local agent on any registered provider, optionally with coding tools.
   serve    Start a local HTTP+SSE daemon for Glue sessions, optionally with coding tools.
   connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP/recall surfaces.
 
@@ -2464,7 +2513,9 @@ Flags:
   --id       Session id. Defaults to "default".
   --prompt   Prompt text. Required unless --skill is set or connect is in an inspection mode.
   --skill    Connect mode: run one daemon skill instead of --prompt.
-  --model    Gemini model id or gemini/<model>. Defaults to gemini-2.5-flash.
+  --provider Run/serve provider: codex, gemini, nvidia, or openrouter. Defaults to gemini.
+             Use --provider codex for a ChatGPT-subscription coding agent (run "codex login" first).
+  --model    Model id. Defaults to the selected provider's default model. gemini/<model> accepted.
   --store    File session store directory. Defaults to .glue/sessions.
   --work     Workspace for AGENTS.md, skills, roles, and --coding tools. Defaults to ".".
   --coding

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -43,7 +43,7 @@ func (p *scriptedProvider) Stream(_ context.Context, req glue.ProviderRequest) (
 }
 
 func fakeFactory(provider glue.Provider) providerFactory {
-	return func() (glue.Provider, error) { return provider, nil }
+	return func(string) (glue.Provider, error) { return provider, nil }
 }
 
 func textTurn(text string) []glue.ProviderEvent {
@@ -2760,12 +2760,93 @@ func TestRunCLIMissingGeminiAPIKey(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runCLI(context.Background(), []string{
 		"run", "--prompt", "go", "--store", t.TempDir(),
-	}, &stdout, &stderr, defaultGeminiFactory)
+	}, &stdout, &stderr, defaultProviderFactory)
 	if code == 0 {
 		t.Fatal("code = 0, want nonzero for missing GEMINI_API_KEY")
 	}
 	if !strings.Contains(stderr.String(), "GEMINI_API_KEY") {
 		t.Fatalf("stderr = %q, want GEMINI_API_KEY hint", stderr.String())
+	}
+}
+
+func TestResolveProvider(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		provider  string
+		model     string
+		wantName  string
+		wantModel string
+		wantErr   string
+	}{
+		{name: "default empty selects gemini", provider: "", model: "", wantName: "gemini", wantModel: "gemini-2.5-flash"},
+		{name: "codex default model", provider: "codex", model: "", wantName: "codex", wantModel: "gpt-5-codex"},
+		{name: "explicit model overrides default", provider: "gemini", model: "gemini-2.0-pro", wantName: "gemini", wantModel: "gemini-2.0-pro"},
+		{name: "case insensitive name", provider: "CodeX", model: "", wantName: "codex", wantModel: "gpt-5-codex"},
+		{name: "unknown provider errors", provider: "bogus", wantErr: "unknown provider"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			name, model, err := resolveProvider(tc.provider, tc.model)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), "known:") {
+					t.Fatalf("err = %v, want a known-providers hint", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if name != tc.wantName {
+				t.Fatalf("name = %q, want %q", name, tc.wantName)
+			}
+			if model != tc.wantModel {
+				t.Fatalf("model = %q, want %q", model, tc.wantModel)
+			}
+		})
+	}
+}
+
+func TestDefaultProviderFactory(t *testing.T) {
+	t.Run("missing gemini key errors", func(t *testing.T) {
+		t.Setenv("GEMINI_API_KEY", "")
+		_, err := defaultProviderFactory("gemini")
+		if err == nil || !strings.Contains(err.Error(), "GEMINI_API_KEY") {
+			t.Fatalf("err = %v, want GEMINI_API_KEY hint", err)
+		}
+	})
+	t.Run("codex needs no env key", func(t *testing.T) {
+		provider, err := defaultProviderFactory("codex")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if provider == nil {
+			t.Fatal("provider = nil, want a codex provider")
+		}
+	})
+	t.Run("unknown provider errors", func(t *testing.T) {
+		if _, err := defaultProviderFactory("bogus"); err == nil || !strings.Contains(err.Error(), "unknown provider") {
+			t.Fatalf("err = %v, want unknown provider", err)
+		}
+	})
+}
+
+func TestRunCLIUnknownProvider(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{
+		"run", "--provider", "bogus", "--prompt", "x", "--store", t.TempDir(),
+	}, &stdout, &stderr, fakeFactory(&scriptedProvider{}))
+	if code == 0 {
+		t.Fatal("code = 0, want nonzero for unknown provider")
+	}
+	if !strings.Contains(stderr.String(), "unknown provider") {
+		t.Fatalf("stderr = %q, want 'unknown provider'", stderr.String())
 	}
 }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -293,14 +293,19 @@ applications use.
 Target command shape:
 
 ```sh
-glue run --id <session-id> --prompt "..." --model gemini/<model> --store .glue/sessions --env .env
+glue run --id <session-id> --prompt "..." --provider <name> --model <model> --store .glue/sessions --env .env
 ```
 
-The built-in runner supports the default Gemini-backed agent only. It streams
-text deltas to stdout, persists sessions through `stores/file`, loads repeatable
-`.env` files, and uses `AgentOptions.WorkDir="."` for AGENTS.md, skills, and
-roles. Dynamic Go source loading, HTTP serving, and build/deploy targets remain
-out of scope.
+The built-in runner selects a provider from the `providers` registry via
+`--provider` (`codex`, `gemini`, `nvidia`, `openrouter`; default `gemini`), so
+the binary can run as a coding agent on a ChatGPT subscription (`--provider
+codex`) without code changes. `--model` defaults to the selected provider's
+registry default model. The runner streams text deltas to stdout, persists
+sessions through `stores/file`, loads repeatable `.env` files, and uses
+`AgentOptions.WorkDir="."` for AGENTS.md, skills, and roles. `--coding`
+registers the `tools/coding` bundle behind local terminal permission prompts
+(per [ADR-0012](adr/0012-sdk-coding-agent-peggy-boundary.md)). Dynamic Go
+source loading and build/deploy targets remain out of scope.
 
 ## Context, Skills, And Roles
 


### PR DESCRIPTION
## Summary

Makes `cmd/glue` provider-agnostic so the binary can run as a coding agent on any registered provider — in particular **codex** (ChatGPT subscription) — instead of being hardwired to Gemini.

- Replaces `defaultGeminiFactory` / `defaultModel` with `defaultProviderFactory(name)` resolving over the `providers` registry, and a `resolveProvider` helper that validates the name and picks the provider's registry default model when `--model` is empty.
- Adds `--provider` to `run` and `serve` (`codex`, `gemini`, `nvidia`, `openrouter`; default `gemini`). `--model` now defaults to the selected provider's default model; `gemini/<model>` still normalizes.
- Blank-imports the provider sub-packages for self-registration; the daemon advertises the selected provider in diagnostics instead of a hardcoded `"gemini"`.
- Recommended coding-agent invocation: `glue run --provider codex --coding`.

**Decision (per the issue's "decide and document"):** default provider stays `gemini` for backward compatibility; codex is one flag away and documented as the coding-agent path. Switching the out-of-box default to codex would be a trivial follow-up if desired.

Closes #272

## Verification

```
go build ./...        # ok
go vet ./...          # ok
go test ./cmd/glue/ ./providers/   # ok
```

New tests: `TestResolveProvider` (defaults, codex default model, explicit-model override, case-insensitivity, unknown-provider error with known list), `TestDefaultProviderFactory` (missing gemini key, codex needs no env key, unknown provider), `TestRunCLIUnknownProvider`.

Manual smoke:
```
$ glue run --provider bogus --prompt x
unknown provider "bogus" (known: codex, gemini, nvidia, openrouter)
$ glue run --prompt x        # no GEMINI_API_KEY
GEMINI_API_KEY is required for provider "gemini" (set in shell or pass --env <file>)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
