### PR TITLE
agents/glue-review: make flaky TestFixtureReplay opt-in (closes #283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,13 +134,20 @@ jobs:
           # See docs/issue-automation.md "Live OpenRouter model" for
           # the refresh-recipe if the meta-router itself ever breaks.
           OPENROUTER_LIVE_MODEL: openrouter/free
+          # agents/glue-review's TestFixtureReplay replays fixtures against
+          # the non-deterministic free router. It is a prompt-regression
+          # tool, not a per-PR gate, so it is opt-in: only the manual
+          # full-live dispatch sets GLUE_REVIEW_LIVE_FIXTURES. On normal
+          # push/PR it stays unset and the replay skips, so model-quality
+          # variance never flakes an unrelated PR. See issue #283.
+          GLUE_REVIEW_LIVE_FIXTURES: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
         run: |
           if [ -z "$OPENROUTER_API_KEY" ]; then
             echo "OPENROUTER_API_KEY not configured; skipping live tests."
             exit 0
           fi
           go test ./providers/openrouter -run Live -count=1 -timeout 300s
-          # agents/glue-review/fixture_test.go exercises the agent end-to-end
-          # against the same free model. Gated on OPENROUTER_API_KEY too, so
-          # they share a job without burning two CI minutes.
+          # The fixture replay shares this job (and the same free model) but
+          # only runs when GLUE_REVIEW_LIVE_FIXTURES is set (manual full-live
+          # dispatch); otherwise it skips quickly.
           go test ./agents/glue-review -run TestFixtureReplay -count=1 -timeout 600s

--- a/agents/glue-review/fixture_test.go
+++ b/agents/glue-review/fixture_test.go
@@ -126,6 +126,17 @@ var fixtures = []fixture{
 	},
 }
 
+// envTruthy reports whether an env-var value means "on". Empty, "0",
+// "false", and "no" (any case) are off; anything else is on.
+func envTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
 // TestFixtureReplay drives every fixture through the agent against a
 // real free model and asserts each scenario's structural invariants.
 // Skipped quietly when no provider key is in env (matches the existing
@@ -135,6 +146,16 @@ var fixtures = []fixture{
 // upstream responses) get two retries before the last attempt is judged
 // normally.
 func TestFixtureReplay(t *testing.T) {
+	// Opt-in only. This replays fixtures against a non-deterministic free
+	// model, so it is a prompt-iteration tool, not a per-PR gate — it has
+	// flaked unrelated PRs (the free router occasionally returns a review
+	// that does not name the changed file or omits the fix block). The CI
+	// per-PR live job runs the deterministic provider Live smoke instead
+	// and only sets GLUE_REVIEW_LIVE_FIXTURES on the manual full-live
+	// (workflow_dispatch run_live) path.
+	if !envTruthy(os.Getenv("GLUE_REVIEW_LIVE_FIXTURES")) {
+		t.Skip("set GLUE_REVIEW_LIVE_FIXTURES=1 to run live fixture replay (non-deterministic prompt-regression check)")
+	}
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}


### PR DESCRIPTION
## Summary

Stops `agents/glue-review`'s `TestFixtureReplay` from flaking the per-PR `live (openrouter)` job on unrelated changes.

The replay drives fixtures through a non-deterministic free meta-router and asserts structural invariants. Despite 3× retries and rate-limit skipping, residual model-quality variance (a review that doesn't name the changed file, or omits the fenced fix block) flaked unrelated PRs twice in one session (#274 panic-stub, #282 subtle-bug ×2), each forcing a CI re-run.

Fix: make the replay **opt-in**. It is a prompt-regression tool, not a gate for every repo change.

- `TestFixtureReplay` skips unless `GLUE_REVIEW_LIVE_FIXTURES` is truthy (in addition to the existing provider-key gate).
- `ci.yml`: the per-PR `live (openrouter)` job still runs the deterministic `providers/openrouter -run Live` smoke, but only sets `GLUE_REVIEW_LIVE_FIXTURES` (and thus runs the replay) on the manual full-live `workflow_dispatch` path.

Closes #283

## Verification

```
go build ./...                                   # ok
go vet ./agents/glue-review/                      # ok
go test ./agents/glue-review/                      # ok; TestFixtureReplay now SKIPs
go test ./agents/glue-review/ -run TestFixtureReplay -v   # --- SKIP (no env var)
```

The replay's unit-level companions (`TestFixtureReplayRetryClassifiers`, `...ReviewMatchers`, `...FixBlockMatcher`) still run and pass — only the live end-to-end replay is gated. `ci.yml` YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
