### PR TITLE
docs: sweep remaining stale references (closes #287)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 # Contributing to Glue
 
-Glue is built one GitHub issue at a time. The pinned project tracker
-(<https://github.com/erain/glue/issues/1>) is the source of truth for what to
-work on next and what is done.
+Glue is built one GitHub issue at a time. The active project tracker
+(<https://github.com/erain/glue/issues/110>) is the source of truth for
+what to work on next and what is done. (The original `0.x` bootstrap
+tracker, [#1](https://github.com/erain/glue/issues/1), is closed and kept
+only as the historical record for the P0/P1/P2 milestones.)
 
 This document is the operating contract. The most important rule:
 
@@ -15,9 +17,9 @@ and reopen it.
 
 Every unit of work follows the same shape:
 
-1. **Read the tracker.** Open issue #1 and pick the next unchecked issue in
-   the priority order listed there. Work P0 before P1 before P2 unless the
-   tracker says otherwise.
+1. **Read the tracker.** Open the active tracker
+   ([#110](https://github.com/erain/glue/issues/110)) and pick the next
+   unchecked issue from its work queue in the priority order listed there.
 2. **Read the issue.** Verify it has all seven required sections (Goal, Scope,
    Out of scope, Implementation notes, Docs update required, Verification
    commands, Acceptance criteria). If anything is missing or stale, edit the
@@ -49,7 +51,7 @@ Every unit of work follows the same shape:
     - the PR number,
     - the verification command output (or a faithful summary if it is large),
     - any caveats or follow-ups for the next session.
-11. **Update the tracker.** Edit issue #1's body to:
+11. **Update the tracker.** Edit the active tracker (#110) body to:
     - check off the completed item,
     - update the Current Phase if a milestone advanced,
     - update the Next Recommended Issue,

--- a/agents/peggy/README.md
+++ b/agents/peggy/README.md
@@ -496,7 +496,7 @@ uses the `cli` tier and `telegram:<chat_id>` uses the `telegram` tier.
 Use this to keep a trusted local terminal fast while making Telegram
 ask every time, or to make Telegram read-only.
 
-Recommended v0.3 daily-driver shape:
+Recommended daily-driver shape:
 
 ```json
 {
@@ -930,12 +930,14 @@ external transports. The pattern is designed in
 
 ## What's coming
 
-Per tracker [#110](https://github.com/erain/glue/issues/110), the next
-dogfood hardening passes are first-run onboarding, persistent
+The M6 dogfood-hardening pass shipped (first-run onboarding, persistent
 permission policy, richer Telegram replies, session/history browsing,
-daemon ops diagnostics, memory backup/export, and a more visual local
-control surface. Later ecosystem polish includes `providers/anthropic`
-when budget allows.
+daemon ops diagnostics, memory backup/restore, the local dashboard), and
+**scheduled/proactive runs** landed on top of it (`peggy schedule` /
+`peggy schedules`). The active queue — surfacing schedules over
+daemon/Telegram/dashboard, richer Telegram streaming, dashboard actions,
+and `providers/anthropic` when budget allows — lives on tracker
+[#110](https://github.com/erain/glue/issues/110).
 
 ## As a library
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -118,12 +118,25 @@ The module path is `github.com/erain/glue`.
   [`adr/0007-memory-layer.md`](adr/0007-memory-layer.md). Pure-Go via
   `modernc.org/sqlite`; `stores/file` stays as the simple option.
 - `tools/fs`: filesystem tool factories — `SafeJoin`, `Truncate`,
-  `Blocklist`, and a ready-to-register `ReadFileTool`. Outside the core
-  package per ADR 0003 so the harness stays free of POSIX coupling.
+  `Blocklist`, plus ready-to-register `ReadFileTool`, `FileWrite`,
+  `FileEdit`, and the read-only navigation tools `ListDirTool`,
+  `FindTool`, `GrepTool`. Outside the core package per ADR 0003 so the
+  harness stays free of POSIX coupling.
 - `tools/git`: git tool factories — `RunGit`, `BuildPathspec`,
   `DiffBranchTool`, `LogBranchTool`. Shells out to the system `git`
   binary; no Git library dependency.
-- `cmd/glue`: local CLI runner built on top of the public library.
+- `tools/shell`: a permission-gated `shell_exec` tool that runs
+  argv-style commands through `glue.Executor` (default local process)
+  with a binary allowlist, timeout, and output caps.
+- `tools/coding`: assembles the reusable local coding-agent bundle
+  (`read_file`, `write_file`, `edit_file`, `list_dir`, `find_files`,
+  `grep`, `shell_exec`, git helpers) over the fs/git/shell/executor
+  primitives. See [`adr/0012-sdk-coding-agent-peggy-boundary.md`](adr/0012-sdk-coding-agent-peggy-boundary.md).
+- `tools/mcp`: a Model Context Protocol client (stdio / Streamable HTTP)
+  that maps MCP server tools to permission-gated `glue.Tool` values. See
+  [`adr/0011-mcp-client-integration.md`](adr/0011-mcp-client-integration.md).
+- `cmd/glue`: local CLI runner and HTTP+SSE daemon (`run` / `serve` /
+  `connect`) built on top of the public library.
 
 The dependency direction is intentionally narrow:
 

--- a/docs/flue-gap-analysis.md
+++ b/docs/flue-gap-analysis.md
@@ -3,6 +3,15 @@
 Date: 2026-05-05
 Reference: https://github.com/withastro/flue#readme
 
+> **Historical snapshot.** This is a point-in-time analysis from
+> 2026-05-05, kept for context. Several gaps it lists have since
+> shipped — subagent orchestration (`glue.SubagentTool`), MCP tooling
+> (`tools/mcp`), the local daemon/serve mode (`cmd/glue serve`,
+> `agents/peggy serve`), and cross-session search (`stores/sqlite`
+> FTS5). For current status see
+> [`project-plan.md`](project-plan.md); for getting started see
+> [`building-agents.md`](building-agents.md).
+
 ## Executive summary
 
 Glue already implements a strong core harness loop in Go (agent/session API, provider abstraction, roles, skills, JSON output, event streaming, and file-backed session store support in examples/CLI). Compared to Flue, the biggest gaps are around **runtime breadth** (multi-target deployment), **sandbox architecture** (virtual + remote sandbox connectors), **task/subagent orchestration**, **MCP tooling**, and **packaging/CLI developer experience**.

--- a/docs/issue-automation.md
+++ b/docs/issue-automation.md
@@ -1,8 +1,10 @@
 # Issue Automation
 
 The Glue project uses GitHub issues as its source of truth (see
-[`CONTRIBUTING.md`](../CONTRIBUTING.md) and the pinned tracker
-[`#1`](https://github.com/erain/glue/issues/1)). This document covers
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) and the active tracker
+[`#110`](https://github.com/erain/glue/issues/110); the closed
+[`#1`](https://github.com/erain/glue/issues/1) is the historical
+bootstrap tracker). This document covers
 the small amount of automation we ship to keep that source of truth
 honest, plus the `gh` cheatsheet for the common operations.
 
@@ -67,9 +69,9 @@ gh issue comment 17 --body "$(cat closing-comment.md)"
 # Reopen an issue (e.g., the bootstrap reset).
 gh issue reopen 17
 
-# Edit the body of the pinned tracker after a PR merges. Reads from a
+# Edit the body of the active tracker after a PR merges. Reads from a
 # file so the heredoc-formatted body survives shell quoting.
-gh issue edit 1 --body "$(cat tracker.md)"
+gh issue edit 110 --body "$(cat tracker.md)"
 
 # Confirm linkage on an issue you just closed via Closes #N.
 gh issue view 17 --json closedByPullRequestsReferences

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -24,7 +24,7 @@ acceptance criteria.
 6. Open a PR whose title or body references the issue (`Closes #N`).
 7. After the PR merges, comment on the issue with implementation notes and
    verification output, then close it (or let `Closes #N` close it).
-8. Update the pinned tracker with completed work and the next recommended issue.
+8. Update the active tracker with completed work and the next recommended issue.
 
 The detailed contributor protocol — including branching conventions, PR shape,
 closing-comment format, and CI expectations — is in [`../CONTRIBUTING.md`](../CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Sweeps the remaining stale references out of the docs so everything is consistent and current.

- **CONTRIBUTING.md** + **docs/issue-automation.md** — stop calling the closed `#1` the active source-of-truth tracker; point the workflow and `gh` cheatsheet at the active tracker `#110`, and mark `#1` as the historical `0.x` bootstrap tracker.
- **docs/design.md** — the package-boundaries list jumped from `tools/git` straight to `cmd/glue`; added the missing `tools/shell`, `tools/coding`, and `tools/mcp` packages (with ADR links) and noted `cmd/glue`'s daemon mode.
- **agents/peggy/README.md** — the "What's coming" section listed M6 items that have all shipped (and omitted scheduled runs); refreshed it to reflect shipped work + the live queue. Dropped the stale "v0.3 daily-driver" label.
- **docs/flue-gap-analysis.md** — added a historical-snapshot banner (it's dated 2026-05-05; subagents, MCP, daemon, and sqlite search have since shipped), pointing at project-plan.md / building-agents.md.
- **docs/project-plan.md** — "pinned tracker" → "active tracker".

ADRs that reference `#1` (e.g. ADR-0005) are intentionally left untouched — they correctly record it as historical and are immutable decision records.

Closes #287

## Verification

```
go build ./...   # ok (docs-only change)
```

Re-scanned for `#1`-as-active references (only the intended historical mentions remain) and verified every internal link in all six changed docs resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
