### PR TITLE
agents/peggy: add scheduled/proactive runs (closes #273)

### DIFF
--- a/agents/peggy/CHANGELOG.md
+++ b/agents/peggy/CHANGELOG.md
@@ -8,6 +8,17 @@ not formally follow SemVer until v1.0.
 
 ### Added
 
+- **Scheduled / proactive runs.** `peggy serve` now runs a scheduler so
+  Peggy initiates on her own — recurring (`--every`) or one-shot
+  (`--at`) prompt or skill runs, managed with `peggy schedule
+  add|remove` and `peggy schedules`. Schedules persist to
+  `~/.peggy/schedules.json` (override `schedules.path`, `"off"` to
+  disable), survive restarts, and fire-forward past missed ticks. Each
+  schedule carries a permission tier for its unattended run — `trusted`
+  (default) or `read_only`; `prompt` is rejected because there is no
+  client to answer. Output is written to the schedule's session
+  (visible via `peggy sessions`/recall). Daemon/Telegram/dashboard
+  schedule surfacing is a planned follow-up.
 - **Reusable coding execution seam.** Peggy now consumes Glue's
   `tools/coding` SDK bundle and exposes a runtime `CodingExecutor`
   injection point, so future VM or container-backed execution can plug

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -242,6 +242,7 @@ and emits a stderr diagnostic.
 | `permissions.default_tier` | `prompt` | Permission tier for side-effecting tools when a channel has no override. One of `prompt`, `read_only`, or `trusted`. |
 | `permissions.remember_path` | `~/.peggy/permissions.json` | JSON file where daemon-mode remembered permission grants are persisted. Set to `off` to keep remembers process-local. |
 | `permissions.channels.<name>` | inherited | Channel override keyed by `cli`, `telegram`, or a future daemon client prefix. |
+| `schedules.path` | `~/.peggy/schedules.json` | JSON file storing proactive/scheduled runs. `~` and `$HOME` expand. Set to `off` to disable scheduling. |
 
 Missing `settings.json` is non-fatal — Peggy uses the built-in
 defaults above and emits a stderr diagnostic.
@@ -256,6 +257,8 @@ peggy skills [flags]
 peggy roles [flags]
 peggy memories [flags]
 peggy sessions [flags]
+peggy schedules [flags]
+peggy schedule add|remove [flags]
 peggy recall [flags] <query>
 peggy doctor [flags]
 peggy mcp prompt [flags]
@@ -716,6 +719,47 @@ container or VM sandbox.
 An explicit `--config` / `--soul` or `$PEGGY_CONFIG` / `$PEGGY_SOUL`
 that points at a missing file is an error. The XDG / HOME fallbacks
 quietly fall through to defaults when missing.
+
+## Scheduled Runs
+
+Peggy can run proactively on a schedule, so she initiates (reminders,
+recurring check-ins, daily summaries) instead of only responding. The
+scheduler runs inside `peggy serve`: while the daemon is up, due
+schedules fire on their own and the result is written to the schedule's
+session (visible via `peggy sessions` and recall).
+
+Schedules persist to `~/.peggy/schedules.json` (override with
+`schedules.path`; set it to `"off"` to disable scheduling) and survive
+daemon restarts. Missed runs during downtime are skipped — Peggy
+fire-forwards to the next future tick rather than firing a backlog.
+
+```sh
+# Recurring: every 24h, summarize open threads (default tier: trusted).
+peggy schedule add --every 24h \
+  --prompt "Summarize my open threads and remind me of deadlines."
+
+# One-shot: run a workspace skill at a specific time, read-only.
+peggy schedule add --at 2026-05-27T09:00:00Z --skill daily_plan --tier read_only
+
+# Inspect and remove.
+peggy schedules
+peggy schedules --json
+peggy schedule remove sch_ab12cd34ef56
+```
+
+Each schedule declares a **permission tier** for its unattended run,
+because there is no client present to answer a prompt:
+
+- `trusted` (default) — side-effecting tools (`write_file`, `edit_file`,
+  `shell_exec`, MCP tools) run without confirmation. Powerful; mind the
+  blast radius of an unattended `shell_exec`.
+- `read_only` — side effects are denied; the run can read, `recall`,
+  `grep`, and summarize only.
+
+`prompt` is not a valid schedule tier — an unattended run has no one to
+ask. A schedule runs either a `--prompt` or a workspace `--skill` (with
+repeatable `--arg key=value`), on either a recurring `--every <duration>`
+(minimum 1m) or a one-shot `--at <RFC3339 time>`.
 
 ## Memory
 

--- a/agents/peggy/runner.go
+++ b/agents/peggy/runner.go
@@ -153,6 +153,10 @@ func runWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout, st
 			return runMemories(ctx, args[1:], stdout, stderr)
 		case "sessions":
 			return runSessions(ctx, args[1:], stdout, stderr)
+		case "schedules":
+			return runSchedules(args[1:], stdout, stderr)
+		case "schedule":
+			return runSchedule(args[1:], stdout, stderr)
 		case "recall":
 			return runRecall(ctx, args[1:], stdout, stderr)
 		case "status":
@@ -189,6 +193,8 @@ Usage:
   peggy roles [flags]
   peggy memories [flags]
   peggy sessions [flags]
+  peggy schedules [flags]
+  peggy schedule add|remove [flags]
   peggy recall [flags] <query>
   peggy status [flags]
   peggy doctor [flags]
@@ -208,6 +214,8 @@ Examples:
   peggy memories export --config ~/.config/peggy/settings.json --output peggy-memories.json
   peggy memories import --config ~/.config/peggy/settings.json --dry-run peggy-memories.json
   peggy sessions --config ~/.config/peggy/settings.json --prefix telegram:
+  peggy schedule add --every 24h --prompt "Summarize my open threads."
+  peggy schedules --config ~/.config/peggy/settings.json
   peggy recall --config ~/.config/peggy/settings.json "Australian Shepherd"
   peggy skill --config ~/.config/peggy/settings.json --arg issue=GLUE-123 triage
   peggy status --config ~/.config/peggy/settings.json
@@ -1199,6 +1207,230 @@ func writeSessions(w io.Writer, sessions []glue.SessionSummary) {
 		fmt.Fprintf(w, "  user_messages: %d\n", session.UserMessages)
 		fmt.Fprintf(w, "  assistant_messages: %d\n", session.AssistantMessages)
 	}
+}
+
+func openScheduleStoreForRunner(configPath string) (*ScheduleStore, bool, error) {
+	settings, settingsPath, err := LoadSettings(configPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if settings.SchedulesDisabled() {
+		return nil, settingsPath == "", fmt.Errorf("scheduling is disabled (schedules.path = off)")
+	}
+	store, err := OpenScheduleStore(settings.Schedules.Path)
+	if err != nil {
+		return nil, settingsPath == "", err
+	}
+	return store, settingsPath == "", nil
+}
+
+func runSchedules(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy schedules", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath = fs.String("config", "", "path to settings.json (overrides $PEGGY_CONFIG / XDG / ~/.config/peggy)")
+		jsonOutput = fs.Bool("json", false, "print machine-readable JSON")
+	)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy schedules — list persisted proactive/scheduled runs.
+
+Usage:
+  peggy schedules [flags]
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy schedules: positional args not supported")
+		return 2
+	}
+	store, missingSettings, err := openScheduleStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy schedules: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy schedules: no settings.json found; using built-in defaults")
+	}
+	schedules := store.List()
+	if *jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(schedules); err != nil {
+			fmt.Fprintf(stderr, "peggy schedules: encode: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(schedules) == 0 {
+		fmt.Fprintln(stdout, "No schedules.")
+		return 0
+	}
+	for _, s := range schedules {
+		fmt.Fprintf(stdout, "%s\n  next: %s", s.describe(), s.NextRun.Format(time.RFC3339))
+		if s.LastRun != nil {
+			fmt.Fprintf(stdout, "  last: %s", s.LastRun.Format(time.RFC3339))
+		}
+		if s.LastError != "" {
+			fmt.Fprintf(stdout, "  last_error: %s", singleLine(s.LastError))
+		}
+		fmt.Fprintln(stdout)
+	}
+	return 0
+}
+
+func runSchedule(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "peggy schedule: expected 'add' or 'remove'")
+		return 2
+	}
+	switch args[0] {
+	case "add":
+		return runScheduleAdd(args[1:], stdout, stderr)
+	case "remove", "rm":
+		return runScheduleRemove(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "peggy schedule: unknown subcommand %q (want add or remove)\n", args[0])
+		return 2
+	}
+}
+
+func runScheduleAdd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy schedule add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		configPath   = fs.String("config", "", "path to settings.json")
+		prompt       = fs.String("prompt", "", "prompt text to run")
+		skill        = fs.String("skill", "", "workspace skill name to run instead of --prompt")
+		every        = fs.Duration("every", 0, "recurring interval, e.g. 1h or 30m (min 1m)")
+		atStr        = fs.String("at", "", "one-shot RFC3339 time, e.g. 2026-05-27T09:00:00Z")
+		tier         = fs.String("tier", "trusted", "permission tier for the unattended run: trusted or read_only")
+		session      = fs.String("session", "", "session id for the run (default schedule:<id>)")
+		scheduleArgs stringListFlag
+	)
+	fs.Var(&scheduleArgs, "arg", "skill argument as key=value (repeatable; --skill only)")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, `peggy schedule add — add a persisted proactive run.
+
+Usage:
+  peggy schedule add (--prompt <text> | --skill <name>) (--every <dur> | --at <time>) [flags]
+
+Examples:
+  peggy schedule add --every 24h --prompt "Summarize my open threads and remind me of deadlines."
+  peggy schedule add --at 2026-05-27T09:00:00Z --skill daily_plan --tier read_only
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "peggy schedule add: positional args not supported")
+		return 2
+	}
+
+	params := NewScheduleParams{
+		Tier:      PermissionTier(*tier),
+		SessionID: *session,
+		Every:     *every,
+	}
+	switch {
+	case strings.TrimSpace(*skill) != "":
+		params.Kind = ScheduleKindSkill
+		params.Skill = *skill
+		parsed, err := parsePromptArgs(scheduleArgs)
+		if err != nil {
+			fmt.Fprintf(stderr, "peggy schedule add: %v\n", err)
+			return 2
+		}
+		params.Args = parsed
+	case strings.TrimSpace(*prompt) != "":
+		params.Kind = ScheduleKindPrompt
+		params.Prompt = *prompt
+	default:
+		fmt.Fprintln(stderr, "peggy schedule add: one of --prompt or --skill is required")
+		return 2
+	}
+	if strings.TrimSpace(*atStr) != "" {
+		at, err := time.Parse(time.RFC3339, *atStr)
+		if err != nil {
+			fmt.Fprintf(stderr, "peggy schedule add: invalid --at time: %v\n", err)
+			return 2
+		}
+		params.At = &at
+	}
+
+	sched, err := NewSchedule(params, time.Now())
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy schedule add: %v\n", err)
+		return 2
+	}
+	store, missingSettings, err := openScheduleStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy schedule add: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy schedule add: no settings.json found; using built-in defaults")
+	}
+	if err := store.Add(sched); err != nil {
+		fmt.Fprintf(stderr, "peggy schedule add: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "added %s (next run %s)\n", sched.ID, sched.NextRun.Format(time.RFC3339))
+	return 0
+}
+
+func runScheduleRemove(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("peggy schedule remove", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", "", "path to settings.json")
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, "peggy schedule remove <id> [--config <path>]\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "peggy schedule remove: exactly one schedule id is required")
+		return 2
+	}
+	id := fs.Arg(0)
+	store, missingSettings, err := openScheduleStoreForRunner(*configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy schedule remove: %v\n", err)
+		return 1
+	}
+	if missingSettings {
+		fmt.Fprintln(stderr, "peggy schedule remove: no settings.json found; using built-in defaults")
+	}
+	removed, err := store.Remove(id)
+	if err != nil {
+		fmt.Fprintf(stderr, "peggy schedule remove: %v\n", err)
+		return 1
+	}
+	if !removed {
+		fmt.Fprintf(stderr, "peggy schedule remove: no schedule with id %q\n", id)
+		return 1
+	}
+	fmt.Fprintf(stdout, "removed %s\n", id)
+	return 0
 }
 
 func runRecall(ctx context.Context, args []string, stdout, stderr io.Writer) int {
@@ -2681,6 +2913,19 @@ Flags:
 	if err != nil {
 		fmt.Fprintf(stderr, "peggy serve: setup: %v\n", err)
 		return 1
+	}
+
+	if !settings.SchedulesDisabled() {
+		store, err := OpenScheduleStore(settings.Schedules.Path)
+		if err != nil {
+			fmt.Fprintf(stderr, "peggy serve: schedules: %v\n", err)
+			return 1
+		}
+		scheduler := NewScheduler(store, p.ScheduleRunner(), WithSchedulerLogger(func(format string, args ...any) {
+			fmt.Fprintf(stderr, format+"\n", args...)
+		}))
+		fmt.Fprintf(stderr, "peggy serve: scheduler active (%d schedule(s)) at %s\n", len(store.List()), settings.Schedules.Path)
+		go func() { _ = scheduler.Run(ctx) }()
 	}
 
 	if err := serve(ctx, serveConfig{

--- a/agents/peggy/schedule.go
+++ b/agents/peggy/schedule.go
@@ -1,0 +1,188 @@
+package peggy
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MinScheduleInterval is the smallest recurring interval a schedule may
+// use. It guards against runaway proactive runs.
+const MinScheduleInterval = time.Minute
+
+// ScheduleKind selects what a schedule runs.
+type ScheduleKind string
+
+const (
+	ScheduleKindPrompt ScheduleKind = "prompt"
+	ScheduleKindSkill  ScheduleKind = "skill"
+)
+
+// Schedule is one persisted proactive task. Exactly one of EverySeconds
+// (recurring) or At (one-shot) is set. Tier is the permission posture the
+// unattended run uses: "trusted" (default) or "read_only"; "prompt" is
+// rejected because a scheduled run has no client to answer.
+type Schedule struct {
+	ID           string            `json:"id"`
+	Kind         ScheduleKind      `json:"kind"`
+	Prompt       string            `json:"prompt,omitempty"`
+	Skill        string            `json:"skill,omitempty"`
+	Args         map[string]string `json:"args,omitempty"`
+	Tier         PermissionTier    `json:"tier"`
+	SessionID    string            `json:"session_id"`
+	EverySeconds int64             `json:"every_seconds,omitempty"`
+	At           *time.Time        `json:"at,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	NextRun      time.Time         `json:"next_run"`
+	LastRun      *time.Time        `json:"last_run,omitempty"`
+	LastError    string            `json:"last_error,omitempty"`
+}
+
+// Recurring reports whether the schedule repeats on an interval.
+func (s Schedule) Recurring() bool { return s.EverySeconds > 0 }
+
+// interval returns the recurring period.
+func (s Schedule) interval() time.Duration {
+	return time.Duration(s.EverySeconds) * time.Second
+}
+
+// Done reports whether a one-shot schedule has already fired.
+func (s Schedule) Done() bool {
+	return !s.Recurring() && s.LastRun != nil
+}
+
+// Due reports whether the schedule should run at now.
+func (s Schedule) Due(now time.Time) bool {
+	if s.Done() {
+		return false
+	}
+	return !s.NextRun.IsZero() && !s.NextRun.After(now)
+}
+
+// advance returns a copy updated after a run at now, recording the error
+// (empty on success) and computing the next fire time. Recurring
+// schedules fire-forward past any missed ticks; one-shot schedules
+// become Done.
+func (s Schedule) advance(now time.Time, runErr string) Schedule {
+	out := s
+	t := now
+	out.LastRun = &t
+	out.LastError = runErr
+	if !s.Recurring() {
+		return out
+	}
+	next := s.NextRun.Add(s.interval())
+	for !next.After(now) {
+		next = next.Add(s.interval())
+	}
+	out.NextRun = next
+	return out
+}
+
+// describe returns a one-line human summary for CLI output.
+func (s Schedule) describe() string {
+	var when string
+	if s.Recurring() {
+		when = "every " + s.interval().String()
+	} else if s.At != nil {
+		when = "at " + s.At.Format(time.RFC3339)
+	}
+	what := s.Prompt
+	if s.Kind == ScheduleKindSkill {
+		what = "skill:" + s.Skill
+	}
+	what = strings.TrimSpace(what)
+	if len(what) > 60 {
+		what = what[:57] + "..."
+	}
+	return fmt.Sprintf("%s  [%s, %s]  %s", s.ID, when, s.Tier, what)
+}
+
+// NewScheduleParams is the input for building a validated Schedule.
+type NewScheduleParams struct {
+	Kind      ScheduleKind
+	Prompt    string
+	Skill     string
+	Args      map[string]string
+	Tier      PermissionTier
+	SessionID string
+	Every     time.Duration
+	At        *time.Time
+}
+
+// NewSchedule validates params and returns a ready-to-store Schedule with
+// a generated id and computed first NextRun. now is the creation time.
+func NewSchedule(params NewScheduleParams, now time.Time) (Schedule, error) {
+	tier := PermissionTier(normalizePermissionTier(string(params.Tier)))
+	if tier == "" {
+		tier = PermissionTierTrusted
+	}
+	switch tier {
+	case PermissionTierTrusted, PermissionTierReadOnly:
+		// ok
+	case PermissionTierPrompt:
+		return Schedule{}, fmt.Errorf("peggy: schedule tier %q is invalid: an unattended run has no client to prompt", tier)
+	default:
+		return Schedule{}, fmt.Errorf("peggy: invalid schedule tier %q", tier)
+	}
+
+	recurring := params.Every > 0
+	oneShot := params.At != nil
+	if recurring == oneShot {
+		return Schedule{}, fmt.Errorf("peggy: schedule needs exactly one of every or at")
+	}
+	if recurring && params.Every < MinScheduleInterval {
+		return Schedule{}, fmt.Errorf("peggy: schedule interval %s is below the %s minimum", params.Every, MinScheduleInterval)
+	}
+
+	s := Schedule{
+		Kind:      params.Kind,
+		Tier:      tier,
+		Args:      params.Args,
+		SessionID: strings.TrimSpace(params.SessionID),
+		CreatedAt: now,
+	}
+	switch params.Kind {
+	case ScheduleKindPrompt:
+		s.Prompt = strings.TrimSpace(params.Prompt)
+		if s.Prompt == "" {
+			return Schedule{}, fmt.Errorf("peggy: prompt schedule needs a prompt")
+		}
+	case ScheduleKindSkill:
+		s.Skill = strings.TrimSpace(params.Skill)
+		if s.Skill == "" {
+			return Schedule{}, fmt.Errorf("peggy: skill schedule needs a skill name")
+		}
+	default:
+		return Schedule{}, fmt.Errorf("peggy: invalid schedule kind %q", params.Kind)
+	}
+
+	id, err := newScheduleID()
+	if err != nil {
+		return Schedule{}, err
+	}
+	s.ID = id
+	if s.SessionID == "" {
+		s.SessionID = "schedule:" + id
+	}
+
+	if recurring {
+		s.EverySeconds = int64(params.Every / time.Second)
+		s.NextRun = now.Add(params.Every)
+	} else {
+		at := params.At.UTC()
+		s.At = &at
+		s.NextRun = at
+	}
+	return s, nil
+}
+
+func newScheduleID() (string, error) {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("peggy: schedule id: %w", err)
+	}
+	return "sch_" + hex.EncodeToString(b[:]), nil
+}

