### PR TITLE
tools/fs: add edit_file tool for surgical edits (closes #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ This file tracks library-level changes only.
   binary can run as a coding agent on a ChatGPT subscription
   (`glue run --provider codex --coding`). `--model` now defaults to the
   selected provider's registry default model.
+- Added `tools/fs.FileEdit` (`edit_file`), a permission-gated surgical
+  exact-string replacement tool with a unique-match guard and optional
+  `replace_all`. It is now part of the `tools/coding` bundle, so
+  `glue run --coding` agents can make targeted edits instead of
+  rewriting whole files.
 
 ## Initial bootstrap (pre-1.0)
 

--- a/README.md
+++ b/README.md
@@ -618,8 +618,8 @@ go run ./cmd/glue run --provider codex --coding --work . --prompt "Fix the faili
 - `--work` — workspace for `AGENTS.md`, `.agents/skills`, roles, and
   optional coding tools (default `.`).
 - `--coding` — register Glue's reusable coding tool bundle:
-  `read_file`, `write_file`, `shell_exec`, `git_diff_branch`, and
-  `git_log_branch`.
+  `read_file`, `write_file`, `edit_file`, `shell_exec`, `git_diff_branch`,
+  and `git_log_branch`.
 - `--allow-binary` — allowed `shell_exec` binary basename when `--coding`
   is enabled. Repeatable; empty uses the conservative default.
 - `--coding-allow-overwrite` — allow `write_file` to overwrite existing

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -554,12 +554,15 @@ model-callable tools:
 - `write_file` — write UTF-8 text inside the workspace. Permission
   required. Existing files require both `coding.allow_overwrite` /
   `--coding-allow-overwrite` and model argument `overwrite: true`.
+- `edit_file` — replace an exact string in an existing workspace file.
+  Permission required. `old_string` must match exactly once unless
+  `replace_all` is set; independent of the overwrite policy.
 - `shell_exec` — run argv-style commands inside the workspace.
   Permission required. `argv[0]` must be a configured binary basename.
 - `git_diff_branch` / `git_log_branch` — read-only branch context via
   the local `git` binary.
 
-For `write_file` and `shell_exec`, the CLI asks on stderr/stdin:
+For `write_file`, `edit_file`, and `shell_exec`, the CLI asks on stderr/stdin:
 
 ```text
 Allow? [y] once, [s] session, [t] target, [n] deny:

--- a/tools/coding/coding.go
+++ b/tools/coding/coding.go
@@ -75,7 +75,8 @@ type Options struct {
 }
 
 // Tools builds the standard local coding tool bundle:
-// read_file, write_file, shell_exec, git_diff_branch, and git_log_branch.
+// read_file, write_file, edit_file, shell_exec, git_diff_branch, and
+// git_log_branch.
 //
 // The returned Options contain the resolved absolute WorkDir, normalized
 // AllowedBinaries, copied Env, and effective Blocklist.
@@ -94,6 +95,14 @@ func Tools(opts Options) ([]glue.Tool, Options, error) {
 		AllowOverwrite: resolved.AllowOverwrite,
 		MaxBytes:       resolved.WriteMaxBytes,
 		Blocklist:      resolved.Blocklist,
+	})
+	if err != nil {
+		return nil, opts, err
+	}
+	edit, err := toolsfs.FileEdit(toolsfs.EditFileOptions{
+		WorkDir:   resolved.WorkDir,
+		MaxBytes:  resolved.WriteMaxBytes,
+		Blocklist: resolved.Blocklist,
 	})
 	if err != nil {
 		return nil, opts, err
@@ -117,6 +126,7 @@ func Tools(opts Options) ([]glue.Tool, Options, error) {
 			MaxBytes:  resolved.ReadMaxBytes,
 		}),
 		write,
+		edit,
 		shell,
 		toolsgit.DiffBranchTool(toolsgit.DiffBranchOptions{
 			WorkDir:     resolved.WorkDir,

--- a/tools/coding/coding_test.go
+++ b/tools/coding/coding_test.go
@@ -66,7 +66,7 @@ func TestToolsResolveDefaultsAndRegisterBundle(t *testing.T) {
 		names = append(names, tool.Name)
 	}
 	sort.Strings(names)
-	want := []string{"git_diff_branch", "git_log_branch", "read_file", "shell_exec", "write_file"}
+	want := []string{"edit_file", "git_diff_branch", "git_log_branch", "read_file", "shell_exec", "write_file"}
 	if !reflect.DeepEqual(names, want) {
 		t.Fatalf("tool names = %#v, want %#v", names, want)
 	}

--- a/tools/fs/edit.go
+++ b/tools/fs/edit.go
@@ -1,0 +1,206 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/erain/glue"
+)
+
+// EditFileOptions configures FileEdit.
+type EditFileOptions struct {
+	// WorkDir is the root the tool edits under. Required.
+	WorkDir string
+
+	// MaxBytes caps the size of the file being edited. Zero falls back to
+	// DefaultWriteMaxBytes.
+	MaxBytes int
+
+	// Blocklist refuses paths matching these glob patterns. Pass
+	// fs.Default().Merge(extras...) to layer extras on top of the
+	// shipped defaults.
+	Blocklist Blocklist
+}
+
+type fileEditArgs struct {
+	Path       string `json:"path"`
+	OldString  string `json:"old_string"`
+	NewString  string `json:"new_string"`
+	ReplaceAll bool   `json:"replace_all,omitempty"`
+}
+
+// FileEdit returns a glue.Tool named "edit_file" that performs an exact
+// string replacement inside a single existing file under opts.WorkDir.
+// It is permission-gated via ToolSpec metadata. Unlike write_file, it is
+// independent of any overwrite policy: editing an existing file is its
+// purpose, and every call is permission-gated.
+//
+// The replacement must be unambiguous: old_string must appear exactly
+// once unless replace_all is set. This mirrors the surgical-edit
+// contract used by Pi-class coding agents and prevents the model from
+// silently changing the wrong occurrence.
+func FileEdit(opts EditFileOptions) (glue.Tool, error) {
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		return glue.Tool{}, errors.New("fs: WorkDir is required")
+	}
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return glue.Tool{}, fmt.Errorf("fs: resolve WorkDir: %w", err)
+	}
+	info, err := os.Stat(absWorkDir)
+	if err != nil {
+		return glue.Tool{}, fmt.Errorf("fs: stat WorkDir: %w", err)
+	}
+	if !info.IsDir() {
+		return glue.Tool{}, fmt.Errorf("fs: WorkDir %q is not a directory", absWorkDir)
+	}
+	max := opts.MaxBytes
+	if max < 0 {
+		return glue.Tool{}, errors.New("fs: MaxBytes must be non-negative")
+	}
+	if max == 0 {
+		max = DefaultWriteMaxBytes
+	}
+	blocklist := opts.Blocklist
+
+	return glue.NewTool[fileEditArgs](
+		glue.ToolSpec{
+			Name:               "edit_file",
+			Description:        "Replace an exact string in an existing UTF-8 text file inside the configured workspace. Requires permission. old_string must match exactly once unless replace_all is set. Use this for surgical edits instead of rewriting the whole file with write_file.",
+			RequiresPermission: true,
+			PermissionAction:   "edit_file",
+			PermissionTarget:   fileEditPermissionTarget,
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "path": { "type": "string", "description": "Path relative to the configured workspace. The file must already exist." },
+    "old_string": { "type": "string", "description": "Exact text to replace. Include enough surrounding context to match exactly once unless replace_all is set." },
+    "new_string": { "type": "string", "description": "Replacement text. Must differ from old_string." },
+    "replace_all": { "type": "boolean", "description": "Replace every occurrence instead of requiring a unique match.", "default": false }
+  },
+  "required": ["path", "old_string", "new_string"]
+}`),
+		},
+		func(_ context.Context, args fileEditArgs) (glue.ToolResult, error) {
+			result, err := editFile(absWorkDir, args, editPolicy{
+				maxBytes:  max,
+				blocklist: blocklist,
+			})
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			return result, nil
+		},
+	), nil
+}
+
+type editPolicy struct {
+	maxBytes  int
+	blocklist Blocklist
+}
+
+func editFile(workDir string, args fileEditArgs, policy editPolicy) (glue.ToolResult, error) {
+	rel := strings.TrimSpace(args.Path)
+	if rel == "" {
+		return glue.ToolResult{}, errors.New("fs: path is required")
+	}
+	if args.OldString == "" {
+		return glue.ToolResult{}, errors.New("fs: old_string is required and must be non-empty")
+	}
+	if args.OldString == args.NewString {
+		return glue.ToolResult{}, errors.New("fs: old_string and new_string are identical; nothing to change")
+	}
+	if blocked, pat := policy.blocklist.Match(rel); blocked {
+		return glue.ToolResult{}, fmt.Errorf("path %q is blocked by sensitive-file pattern %q; do not retry", rel, pat)
+	}
+
+	target, err := SafeJoin(workDir, rel)
+	if err != nil {
+		return glue.ToolResult{}, err
+	}
+
+	info, err := os.Lstat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return glue.ToolResult{}, fmt.Errorf("fs: target %q does not exist; use write_file to create it", rel)
+		}
+		return glue.ToolResult{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return glue.ToolResult{}, fmt.Errorf("fs: target %q is a symlink; refusing to edit", rel)
+	}
+	if info.IsDir() {
+		return glue.ToolResult{}, fmt.Errorf("fs: target %q is a directory; refusing to edit", rel)
+	}
+	if info.Size() > int64(policy.maxBytes) {
+		return glue.ToolResult{}, fmt.Errorf("fs: file %q is %d bytes, exceeds max %d", rel, info.Size(), policy.maxBytes)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return glue.ToolResult{}, err
+	}
+	content := string(data)
+
+	count := strings.Count(content, args.OldString)
+	if count == 0 {
+		return glue.ToolResult{}, fmt.Errorf("fs: old_string not found in %q; read the file and match its exact text", rel)
+	}
+	if count > 1 && !args.ReplaceAll {
+		return glue.ToolResult{}, fmt.Errorf("fs: old_string matches %d times in %q; add surrounding context for a unique match or set replace_all=true", count, rel)
+	}
+
+	var updated string
+	replacements := count
+	if args.ReplaceAll {
+		updated = strings.ReplaceAll(content, args.OldString, args.NewString)
+	} else {
+		updated = strings.Replace(content, args.OldString, args.NewString, 1)
+		replacements = 1
+	}
+
+	updatedBytes := []byte(updated)
+	if len(updatedBytes) > policy.maxBytes {
+		return glue.ToolResult{}, fmt.Errorf("fs: edited content is %d bytes, exceeds max %d", len(updatedBytes), policy.maxBytes)
+	}
+
+	perm := info.Mode().Perm()
+	if perm == 0 {
+		perm = 0o644
+	}
+	if err := atomicWriteFile(filepath.Dir(target), target, updatedBytes, perm); err != nil {
+		return glue.ToolResult{}, err
+	}
+
+	cleanRel := filepath.ToSlash(filepath.Clean(rel))
+	plural := ""
+	if replacements != 1 {
+		plural = "s"
+	}
+	return glue.ToolResult{
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: fmt.Sprintf("made %d replacement%s in %s (%d bytes)", replacements, plural, cleanRel, len(updatedBytes))}},
+		Metadata: map[string]any{
+			"path":         cleanRel,
+			"replacements": replacements,
+			"bytes":        len(updatedBytes),
+		},
+	}, nil
+}
+
+func fileEditPermissionTarget(call glue.ToolCall) string {
+	var args fileEditArgs
+	if err := json.Unmarshal(call.Arguments, &args); err != nil || strings.TrimSpace(args.Path) == "" {
+		return "edit_file"
+	}
+	target := strings.TrimSpace(args.Path)
+	if args.ReplaceAll {
+		return target + " (replace_all)"
+	}
+	return target
+}

