### PR TITLE
tools/fs: add read-only navigation tools (ls, find_files, grep) (closes #277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ This file tracks library-level changes only.
   `replace_all`. It is now part of the `tools/coding` bundle, so
   `glue run --coding` agents can make targeted edits instead of
   rewriting whole files.
+- Added read-only navigation tools `tools/fs.ListDirTool` (`list_dir`),
+  `FindTool` (`find_files`), and `GrepTool` (`grep`), also registered in
+  the `tools/coding` bundle. They are workspace-scoped and escape-safe;
+  `grep` skips secret-shaped (Blocklist) and oversized files, and all
+  three skip `.git`.
 
 ## Initial bootstrap (pre-1.0)
 

--- a/README.md
+++ b/README.md
@@ -618,8 +618,8 @@ go run ./cmd/glue run --provider codex --coding --work . --prompt "Fix the faili
 - `--work` — workspace for `AGENTS.md`, `.agents/skills`, roles, and
   optional coding tools (default `.`).
 - `--coding` — register Glue's reusable coding tool bundle:
-  `read_file`, `write_file`, `edit_file`, `shell_exec`, `git_diff_branch`,
-  and `git_log_branch`.
+  `read_file`, `write_file`, `edit_file`, `list_dir`, `find_files`,
+  `grep`, `shell_exec`, `git_diff_branch`, and `git_log_branch`.
 - `--allow-binary` — allowed `shell_exec` binary basename when `--coding`
   is enabled. Repeatable; empty uses the conservative default.
 - `--coding-allow-overwrite` — allow `write_file` to overwrite existing

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -557,6 +557,10 @@ model-callable tools:
 - `edit_file` — replace an exact string in an existing workspace file.
   Permission required. `old_string` must match exactly once unless
   `replace_all` is set; independent of the overwrite policy.
+- `list_dir` / `find_files` / `grep` — read-only navigation: list a
+  directory, find files by glob, or search file contents by regex. No
+  permission prompt; `grep` skips secret-shaped and oversized files and
+  all three skip `.git`.
 - `shell_exec` — run argv-style commands inside the workspace.
   Permission required. `argv[0]` must be a configured binary basename.
 - `git_diff_branch` / `git_log_branch` — read-only branch context via

--- a/tools/coding/coding.go
+++ b/tools/coding/coding.go
@@ -75,8 +75,8 @@ type Options struct {
 }
 
 // Tools builds the standard local coding tool bundle:
-// read_file, write_file, edit_file, shell_exec, git_diff_branch, and
-// git_log_branch.
+// read_file, write_file, edit_file, list_dir, find_files, grep,
+// shell_exec, git_diff_branch, and git_log_branch.
 //
 // The returned Options contain the resolved absolute WorkDir, normalized
 // AllowedBinaries, copied Env, and effective Blocklist.
@@ -107,6 +107,19 @@ func Tools(opts Options) ([]glue.Tool, Options, error) {
 	if err != nil {
 		return nil, opts, err
 	}
+	navOpts := toolsfs.NavOptions{WorkDir: resolved.WorkDir, Blocklist: resolved.Blocklist}
+	listDir, err := toolsfs.ListDirTool(navOpts)
+	if err != nil {
+		return nil, opts, err
+	}
+	find, err := toolsfs.FindTool(navOpts)
+	if err != nil {
+		return nil, opts, err
+	}
+	grep, err := toolsfs.GrepTool(navOpts)
+	if err != nil {
+		return nil, opts, err
+	}
 	shell, err := toolsshell.Exec(toolsshell.ExecOptions{
 		Executor:        resolved.Executor,
 		WorkDir:         resolved.WorkDir,
@@ -127,6 +140,9 @@ func Tools(opts Options) ([]glue.Tool, Options, error) {
 		}),
 		write,
 		edit,
+		listDir,
+		find,
+		grep,
 		shell,
 		toolsgit.DiffBranchTool(toolsgit.DiffBranchOptions{
 			WorkDir:     resolved.WorkDir,

--- a/tools/coding/coding_test.go
+++ b/tools/coding/coding_test.go
@@ -66,7 +66,7 @@ func TestToolsResolveDefaultsAndRegisterBundle(t *testing.T) {
 		names = append(names, tool.Name)
 	}
 	sort.Strings(names)
-	want := []string{"edit_file", "git_diff_branch", "git_log_branch", "read_file", "shell_exec", "write_file"}
+	want := []string{"edit_file", "find_files", "git_diff_branch", "git_log_branch", "grep", "list_dir", "read_file", "shell_exec", "write_file"}
 	if !reflect.DeepEqual(names, want) {
 		t.Fatalf("tool names = %#v, want %#v", names, want)
 	}

--- a/tools/fs/nav.go
+++ b/tools/fs/nav.go
@@ -1,0 +1,383 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/erain/glue"
+)
+
+// DefaultNavMaxResults caps the number of entries or matches a single
+// navigation tool call returns when the call does not request otherwise.
+const DefaultNavMaxResults = 200
+
+// DefaultGrepMaxFileBytes is the per-file size ceiling for grep. Files
+// larger than this are skipped so a single binary blob cannot stall a
+// search.
+const DefaultGrepMaxFileBytes = 512 * 1024
+
+// NavOptions configures the read-only navigation tools (list_dir,
+// find_files, grep).
+type NavOptions struct {
+	// WorkDir is the root the tools operate under. Required.
+	WorkDir string
+
+	// MaxResults caps returned entries/matches. Zero falls back to
+	// DefaultNavMaxResults.
+	MaxResults int
+
+	// Blocklist refuses reading contents of matching paths in grep, and
+	// hides them from find_files/list_dir output.
+	Blocklist Blocklist
+
+	// GrepMaxFileBytes is the per-file size ceiling for grep. Zero falls
+	// back to DefaultGrepMaxFileBytes.
+	GrepMaxFileBytes int
+}
+
+func (o NavOptions) maxResults() int {
+	if o.MaxResults > 0 {
+		return o.MaxResults
+	}
+	return DefaultNavMaxResults
+}
+
+func (o NavOptions) grepMaxFileBytes() int {
+	if o.GrepMaxFileBytes > 0 {
+		return o.GrepMaxFileBytes
+	}
+	return DefaultGrepMaxFileBytes
+}
+
+func navWorkDir(workDir string) (string, error) {
+	workDir = strings.TrimSpace(workDir)
+	if workDir == "" {
+		return "", errors.New("fs: WorkDir is required")
+	}
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		return "", fmt.Errorf("fs: resolve WorkDir: %w", err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("fs: stat WorkDir: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("fs: WorkDir %q is not a directory", abs)
+	}
+	return abs, nil
+}
+
+// relArg returns the cleaned root for a navigation call, defaulting an
+// empty path to the workspace root.
+func navRoot(workDir, path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		path = "."
+	}
+	return SafeJoin(workDir, path)
+}
+
+type listDirArgs struct {
+	Path string `json:"path"`
+	All  bool   `json:"all"`
+}
+
+// ListDirTool returns a read-only "list_dir" tool that lists the
+// immediate entries of a directory inside opts.WorkDir.
+func ListDirTool(opts NavOptions) (glue.Tool, error) {
+	workDir, err := navWorkDir(opts.WorkDir)
+	if err != nil {
+		return glue.Tool{}, err
+	}
+	blocklist := opts.Blocklist
+	limit := opts.maxResults()
+
+	return glue.NewTool[listDirArgs](
+		glue.ToolSpec{
+			Name:        "list_dir",
+			Description: "List the immediate entries of a directory inside the workspace (non-recursive). Read-only.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "path": { "type": "string", "description": "Directory path relative to the workspace. Defaults to the workspace root." },
+    "all": { "type": "boolean", "description": "Include dotfiles. Default false.", "default": false }
+  }
+}`),
+		},
+		func(_ context.Context, args listDirArgs) (glue.ToolResult, error) {
+			root, err := navRoot(workDir, args.Path)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			lines := make([]string, 0, len(entries))
+			truncated := false
+			for _, entry := range entries {
+				name := entry.Name()
+				if !args.All && strings.HasPrefix(name, ".") {
+					continue
+				}
+				rel := relForDisplay(workDir, filepath.Join(root, name))
+				if blocked, _ := blocklist.Match(rel); blocked {
+					continue
+				}
+				if len(lines) >= limit {
+					truncated = true
+					break
+				}
+				switch {
+				case entry.IsDir():
+					lines = append(lines, name+"/")
+				case entry.Type()&os.ModeSymlink != 0:
+					lines = append(lines, name+"@")
+				default:
+					size := int64(-1)
+					if info, err := entry.Info(); err == nil {
+						size = info.Size()
+					}
+					lines = append(lines, fmt.Sprintf("%s\t%d", name, size))
+				}
+			}
+			sort.Strings(lines)
+			text := strings.Join(lines, "\n")
+			if truncated {
+				text += fmt.Sprintf("\n[... truncated at %d entries]", limit)
+			}
+			if text == "" {
+				text = "(empty)"
+			}
+			return glue.TextResult(text), nil
+		},
+	), nil
+}
+
+type findFilesArgs struct {
+	Pattern    string `json:"pattern"`
+	Path       string `json:"path"`
+	MaxResults int    `json:"max_results"`
+}
+
+// FindTool returns a read-only "find_files" tool that recursively finds
+// files whose basename matches a glob pattern under opts.WorkDir.
+func FindTool(opts NavOptions) (glue.Tool, error) {
+	workDir, err := navWorkDir(opts.WorkDir)
+	if err != nil {
+		return glue.Tool{}, err
+	}
+	blocklist := opts.Blocklist
+	defaultLimit := opts.maxResults()
+
+	return glue.NewTool[findFilesArgs](
+		glue.ToolSpec{
+			Name:        "find_files",
+			Description: "Recursively find files whose name matches a glob pattern (e.g. *.go) under a workspace directory. Returns workspace-relative paths. Read-only; skips .git.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "pattern": { "type": "string", "description": "Glob matched against each file's basename, e.g. *.go or *_test.go." },
+    "path": { "type": "string", "description": "Directory to search under, relative to the workspace. Defaults to the workspace root." },
+    "max_results": { "type": "integer", "description": "Cap on returned paths." }
+  },
+  "required": ["pattern"]
+}`),
+		},
+		func(_ context.Context, args findFilesArgs) (glue.ToolResult, error) {
+			pattern := strings.TrimSpace(args.Pattern)
+			if pattern == "" {
+				return glue.ErrorResult(errors.New("fs: pattern is required")), nil
+			}
+			if _, err := filepath.Match(pattern, "probe"); err != nil {
+				return glue.ErrorResult(fmt.Errorf("fs: invalid glob pattern: %w", err)), nil
+			}
+			root, err := navRoot(workDir, args.Path)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			limit := defaultLimit
+			if args.MaxResults > 0 && args.MaxResults < limit {
+				limit = args.MaxResults
+			}
+
+			matches := []string{}
+			truncated := false
+			walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return nil
+				}
+				if d.IsDir() {
+					if d.Name() == ".git" {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				if d.Type()&os.ModeSymlink != 0 {
+					return nil
+				}
+				ok, _ := filepath.Match(pattern, d.Name())
+				if !ok {
+					return nil
+				}
+				rel := relForDisplay(workDir, p)
+				if blocked, _ := blocklist.Match(rel); blocked {
+					return nil
+				}
+				if len(matches) >= limit {
+					truncated = true
+					return filepath.SkipAll
+				}
+				matches = append(matches, rel)
+				return nil
+			})
+			if walkErr != nil {
+				return glue.ErrorResult(walkErr), nil
+			}
+			sort.Strings(matches)
+			text := strings.Join(matches, "\n")
+			if truncated {
+				text += fmt.Sprintf("\n[... truncated at %d matches]", limit)
+			}
+			if text == "" {
+				text = "(no matches)"
+			}
+			return glue.TextResult(text), nil
+		},
+	), nil
+}
+
+type grepArgs struct {
+	Pattern    string `json:"pattern"`
+	Path       string `json:"path"`
+	Glob       string `json:"glob"`
+	MaxResults int    `json:"max_results"`
+}
+
+// GrepTool returns a read-only "grep" tool that recursively searches file
+// contents for a regular expression under opts.WorkDir.
+func GrepTool(opts NavOptions) (glue.Tool, error) {
+	workDir, err := navWorkDir(opts.WorkDir)
+	if err != nil {
+		return glue.Tool{}, err
+	}
+	blocklist := opts.Blocklist
+	defaultLimit := opts.maxResults()
+	maxFileBytes := opts.grepMaxFileBytes()
+
+	return glue.NewTool[grepArgs](
+		glue.ToolSpec{
+			Name:        "grep",
+			Description: "Recursively search file contents for a regular expression (RE2) under a workspace directory. Returns path:line:text matches. Read-only; skips .git, secret-shaped files, and files over the size ceiling.",
+			Parameters: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "pattern": { "type": "string", "description": "RE2 regular expression matched against each line." },
+    "path": { "type": "string", "description": "Directory to search under, relative to the workspace. Defaults to the workspace root." },
+    "glob": { "type": "string", "description": "Optional glob to restrict matched files by basename, e.g. *.go." },
+    "max_results": { "type": "integer", "description": "Cap on returned match lines." }
+  },
+  "required": ["pattern"]
+}`),
+		},
+		func(_ context.Context, args grepArgs) (glue.ToolResult, error) {
+			pattern := strings.TrimSpace(args.Pattern)
+			if pattern == "" {
+				return glue.ErrorResult(errors.New("fs: pattern is required")), nil
+			}
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return glue.ErrorResult(fmt.Errorf("fs: invalid regular expression: %w", err)), nil
+			}
+			glob := strings.TrimSpace(args.Glob)
+			if glob != "" {
+				if _, err := filepath.Match(glob, "probe"); err != nil {
+					return glue.ErrorResult(fmt.Errorf("fs: invalid glob: %w", err)), nil
+				}
+			}
+			root, err := navRoot(workDir, args.Path)
+			if err != nil {
+				return glue.ErrorResult(err), nil
+			}
+			limit := defaultLimit
+			if args.MaxResults > 0 && args.MaxResults < limit {
+				limit = args.MaxResults
+			}
+
+			matches := []string{}
+			truncated := false
+			walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return nil
+				}
+				if d.IsDir() {
+					if d.Name() == ".git" {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				if d.Type()&os.ModeSymlink != 0 {
+					return nil
+				}
+				if glob != "" {
+					if ok, _ := filepath.Match(glob, d.Name()); !ok {
+						return nil
+					}
+				}
+				rel := relForDisplay(workDir, p)
+				if blocked, _ := blocklist.Match(rel); blocked {
+					return nil
+				}
+				info, err := d.Info()
+				if err != nil || info.Size() > int64(maxFileBytes) {
+					return nil
+				}
+				data, err := os.ReadFile(p)
+				if err != nil {
+					return nil
+				}
+				for i, line := range strings.Split(string(data), "\n") {
+					if !re.MatchString(line) {
+						continue
+					}
+					if len(matches) >= limit {
+						truncated = true
+						return filepath.SkipAll
+					}
+					matches = append(matches, fmt.Sprintf("%s:%d:%s", rel, i+1, Truncate(line, 500)))
+				}
+				return nil
+			})
+			if walkErr != nil {
+				return glue.ErrorResult(walkErr), nil
+			}
+			text := strings.Join(matches, "\n")
+			if truncated {
+				text += fmt.Sprintf("\n[... truncated at %d matches]", limit)
+			}
+			if text == "" {
+				text = "(no matches)"
+			}
+			return glue.TextResult(text), nil
+		},
+	), nil
+}
+
+// relForDisplay returns a slash-separated path relative to workDir for
+// tool output. Falls back to the absolute path if it cannot be made
+// relative.
+func relForDisplay(workDir, abs string) string {
+	rel, err := filepath.Rel(workDir, abs)
+	if err != nil {
+		return filepath.ToSlash(abs)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/tools/fs/nav_test.go
+++ b/tools/fs/nav_test.go
@@ -1,0 +1,207 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func callTool(t *testing.T, tool glue.Tool, err error, args string) glue.ToolResult {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("build tool: %v", err)
+	}
+	res, err := tool.Execute(context.Background(), glue.ToolCall{Name: tool.Name, Arguments: json.RawMessage(args)})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	return res
+}
+
+func navTree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, dir, "main.go", "package main\nfunc main() { hello() }\n")
+	mustWrite(t, dir, "util.go", "package main\nfunc hello() {}\n")
+	mustWrite(t, dir, "README.md", "# title\nhello world\n")
+	mustWrite(t, dir, ".env", "SECRET=top\n")
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, dir, filepath.Join("sub", "deep.go"), "package sub\n// hello again\n")
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, dir, filepath.Join(".git", "config"), "hello in git\n")
+	return dir
+}
+
+func mustWrite(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListDirHidesDotfilesAndBlocked(t *testing.T) {
+	dir := navTree(t)
+	tool, err := ListDirTool(NavOptions{WorkDir: dir, Blocklist: Default()})
+	res := callTool(t, tool, err, `{"path":"."}`)
+	if res.IsError {
+		t.Fatalf("IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if strings.Contains(text, ".env") || strings.Contains(text, ".git") {
+		t.Fatalf("dotfiles leaked: %q", text)
+	}
+	if !strings.Contains(text, "main.go") || !strings.Contains(text, "sub/") {
+		t.Fatalf("missing expected entries: %q", text)
+	}
+
+	// With all=true, .env is still hidden by the blocklist.
+	res = callTool(t, tool, err, `{"path":".","all":true}`)
+	if strings.Contains(res.Content[0].Text, ".env") {
+		t.Fatalf("blocked .env leaked with all=true: %q", res.Content[0].Text)
+	}
+}
+
+func TestFindFilesGlob(t *testing.T) {
+	dir := navTree(t)
+	tool, err := FindTool(NavOptions{WorkDir: dir, Blocklist: Default()})
+	res := callTool(t, tool, err, `{"pattern":"*.go"}`)
+	if res.IsError {
+		t.Fatalf("IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	for _, want := range []string{"main.go", "util.go", "sub/deep.go"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in %q", want, text)
+		}
+	}
+	if strings.Contains(text, "README.md") {
+		t.Fatalf("non-matching file returned: %q", text)
+	}
+}
+
+func TestFindFilesSkipsGit(t *testing.T) {
+	dir := navTree(t)
+	tool, err := FindTool(NavOptions{WorkDir: dir})
+	res := callTool(t, tool, err, `{"pattern":"config"}`)
+	if strings.Contains(res.Content[0].Text, ".git") {
+		t.Fatalf(".git not skipped: %q", res.Content[0].Text)
+	}
+}
+
+func TestGrepFindsMatches(t *testing.T) {
+	dir := navTree(t)
+	tool, err := GrepTool(NavOptions{WorkDir: dir, Blocklist: Default()})
+	res := callTool(t, tool, err, `{"pattern":"hello"}`)
+	if res.IsError {
+		t.Fatalf("IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "main.go:") || !strings.Contains(text, "util.go:") {
+		t.Fatalf("missing matches: %q", text)
+	}
+	// .git contents and the secret file must not appear.
+	if strings.Contains(text, ".git") || strings.Contains(text, ".env") || strings.Contains(text, "SECRET") {
+		t.Fatalf("grep leaked skipped path: %q", text)
+	}
+}
+
+func TestGrepGlobFilter(t *testing.T) {
+	dir := navTree(t)
+	tool, err := GrepTool(NavOptions{WorkDir: dir})
+	res := callTool(t, tool, err, `{"pattern":"hello","glob":"*.md"}`)
+	text := res.Content[0].Text
+	if !strings.Contains(text, "README.md:") {
+		t.Fatalf("expected README match: %q", text)
+	}
+	if strings.Contains(text, "main.go") {
+		t.Fatalf("glob filter ignored: %q", text)
+	}
+}
+
+func TestGrepInvalidRegex(t *testing.T) {
+	dir := navTree(t)
+	tool, err := GrepTool(NavOptions{WorkDir: dir})
+	res := callTool(t, tool, err, `{"pattern":"("}`)
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "regular expression") {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestGrepSkipsOversizeFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "big.txt", strings.Repeat("hello\n", 100))
+	tool, err := GrepTool(NavOptions{WorkDir: dir, GrepMaxFileBytes: 10})
+	res := callTool(t, tool, err, `{"pattern":"hello"}`)
+	if res.Content[0].Text != "(no matches)" {
+		t.Fatalf("oversize file not skipped: %q", res.Content[0].Text)
+	}
+}
+
+func TestGrepResultCap(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "many.txt", strings.Repeat("hit\n", 50))
+	tool, err := GrepTool(NavOptions{WorkDir: dir, MaxResults: 5})
+	res := callTool(t, tool, err, `{"pattern":"hit"}`)
+	if !strings.Contains(res.Content[0].Text, "truncated at 5") {
+		t.Fatalf("expected truncation marker: %q", res.Content[0].Text)
+	}
+}
+
+func TestNavRejectsEscape(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		name string
+		tool func() (glue.Tool, error)
+		args string
+	}{
+		{"list_dir", func() (glue.Tool, error) { return ListDirTool(NavOptions{WorkDir: dir}) }, `{"path":"../"}`},
+		{"find_files", func() (glue.Tool, error) { return FindTool(NavOptions{WorkDir: dir}) }, `{"pattern":"*","path":"../"}`},
+		{"grep", func() (glue.Tool, error) { return GrepTool(NavOptions{WorkDir: dir}) }, `{"pattern":"x","path":"../"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, err := tc.tool()
+			res := callTool(t, tool, err, tc.args)
+			if !res.IsError || !strings.Contains(res.Content[0].Text, "escape") {
+				t.Fatalf("result = %+v, want escape error", res)
+			}
+		})
+	}
+}
+
+func TestNavRequiresPattern(t *testing.T) {
+	dir := t.TempDir()
+	find, err := FindTool(NavOptions{WorkDir: dir})
+	if res := callTool(t, find, err, `{"pattern":""}`); !res.IsError || !strings.Contains(res.Content[0].Text, "pattern is required") {
+		t.Fatalf("find result = %+v", res)
+	}
+	grep, err := GrepTool(NavOptions{WorkDir: dir})
+	if res := callTool(t, grep, err, `{"pattern":""}`); !res.IsError || !strings.Contains(res.Content[0].Text, "pattern is required") {
+		t.Fatalf("grep result = %+v", res)
+	}
+}
+
+func TestNavToolsAreReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	for _, build := range []func() (glue.Tool, error){
+		func() (glue.Tool, error) { return ListDirTool(NavOptions{WorkDir: dir}) },
+		func() (glue.Tool, error) { return FindTool(NavOptions{WorkDir: dir}) },
+		func() (glue.Tool, error) { return GrepTool(NavOptions{WorkDir: dir}) },
+	} {
+		tool, err := build()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tool.RequiresPermission {
+			t.Fatalf("%s requires permission, want read-only", tool.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds three read-only, workspace-scoped navigation tools so `glue run --coding` agents can explore a repo without going through the permission-gated `shell_exec`. This closes the remaining Pi-class navigation gap from ADR-0012.

- `list_dir` — immediate entries of a directory (dirs marked `/`, symlinks `@`, files with size).
- `find_files` — recursive basename-glob search, returns workspace-relative paths.
- `grep` — recursive RE2 content search, returns `path:line:text`, with an optional basename `glob` filter.

All resolve via `SafeJoin` (escape-safe), skip `.git`, and cap output (default 200). `grep` additionally skips `Blocklist` (secret-shaped) and oversized files (512 KiB ceiling), and truncates long lines. None require permission. Registered in the `tools/coding` bundle, which is now: read_file, write_file, edit_file, list_dir, find_files, grep, shell_exec, git_diff_branch, git_log_branch.

Closes #277

## Verification

```
go build ./...        # ok
go vet ./...          # ok
go test ./tools/fs/ ./tools/coding/ ./agents/peggy/ ./cmd/glue/   # ok
```

New `tools/fs` tests: dotfile/blocklist hiding in `list_dir`, glob matching and `.git` skip in `find_files`, grep matches with secret/.git exclusion, grep glob filter, invalid-regex error, oversize-file skip, result cap/truncation, path-escape rejection for all three, required-pattern errors, and a read-only (no-permission) assertion. The `tools/coding` bundle test asserts all three are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