--- a/agents/peggy/schedule_store.go
+++ b/agents/peggy/schedule_store.go
@@ -1,0 +1,144 @@
+package peggy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// scheduleFileVersion is the on-disk envelope version.
+const scheduleFileVersion = 1
+
+type scheduleFile struct {
+	Version   int        `json:"version"`
+	Schedules []Schedule `json:"schedules"`
+}
+
+// ScheduleStore persists schedules to a JSON file with atomic writes. It
+// is safe for concurrent use. A zero path disables persistence (in-memory
+// only), which keeps tests and disabled-scheduling callers simple.
+type ScheduleStore struct {
+	path string
+
+	mu        sync.Mutex
+	schedules map[string]Schedule
+}
+
+// OpenScheduleStore loads schedules from path, creating an empty store if
+// the file is absent. An empty path yields an in-memory store.
+func OpenScheduleStore(path string) (*ScheduleStore, error) {
+	s := &ScheduleStore{path: path, schedules: map[string]Schedule{}}
+	if path == "" {
+		return s, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("peggy: read schedules: %w", err)
+	}
+	var file scheduleFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("peggy: parse schedules %s: %w", path, err)
+	}
+	for _, sched := range file.Schedules {
+		if sched.ID == "" {
+			continue
+		}
+		s.schedules[sched.ID] = sched
+	}
+	return s, nil
+}
+
+// List returns all schedules sorted by next run time, then id.
+func (s *ScheduleStore) List() []Schedule {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listLocked()
+}
+
+func (s *ScheduleStore) listLocked() []Schedule {
+	out := make([]Schedule, 0, len(s.schedules))
+	for _, sched := range s.schedules {
+		out = append(out, sched)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].NextRun.Equal(out[j].NextRun) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].NextRun.Before(out[j].NextRun)
+	})
+	return out
+}
+
+// Add stores a new schedule and persists.
+func (s *ScheduleStore) Add(sched Schedule) error {
+	if sched.ID == "" {
+		return errors.New("peggy: schedule id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.schedules[sched.ID] = sched
+	return s.saveLocked()
+}
+
+// Remove deletes a schedule by id and persists. Returns false if absent.
+func (s *ScheduleStore) Remove(id string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.schedules[id]; !ok {
+		return false, nil
+	}
+	delete(s.schedules, id)
+	return true, s.saveLocked()
+}
+
+// Update replaces an existing schedule (e.g. after a run) and persists.
+// It is a no-op if the id no longer exists, so a run completing after the
+// schedule was removed does not resurrect it.
+func (s *ScheduleStore) Update(sched Schedule) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.schedules[sched.ID]; !ok {
+		return nil
+	}
+	s.schedules[sched.ID] = sched
+	return s.saveLocked()
+}
+
+func (s *ScheduleStore) saveLocked() error {
+	if s.path == "" {
+		return nil
+	}
+	file := scheduleFile{Version: scheduleFileVersion, Schedules: s.listLocked()}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("peggy: encode schedules: %w", err)
+	}
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("peggy: schedules dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".schedules-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, s.path)
+}