--- a/tools/fs/edit_test.go
+++ b/tools/fs/edit_test.go
@@ -1,0 +1,197 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func callEdit(t *testing.T, opts EditFileOptions, args string) glue.ToolResult {
+	t.Helper()
+	tool, err := FileEdit(opts)
+	if err != nil {
+		t.Fatalf("FileEdit: %v", err)
+	}
+	res, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name, Arguments: json.RawMessage(args)})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return res
+}
+
+func writeTemp(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestFileEditToolSpecPermissionMetadata(t *testing.T) {
+	tool, err := FileEdit(EditFileOptions{WorkDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("FileEdit: %v", err)
+	}
+	if tool.Name != "edit_file" {
+		t.Fatalf("tool name = %q, want edit_file", tool.Name)
+	}
+	if !tool.RequiresPermission {
+		t.Fatal("RequiresPermission = false, want true")
+	}
+	if tool.PermissionAction != "edit_file" {
+		t.Fatalf("PermissionAction = %q, want edit_file", tool.PermissionAction)
+	}
+	got := tool.PermissionTarget(glue.ToolCall{Arguments: json.RawMessage(`{"path":"a.go","old_string":"x","new_string":"y","replace_all":true}`)})
+	if got != "a.go (replace_all)" {
+		t.Fatalf("PermissionTarget = %q", got)
+	}
+}
+
+func TestFileEditUniqueReplacement(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "a.txt", "alpha beta gamma")
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"a.txt","old_string":"beta","new_string":"BETA"}`)
+	if res.IsError {
+		t.Fatalf("IsError = true: %q", res.Content[0].Text)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "a.txt"))
+	if string(got) != "alpha BETA gamma" {
+		t.Fatalf("content = %q", got)
+	}
+	if res.Metadata["replacements"] != 1 {
+		t.Fatalf("replacements = %v, want 1", res.Metadata["replacements"])
+	}
+}
+
+func TestFileEditAmbiguousWithoutReplaceAll(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "a.txt", "x x x")
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"a.txt","old_string":"x","new_string":"y"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "matches 3 times") {
+		t.Fatalf("result = %+v", res)
+	}
+	// File must be untouched.
+	got, _ := os.ReadFile(filepath.Join(dir, "a.txt"))
+	if string(got) != "x x x" {
+		t.Fatalf("file mutated on ambiguous edit: %q", got)
+	}
+}
+
+func TestFileEditReplaceAll(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "a.txt", "x x x")
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"a.txt","old_string":"x","new_string":"y","replace_all":true}`)
+	if res.IsError {
+		t.Fatalf("IsError = true: %q", res.Content[0].Text)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "a.txt"))
+	if string(got) != "y y y" {
+		t.Fatalf("content = %q", got)
+	}
+	if res.Metadata["replacements"] != 3 {
+		t.Fatalf("replacements = %v, want 3", res.Metadata["replacements"])
+	}
+}
+
+func TestFileEditNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "a.txt", "hello")
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"a.txt","old_string":"absent","new_string":"y"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "not found") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestFileEditRejectsEmptyAndNoop(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "a.txt", "hello")
+	if res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"a.txt","old_string":"","new_string":"y"}`); !res.IsError || !strings.Contains(res.Content[0].Text, "non-empty") {
+		t.Fatalf("empty old_string result = %+v", res)
+	}
+	if res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"a.txt","old_string":"hello","new_string":"hello"}`); !res.IsError || !strings.Contains(res.Content[0].Text, "identical") {
+		t.Fatalf("noop result = %+v", res)
+	}
+}
+
+func TestFileEditMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"nope.txt","old_string":"a","new_string":"b"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "does not exist") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestFileEditRefusesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"sub","old_string":"a","new_string":"b"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "directory") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestFileEditRefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "real.txt", "data")
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(filepath.Join(dir, "real.txt"), link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"link.txt","old_string":"data","new_string":"x"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "symlink") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestFileEditRefusesBlockedPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, ".env", "SECRET=1")
+	res := callEdit(t, EditFileOptions{WorkDir: dir, Blocklist: Default()}, `{"path":".env","old_string":"1","new_string":"2"}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "blocked") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestFileEditRefusesPathEscape(t *testing.T) {
+	dir := t.TempDir()
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"../escape.txt","old_string":"a","new_string":"b"}`)
+	if !res.IsError {
+		t.Fatalf("result = %+v, want path-escape error", res)
+	}
+}
+
+func TestFileEditOversizeFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "big.txt", "aaaa")
+	res := callEdit(t, EditFileOptions{WorkDir: dir, MaxBytes: 2}, `{"path":"big.txt","old_string":"a","new_string":"b","replace_all":true}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "exceeds max") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestFileEditPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTemp(t, dir, "exec.sh", "echo old")
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	res := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"exec.sh","old_string":"old","new_string":"new"}`)
+	if res.IsError {
+		t.Fatalf("IsError = true: %q", res.Content[0].Text)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %v, want 0755", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a surgical `edit_file` tool so `glue run --coding` agents can make targeted in-place edits instead of rewriting whole files with `write_file` — the largest remaining Pi-class gap from ADR-0012.

- `tools/fs.FileEdit(EditFileOptions)` returns a permission-gated `edit_file` tool: exact-string replacement with `path`, `old_string`, `new_string`, optional `replace_all`.
- Unique-match guard: errors on no-match, on >1 match without `replace_all`, on empty `old_string`, and on no-op edits (`old_string == new_string`).
- Safety parity with `write_file`: workspace `SafeJoin`, secret-path `Blocklist`, symlink/dir refusal, file-size ceiling, atomic write, preserved file mode. Independent of `AllowOverwrite` (editing an existing file is the point; every call is permission-gated).
- Registered in the `tools/coding` bundle (now: read_file, write_file, edit_file, shell_exec, git_diff_branch, git_log_branch).

Closes #275

## Verification

```
go build ./...        # ok
go vet ./...          # ok
go test ./tools/fs/ ./tools/coding/ ./agents/peggy/ ./cmd/glue/   # ok
```

New `tools/fs` tests cover unique replacement, ambiguous-without-replace_all (file untouched), replace_all, no-match, empty/no-op rejection, missing file, directory, symlink, blocked path, path escape, oversize file, and preserved mode. The `tools/coding` bundle test asserts `edit_file` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