--- a/agents/peggy/scheduler.go
+++ b/agents/peggy/scheduler.go
@@ -1,0 +1,171 @@
+package peggy
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/erain/glue"
+)
+
+// DefaultSchedulerInterval is how often the scheduler checks for due
+// schedules when no interval is configured.
+const DefaultSchedulerInterval = 30 * time.Second
+
+// ScheduleRunner executes one due schedule and returns the assistant
+// response text. The scheduler records any error on the schedule but does
+// not stop the loop.
+type ScheduleRunner func(ctx context.Context, s Schedule) (string, error)
+
+// Scheduler fires due schedules from a store on an interval. It is the
+// proactive engine behind `peggy serve`: it lets Peggy initiate runs
+// (reminders, recurring tasks) instead of only responding.
+type Scheduler struct {
+	store    *ScheduleStore
+	run      ScheduleRunner
+	now      func() time.Time
+	interval time.Duration
+	logf     func(format string, args ...any)
+
+	mu      sync.Mutex
+	running map[string]bool
+	wg      sync.WaitGroup
+}
+
+// SchedulerOption configures a Scheduler.
+type SchedulerOption func(*Scheduler)
+
+// WithSchedulerClock overrides the time source (for tests).
+func WithSchedulerClock(now func() time.Time) SchedulerOption {
+	return func(s *Scheduler) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+// WithSchedulerInterval overrides the tick interval.
+func WithSchedulerInterval(d time.Duration) SchedulerOption {
+	return func(s *Scheduler) {
+		if d > 0 {
+			s.interval = d
+		}
+	}
+}
+
+// WithSchedulerLogger sets a log sink for fired-run summaries and errors.
+func WithSchedulerLogger(logf func(format string, args ...any)) SchedulerOption {
+	return func(s *Scheduler) {
+		if logf != nil {
+			s.logf = logf
+		}
+	}
+}
+
+// NewScheduler builds a scheduler over a store and run function.
+func NewScheduler(store *ScheduleStore, run ScheduleRunner, options ...SchedulerOption) *Scheduler {
+	s := &Scheduler{
+		store:    store,
+		run:      run,
+		now:      time.Now,
+		interval: DefaultSchedulerInterval,
+		logf:     func(string, ...any) {},
+		running:  map[string]bool{},
+	}
+	for _, opt := range options {
+		if opt != nil {
+			opt(s)
+		}
+	}
+	return s
+}
+
+// Run ticks until ctx is cancelled, then waits for in-flight runs to
+// finish. It returns ctx.Err().
+func (s *Scheduler) Run(ctx context.Context) error {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.wg.Wait()
+			return ctx.Err()
+		case <-ticker.C:
+			s.Tick(ctx)
+		}
+	}
+}
+
+// Tick dispatches every due schedule that is not already running. Each
+// fires in its own goroutine so a slow run does not block the loop; an
+// overlap guard skips a schedule whose previous run is still in flight.
+func (s *Scheduler) Tick(ctx context.Context) {
+	now := s.now()
+	for _, sched := range s.store.List() {
+		if !sched.Due(now) {
+			continue
+		}
+		if !s.tryStart(sched.ID) {
+			continue
+		}
+		sched := sched
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			defer s.finish(sched.ID)
+			s.execute(ctx, sched)
+		}()
+	}
+}
+
+func (s *Scheduler) tryStart(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.running[id] {
+		return false
+	}
+	s.running[id] = true
+	return true
+}
+
+func (s *Scheduler) finish(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.running, id)
+}
+
+func (s *Scheduler) execute(ctx context.Context, sched Schedule) {
+	text, err := s.run(ctx, sched)
+	runErr := ""
+	if err != nil {
+		runErr = err.Error()
+		s.logf("peggy schedule %s failed: %v", sched.ID, err)
+	} else {
+		s.logf("peggy schedule %s ran (%d chars)", sched.ID, len(text))
+	}
+	// Advance using the schedule's recorded fire time, not a fresh clock,
+	// so recurring cadence stays stable across slow runs.
+	if updateErr := s.store.Update(sched.advance(s.now(), runErr)); updateErr != nil {
+		s.logf("peggy schedule %s persist failed: %v", sched.ID, updateErr)
+	}
+}
+
+// ScheduleRunner returns a ScheduleRunner bound to this Peggy. Each run
+// applies the schedule's own permission tier via a per-prompt permission
+// override and writes into the schedule's session id; output is persisted
+// in the session (visible via `peggy sessions` and recall).
+func (p *Peggy) ScheduleRunner() ScheduleRunner {
+	return func(ctx context.Context, s Schedule) (string, error) {
+		perm := NewTieredPermission(nil, s.Tier, "schedule")
+		opts := []glue.PromptOption{glue.WithPermission(perm)}
+		if s.Kind == ScheduleKindSkill {
+			args := map[string]string(nil)
+			if len(s.Args) > 0 {
+				args = s.Args
+			}
+			return p.SkillWithOptions(ctx, s.SessionID, s.Skill, args, io.Discard, opts...)
+		}
+		return p.PromptWithOptions(ctx, s.SessionID, s.Prompt, io.Discard, opts...)
+	}
+}

--- a/agents/peggy/scheduler_test.go
+++ b/agents/peggy/scheduler_test.go
@@ -1,0 +1,221 @@
+package peggy
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func mustSchedule(t *testing.T, params NewScheduleParams, now time.Time) Schedule {
+	t.Helper()
+	s, err := NewSchedule(params, now)
+	if err != nil {
+		t.Fatalf("NewSchedule: %v", err)
+	}
+	return s
+}
+
+func TestNewScheduleValidation(t *testing.T) {
+	now := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		params  NewScheduleParams
+		wantErr string
+	}{
+		{"prompt requires text", NewScheduleParams{Kind: ScheduleKindPrompt, Every: time.Hour}, "needs a prompt"},
+		{"skill requires name", NewScheduleParams{Kind: ScheduleKindSkill, Every: time.Hour}, "needs a skill"},
+		{"needs a cadence", NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "x"}, "exactly one of every or at"},
+		{"both cadences rejected", NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "x", Every: time.Hour, At: &now}, "exactly one of every or at"},
+		{"interval floor", NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "x", Every: time.Second}, "below the"},
+		{"prompt tier rejected", NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "x", Every: time.Hour, Tier: PermissionTierPrompt}, "no client to prompt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewSchedule(tc.params, now)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewScheduleDefaultsTierAndSession(t *testing.T) {
+	now := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	s := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "hi", Every: time.Hour}, now)
+	if s.Tier != PermissionTierTrusted {
+		t.Fatalf("tier = %q, want trusted (default)", s.Tier)
+	}
+	if s.SessionID != "schedule:"+s.ID {
+		t.Fatalf("session = %q, want schedule:%s", s.SessionID, s.ID)
+	}
+	if !s.NextRun.Equal(now.Add(time.Hour)) {
+		t.Fatalf("next run = %v, want now+1h", s.NextRun)
+	}
+}
+
+func TestScheduleAdvanceRecurringFireForward(t *testing.T) {
+	now := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	s := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "hi", Every: time.Hour}, now)
+	// First run is due at now+1h; simulate the scheduler waking up 3h
+	// late. The next run should jump forward past the missed ticks.
+	late := now.Add(3*time.Hour + 30*time.Minute)
+	advanced := s.advance(late, "")
+	if !advanced.NextRun.After(late) {
+		t.Fatalf("next run %v not after %v", advanced.NextRun, late)
+	}
+	if advanced.NextRun.Sub(now)%time.Hour != 0 {
+		t.Fatalf("next run not aligned to interval: %v", advanced.NextRun)
+	}
+	if advanced.LastRun == nil || !advanced.LastRun.Equal(late) {
+		t.Fatalf("last run = %v", advanced.LastRun)
+	}
+}
+
+func TestScheduleOneShotBecomesDone(t *testing.T) {
+	now := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	at := now.Add(time.Minute)
+	s := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "hi", At: &at}, now)
+	if !s.Due(at) {
+		t.Fatal("one-shot not due at its time")
+	}
+	done := s.advance(at, "")
+	if !done.Done() {
+		t.Fatal("one-shot not Done after run")
+	}
+	if done.Due(at.Add(time.Hour)) {
+		t.Fatal("done one-shot still due")
+	}
+}
+
+func TestScheduleStoreRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "schedules.json")
+	store, err := OpenScheduleStore(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	now := time.Now()
+	s := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "hi", Every: time.Hour}, now)
+	if err := store.Add(s); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	reopened, err := OpenScheduleStore(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got := reopened.List()
+	if len(got) != 1 || got[0].ID != s.ID {
+		t.Fatalf("reloaded = %#v", got)
+	}
+
+	// Update on a missing id is a no-op (does not resurrect).
+	if err := reopened.Update(Schedule{ID: "ghost", EverySeconds: 60}); err != nil {
+		t.Fatalf("update ghost: %v", err)
+	}
+	if len(reopened.List()) != 1 {
+		t.Fatal("ghost schedule resurrected")
+	}
+
+	removed, err := reopened.Remove(s.ID)
+	if err != nil || !removed {
+		t.Fatalf("remove: removed=%v err=%v", removed, err)
+	}
+	final, _ := OpenScheduleStore(path)
+	if len(final.List()) != 0 {
+		t.Fatalf("after remove = %#v", final.List())
+	}
+}
+
+func TestSchedulerTickRunsDueAndAdvances(t *testing.T) {
+	store, _ := OpenScheduleStore("") // in-memory
+	base := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	recurring := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "tick", Every: time.Hour}, base)
+	if err := store.Add(recurring); err != nil {
+		t.Fatal(err)
+	}
+
+	var ran int32
+	var gotTier PermissionTier
+	var mu sync.Mutex
+	run := func(_ context.Context, s Schedule) (string, error) {
+		atomic.AddInt32(&ran, 1)
+		mu.Lock()
+		gotTier = s.Tier
+		mu.Unlock()
+		return "done", nil
+	}
+
+	clock := base.Add(2 * time.Hour) // schedule due (next was base+1h)
+	sched := NewScheduler(store, run, WithSchedulerClock(func() time.Time { return clock }))
+	sched.Tick(context.Background())
+	sched.wg.Wait()
+
+	if atomic.LoadInt32(&ran) != 1 {
+		t.Fatalf("ran = %d, want 1", ran)
+	}
+	if gotTier != PermissionTierTrusted {
+		t.Fatalf("run tier = %q, want trusted", gotTier)
+	}
+	after := store.List()[0]
+	if !after.NextRun.After(clock) {
+		t.Fatalf("next run %v not advanced past %v", after.NextRun, clock)
+	}
+	if after.LastRun == nil {
+		t.Fatal("last run not recorded")
+	}
+
+	// Not due again at the same clock: a second tick must not re-run.
+	sched.Tick(context.Background())
+	sched.wg.Wait()
+	if atomic.LoadInt32(&ran) != 1 {
+		t.Fatalf("ran = %d after second tick, want 1", ran)
+	}
+}
+
+func TestSchedulerRecordsRunError(t *testing.T) {
+	store, _ := OpenScheduleStore("")
+	base := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	s := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "boom", Every: time.Hour}, base)
+	store.Add(s)
+	run := func(_ context.Context, _ Schedule) (string, error) {
+		return "", errors.New("kaboom")
+	}
+	sched := NewScheduler(store, run, WithSchedulerClock(func() time.Time { return base.Add(2 * time.Hour) }))
+	sched.Tick(context.Background())
+	sched.wg.Wait()
+	got := store.List()[0]
+	if got.LastError != "kaboom" {
+		t.Fatalf("last error = %q, want kaboom", got.LastError)
+	}
+	if got.LastRun == nil {
+		t.Fatal("errored run still advances cadence and records LastRun")
+	}
+}
+
+func TestSchedulerOverlapGuard(t *testing.T) {
+	store, _ := OpenScheduleStore("")
+	base := time.Date(2026, 5, 27, 9, 0, 0, 0, time.UTC)
+	s := mustSchedule(t, NewScheduleParams{Kind: ScheduleKindPrompt, Prompt: "slow", Every: time.Hour}, base)
+	store.Add(s)
+
+	release := make(chan struct{})
+	var started int32
+	run := func(_ context.Context, _ Schedule) (string, error) {
+		atomic.AddInt32(&started, 1)
+		<-release
+		return "ok", nil
+	}
+	sched := NewScheduler(store, run, WithSchedulerClock(func() time.Time { return base.Add(2 * time.Hour) }))
+	sched.Tick(context.Background()) // starts run, blocks on release
+	sched.Tick(context.Background()) // same schedule still running → skip
+	close(release)
+	sched.wg.Wait()
+	if got := atomic.LoadInt32(&started); got != 1 {
+		t.Fatalf("started = %d, want 1 (overlap not guarded)", got)
+	}
+}

--- a/agents/peggy/settings.go
+++ b/agents/peggy/settings.go
@@ -54,6 +54,9 @@ type Settings struct {
 	// Defaults to prompt for every channel.
 	Permissions PermissionSettings `json:"permissions"`
 
+	// Schedules configures persisted proactive/scheduled runs.
+	Schedules ScheduleSettings `json:"schedules"`
+
 	// Channels carries per-channel configuration subtrees keyed by
 	// channel name (e.g. "telegram"). Each channel package decodes
 	// its own subtree via a DecodeConfig helper. Empty means "no
@@ -127,6 +130,13 @@ type PermissionSettings struct {
 	DefaultTier  string            `json:"default_tier"`
 	RememberPath string            `json:"remember_path,omitempty"`
 	Channels     map[string]string `json:"channels,omitempty"`
+}
+
+// ScheduleSettings configures persisted proactive/scheduled runs.
+type ScheduleSettings struct {
+	// Path is the JSON file that stores schedules. Empty falls back to
+	// ~/.peggy/schedules.json. Set to "off" to disable scheduling.
+	Path string `json:"path,omitempty"`
 }
 
 // Environment variables consulted when paths aren't given explicitly.
@@ -208,6 +218,13 @@ func LoadSettings(path string) (Settings, string, error) {
 			return Settings{}, resolved, err
 		}
 		s.Permissions.RememberPath = expanded
+	}
+	if !s.SchedulesDisabled() && strings.TrimSpace(s.Schedules.Path) != "" {
+		expanded, err := expandPath(s.Schedules.Path)
+		if err != nil {
+			return Settings{}, resolved, err
+		}
+		s.Schedules.Path = expanded
 	}
 	if len(s.MCP.Servers) > 0 {
 		expanded, err := expandMCPSettings(s.MCP)
@@ -361,7 +378,17 @@ func fillDefaults(s Settings) Settings {
 		home, _ := os.UserHomeDir()
 		s.Permissions.RememberPath = filepath.Join(home, ".peggy", "permissions.json")
 	}
+	if s.Schedules.Path == "" {
+		home, _ := os.UserHomeDir()
+		s.Schedules.Path = filepath.Join(home, ".peggy", "schedules.json")
+	}
 	return s
+}
+
+// SchedulesDisabled reports whether scheduling is turned off via
+// Schedules.Path == "off".
+func (s Settings) SchedulesDisabled() bool {
+	return strings.EqualFold(strings.TrimSpace(s.Schedules.Path), "off")
 }
 
 func permissionRememberPathDisabled(path string) bool {


### PR DESCRIPTION
## Summary

Makes Peggy proactive — she now initiates runs on a schedule instead of only responding. This is the headline OpenClaw-shaped gap from tracker #110.

- **Scheduler engine** (`scheduler.go`): runs inside `peggy serve`; ticks, fires due schedules in guarded goroutines (overlap guard), records errors, and fire-forwards recurring cadence past missed ticks (no backlog burst after downtime).
- **Schedule model** (`schedule.go`): a prompt or workspace skill (`--arg key=value`), on a recurring `--every <dur>` (min 1m) or one-shot `--at <RFC3339>`; validated, with a generated id and computed next-run.
- **Persistence** (`schedule_store.go`): atomic JSON at `~/.peggy/schedules.json` (`schedules.path`; `"off"` disables); survives restarts.
- **Per-schedule permission tier**: `trusted` (default) or `read_only`, applied per run via `glue.WithPermission(NewTieredPermission(...))`. `prompt` is rejected — an unattended run has no client to answer. (Default-`trusted` is the chosen posture; per-schedule override keeps safety opt-in.)
- **CLI**: `peggy schedule add|remove`, `peggy schedules` (text/JSON). Output of a fired run lands in the schedule's session (visible via `peggy sessions`/recall).

Closes #273

### Scope / follow-up
Kept to a reviewable core. Surfacing schedules over the daemon (`glue connect`), Telegram commands, and the dashboard is deferred to a follow-up issue (filed separately). Deferred-approval-over-Telegram (pause on a side effect, ask, resume) is also a possible follow-up.

## Verification

```
go build ./...        # ok
go vet ./...          # ok
go test ./agents/peggy/... ./cmd/glue/   # ok
```

Tests cover schedule validation (prompt/skill required, cadence exclusivity, interval floor, prompt-tier rejection, default trusted tier + session id), recurring fire-forward, one-shot becomes-done, store round-trip + ghost-update no-op + remove, and scheduler tick (runs due, applies tier, advances, no double-run; records run errors; overlap guard).

Manual CLI smoke (built binary): `schedule add` (success + persisted JSON), validation rejections for `--tier prompt` and sub-minute `--every`, `schedules` list, and `schedule remove` (present + missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
