### PR TITLE
launch hygiene: ADR-0013, SECURITY, issue/PR templates, v0.1.0 cut (closes #289)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: 🐛 Bug report
+description: Something in glue, the cmd/glue binary, or a shipped reference agent is broken or behaves wrong.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing! Two quick checks first:
+
+        - "How do I…?" questions belong in [Discussions](https://github.com/erain/glue/discussions),
+          not here.
+        - Suspect a security issue? Use a [private security advisory](https://github.com/erain/glue/security/advisories/new)
+          instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: One or two sentences on what went wrong.
+      placeholder: "`session.Prompt` returned …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: |
+        The smallest Go program / CLI invocation that triggers it. Inline a fake provider
+        if a model call isn't part of the bug (see `docs/building-agents.md` §10 for a
+        copy-pasteable fake).
+      render: go
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: glue version
+      description: Output of `go list -m github.com/erain/glue` (or the commit you're on).
+      placeholder: "v0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      placeholder: "go version go1.23.4 linux/amd64"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider (if relevant)
+      multiple: false
+      options:
+        - "Not provider-specific"
+        - codex
+        - gemini
+        - nvidia
+        - openrouter
+        - "Custom (your own Provider impl)"
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Stack traces, logs, related issues, screenshots — whatever helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions and discussion
+    url: https://github.com/erain/glue/discussions
+    about: 'General usage questions, "how do I…?", show-and-tell — please use Discussions, not Issues.'
+  - name: 📖 Getting started
+    url: https://github.com/erain/glue/blob/main/docs/building-agents.md
+    about: The end-to-end guide for building an agent on glue. Start here before filing a bug.
+  - name: 🔒 Security report
+    url: https://github.com/erain/glue/security/advisories/new
+    about: Suspect a vulnerability? Use a private security advisory, not a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: 💡 Feature request
+description: Propose a new framework primitive, tool, provider, or behavior.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, two quick sanity checks:
+
+        - Could this live in *your* agent package instead of in core glue?
+          The framework rule (ADR-0005) is that product concerns enter only
+          as interfaces the host fills in. Things like sandboxing, channels,
+          and scheduling belong in your agent, not in glue.
+        - Is it already on the [tracker](https://github.com/erain/glue/issues/110)
+          or the [flue gap analysis](https://github.com/erain/glue/blob/main/docs/flue-gap-analysis.md)?
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What can&rsquo;t you do today, or what's painful?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: |
+        Rough API sketch is great — `glue.Foo(...)` signature, where it lives
+        (`tools/`? `agents/`? new package?), what's in scope vs out.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Including "I built it in my own agent package and it works."
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!--
+glue is built one issue at a time. See CONTRIBUTING.md for the full
+contract; this template is the short version.
+-->
+
+## Summary
+
+<!-- One or two sentences on what this PR ships. -->
+
+Closes #<!-- issue number; required. PRs without a linked issue should be filed against a new issue first. -->
+
+## Verification
+
+<!--
+Paste the literal output (or a faithful summary) of the verification
+commands listed in the linked issue. At minimum:
+
+  go build ./...
+  go vet ./...
+  go test ./...           # or the touched packages, if you ran narrower
+
+Live provider tests are gated behind their API keys and skipped in CI
+unless you ran them locally on purpose — call that out if so.
+-->
+
+```
+go build ./...        # ok
+go vet ./...          # ok
+go test ./...         # ok
+```
+
+## Notes for the reviewer
+
+<!--
+Optional: trade-offs, follow-ups you filed, anything non-obvious. If
+this is a breaking change, lead with "**Breaking:**" and a migration
+note — per ADR-0013 we only break API on minor bumps and only with a
+CHANGELOG entry.
+-->
+
+<!--
+Co-Authored-By trailer (drop if not applicable). The repo convention is
+to credit AI pair-programmers like:
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ go.work.sum
 /glue-review
 /local-agent
 
+.gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,80 @@
 # Changelog
 
-The library at `github.com/erain/glue` remains **pre-1.0**; the `0.x`
-series may break API on minor bumps. The PR-review agent at
-`agents/glue-review` ships with its own version line and is **1.0**;
-see [`agents/glue-review/CHANGELOG.md`](agents/glue-review/CHANGELOG.md)
-for its release notes.
+The library at `github.com/erain/glue` is **pre-1.0**; the `0.x`
+series may break API on minor bumps. See
+[`docs/adr/0013-pre-1-0-stability-stance.md`](docs/adr/0013-pre-1-0-stability-stance.md)
+for the policy, and pin a tag in your `go.mod` if you need stability.
+Breaking changes always land with a `**Breaking:**` entry under a
+minor-bump section — never on a patch release.
 
-This file tracks library-level changes only.
+This file tracks library-level changes. The reference agents version
+independently:
+[`agents/glue-review`](agents/glue-review/README.md) (release notes in
+its [GitHub Releases](https://github.com/erain/glue/releases?q=agents%2Fglue-review)),
+and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
-- Added `tools/coding`, a reusable SDK package that assembles the local
-  coding-agent tool bundle (`read_file`, `write_file`, `shell_exec`,
-  `git_diff_branch`, and `git_log_branch`) over the existing filesystem,
-  shell, git, and `glue.Executor` primitives.
-- Added `cmd/glue` coding-agent mode: `glue run --coding` and
-  `glue serve --coding` now register the SDK coding bundle, with local
+_(no changes yet)_
+
+## 0.1.0 — 2026-05-27
+
+First tagged release. Brings the framework to launch shape and stabilizes
+the public surface for `go get github.com/erain/glue@v0.1.0`.
+
+### Added (M7 dual-track surface)
+
+- `tools/coding`, a reusable SDK package that assembles the local
+  coding-agent tool bundle (`read_file`, `write_file`, `edit_file`,
+  `list_dir`, `find_files`, `grep`, `shell_exec`, `git_diff_branch`,
+  `git_log_branch`) over the existing `tools/fs`, `tools/git`,
+  `tools/shell`, and `glue.Executor` primitives.
+- `cmd/glue` coding-agent mode: `glue run --coding` and
+  `glue serve --coding` register the SDK coding bundle, with local
   terminal permission prompts for one-shot runs and daemon-brokered
   permissions for served runs.
-- Added `cmd/glue --provider`: `run` and `serve` now select any
-  registered provider (`codex`, `gemini`, `nvidia`, `openrouter`) through
-  the `providers` registry instead of being hardwired to Gemini, so the
+- `cmd/glue --provider`: `run` and `serve` select any registered
+  provider (`codex`, `gemini`, `nvidia`, `openrouter`) through the
+  `providers` registry instead of being hardwired to Gemini, so the
   binary can run as a coding agent on a ChatGPT subscription
-  (`glue run --provider codex --coding`). `--model` now defaults to the
+  (`glue run --provider codex --coding`). `--model` defaults to the
   selected provider's registry default model.
-- Added `tools/fs.FileEdit` (`edit_file`), a permission-gated surgical
+- `tools/fs.FileEdit` (`edit_file`), a permission-gated surgical
   exact-string replacement tool with a unique-match guard and optional
-  `replace_all`. It is now part of the `tools/coding` bundle, so
-  `glue run --coding` agents can make targeted edits instead of
-  rewriting whole files.
-- Added read-only navigation tools `tools/fs.ListDirTool` (`list_dir`),
-  `FindTool` (`find_files`), and `GrepTool` (`grep`), also registered in
-  the `tools/coding` bundle. They are workspace-scoped and escape-safe;
-  `grep` skips secret-shaped (Blocklist) and oversized files, and all
-  three skip `.git`.
+  `replace_all`.
+- Read-only navigation tools `tools/fs.ListDirTool` (`list_dir`),
+  `FindTool` (`find_files`), and `GrepTool` (`grep`).
+  Workspace-scoped and escape-safe; `grep` skips secret-shaped
+  (Blocklist) and oversized files, and all three skip `.git`.
 
-## Initial bootstrap (pre-1.0)
+### Public surface present at this tag
 
-The library has been under active development as a Go agent harness
+For completeness, this first tagged release also stabilizes everything
+shipped during the bootstrap and the long-running foundation
+(ADR-0005). The full surface — `Agent` / `Session` / `Tool` /
+`Provider` types, the `loop` package, the four providers, both stores
+(`stores/file`, `stores/sqlite` with FTS5 search), every `tools/*`
+package, subagents (`glue.SubagentTool`), skills/roles/AGENTS.md,
+structured JSON, opt-in parallel tool execution, the `Compactor`
+interface and `SummarizingCompactor`, the `prompts` versioned-prompt
+catalog, the `cli` standard-flags helper, and the `cmd/glue`
+`run` / `serve` / `connect` daemon protocol — is documented in
+[`README.md`](README.md), [`docs/building-agents.md`](docs/building-agents.md),
+and [`docs/design.md`](docs/design.md).
+
+### Notes
+
+- The Codex provider authenticates via `codex login` (subscription
+  auth path OpenAI does not formally document). Intended for personal
+  use; see [`SECURITY.md`](SECURITY.md) for the scope statement.
+- The local executor is permission-gated, not sandboxed. Implement
+  `glue.Executor` against a container/VM if you need isolation
+  ([ADR-0009](docs/adr/0009-executor-permission-hook.md)).
+
+## Initial bootstrap (pre-0.1.0)
+
+The library was under active development as a Go agent harness
 inspired by [pi-mono](https://github.com/badlogic/pi-mono) and
-[Flue](https://github.com/withastro/flue). Notable shipped surface:
-
-- `Agent` / `Session` public API; file-backed session store at
-  `stores/file`.
-- Reusable provider-agnostic loop in `loop/`.
-- Providers: `gemini`, `nvidia`, `openrouter`, with shared
-  OpenAI-compatible plumbing in `providers/openaicompat`.
-- Skills, roles, structured JSON output, parallel tool execution.
-
-The library will cut `v1.0.0` once the public API is settled. For now
-the agent's stability does not require library stability — the agent
-absorbs library bumps internally.
+[Flue](https://github.com/withastro/flue) before this first tag. The
+detailed history lives in the git log; the surface that survived into
+`v0.1.0` is listed above under "Public surface present at this tag."

--- a/README.md
+++ b/README.md
@@ -415,12 +415,16 @@ GEMINI_API_KEY=... go test ./providers/gemini -run Live
 
 ## Project status & contributing
 
-The harness is feature-complete for the `0.x` series and in active use
-behind the [`agents/glue-review`](agents/glue-review) and
+The harness is feature-complete for the `0.x` series, tagged at
+**`v0.1.0`**, and in active use behind the
+[`agents/glue-review`](agents/glue-review) and
 [`agents/peggy`](agents/peggy) reference agents. The library remains
 pre-1.0: the public `Agent` / `Session` surface is stable in practice,
-but minor versions may still break API. See
-[`CHANGELOG.md`](CHANGELOG.md) for library-level notes.
+but minor versions may still break API. The full stability stance is
+[ADR-0013](docs/adr/0013-pre-1-0-stability-stance.md); breaking
+changes always land with a `**Breaking:**` entry in
+[`CHANGELOG.md`](CHANGELOG.md), never on a patch release. Security
+reports go through [`SECURITY.md`](SECURITY.md).
 
 Glue is built one GitHub issue at a time. The contributor workflow,
 branch/PR conventions, and the active tracker are documented in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,78 @@
+# Security Policy
+
+## Supported Versions
+
+Glue is **pre-1.0**. Only the latest `0.x` minor release receives
+security fixes; older minor versions are not patched. Pin to a tag in
+your `go.mod` and read `CHANGELOG.md` before you upgrade — see
+[ADR-0013](docs/adr/0013-pre-1-0-stability-stance.md) for the full
+stability stance.
+
+| Version | Status |
+|---------|--------|
+| Latest `v0.x.y` | ✅ Fixes land on `main`; new patch release as needed. |
+| Older `v0.x.y` | ❌ No backports. Upgrade. |
+
+## Reporting a Vulnerability
+
+Please **do not file public GitHub issues** for security reports.
+
+- Preferred: open a [private vulnerability report](https://github.com/erain/glue/security/advisories/new)
+  via GitHub Security Advisories.
+- Fallback: email <koheiipro@gmail.com> with subject `[glue security]`.
+
+You should hear back within 5 business days. We aim to acknowledge,
+triage, fix, and release within 30 days for serious issues; if the fix
+needs longer we will say so explicitly.
+
+When reporting, include the affected version (`go list -m
+github.com/erain/glue` output is ideal), a minimal reproduction, and
+your assessment of impact.
+
+## Scope
+
+In scope:
+
+- The public `glue.*` API (Agent, Session, Tool, Provider) and the
+  loop package — anything an agent author imports directly.
+- The shipped tool packages (`tools/fs`, `tools/shell`, `tools/git`,
+  `tools/coding`, `tools/mcp`): path-escape, blocklist evasion,
+  permission-gate bypass, symlink races, command-injection through
+  `shell_exec`, etc.
+- The `cmd/glue` CLI and daemon (HTTP+SSE protocol, token handling,
+  permission broker).
+- The shipped stores (`stores/file`, `stores/sqlite`) — accidental
+  cross-session leakage, SQL injection via FTS5 query construction,
+  etc.
+- The reference agents under `agents/` to the extent the issue lives
+  in agent-side code we ship.
+
+Out of scope (already known, not security bugs):
+
+- **Codex provider auth path.** `providers/codex` uses the upstream
+  Codex CLI&rsquo;s `~/.codex/auth.json` to authenticate against a
+  ChatGPT-subscription endpoint that OpenAI does not formally document.
+  This is a personal-use convenience, not a supported integration. Do
+  not ship Codex-backed agents to users.
+- **Local execution is not a sandbox.** `tools/shell` and the
+  `tools/coding` bundle run commands in the host process via
+  `glue.LocalExecutor`. They are permission-gated, not isolated. Hosts
+  that need isolation must implement their own `glue.Executor` against
+  a container or VM (see ADR-0009).
+- **Models can be coerced.** Bugs in *what the model decides to do*
+  with the tools we give it (prompt injection, jailbreaks, tool misuse)
+  are model-behavior issues, not glue bugs, unless they exploit a flaw
+  in the tool layer above.
+- **Downstream API key handling.** Glue reads provider keys from env
+  vars (`GEMINI_API_KEY`, etc.) and forwards them only to the
+  configured provider. Misconfigured shells or leaked `.env` files are
+  your operational concern, not glue's.
+
+## Coordinated Disclosure
+
+If you find a vulnerability that affects another OSS project as well
+(an upstream Go module, a provider SDK, etc.), please coordinate that
+disclosure as you see fit. We will hold our fix until the embargo
+window you propose lifts.
+
+Thank you for reporting responsibly.

--- a/docs/adr/0013-pre-1-0-stability-stance.md
+++ b/docs/adr/0013-pre-1-0-stability-stance.md
@@ -1,0 +1,80 @@
+# ADR-0013: Pre-1.0 Stability Stance and Release Cadence
+
+## Status
+
+Accepted.
+
+## Context
+
+The framework is feature-complete for the `0.x` series and powers two
+reference agents (`agents/glue-review`, `agents/peggy`). The public
+`Agent` / `Session` / `Tool` surface has been stable in practice across
+~30 PRs without breaking changes. We are about to publish an official
+homepage and a tagged release for the first time, which forces a
+decision: lock the surface and cut `v1.0.0` now, or stay pre-1.0 and
+keep the right to break API on minor bumps.
+
+The choice is between two real trade-offs:
+
+- **Lock now (`v1.0.0`).** Strongest external commitment; every
+  subsequent break would require `v2.0.0`, `v3.0.0`, etc. With no
+  external users yet, an early `v1.0.0` would tie our hands for
+  refactors we haven&rsquo;t even discovered we want.
+- **Stay pre-1.0 (`v0.x`).** SemVer permits breaking changes on minor
+  bumps in `0.x`. Lower commitment, faster iteration. The downside is
+  a "we may still break things" caveat on the homepage.
+
+## Decision
+
+Stay on `0.x` for now. Cut **`v0.1.0`** as the first tagged release
+and use minor bumps (`v0.2.0`, `v0.3.0`, …) for breaking changes,
+patch bumps (`v0.1.1`, `v0.1.2`, …) for non-breaking fixes. Lock
+`v1.0.0` only after a deliberate surface-review pass — not on a launch
+deadline.
+
+Concretely:
+
+- The public `glue.Agent` / `glue.Session` / `glue.Tool` /
+  `glue.Provider` surface, the `loop` package types, and the registered
+  tool / provider / store packages are all considered API in the SemVer
+  sense.
+- Internal helpers (unexported symbols, anything inside an `internal/`
+  package — none exist today but the rule reserves the right) are
+  exempt.
+- Every breaking change must land with a `CHANGELOG.md` entry under
+  the next minor version, prefixed `**Breaking:**`, and a migration
+  note. We do not break API on patch releases.
+- The README, `docs/building-agents.md`, and the homepage carry one
+  honest sentence on stability rather than implying production readiness.
+
+## Loopholes and Fixes
+
+- **Loophole: subscription-auth providers leak through the
+  stability promise.** The Codex provider depends on a third-party
+  auth path OpenAI does not formally document. Fixed by carrying the
+  caveat on the provider package, the README, the homepage, and
+  `SECURITY.md` separately from the framework-wide stability claim.
+
+- **Loophole: "stable in practice" is not measurable.** Fixed by tying
+  the stability commitment to `CHANGELOG.md` discipline: a breaking
+  change without a `**Breaking:**` entry under a minor-bump section
+  is a release bug, not a design choice.
+
+- **Loophole: `v1.0.0` could be deferred forever.** Not fixed in this
+  ADR. The trigger is "we have outside users whose breakage cost
+  exceeds our iteration cost" plus an explicit surface-review pass.
+  We will revisit when that becomes true; until then, this is the
+  honest answer.
+
+- **Loophole: tagging dilutes the contributor protocol&rsquo;s
+  one-issue/one-PR rule.** Not really — tags are cut on the merge
+  commit of the issue that bumps `CHANGELOG.md`, not as separate
+  unowned mutations.
+
+## Consequences
+
+The homepage can ship today with an honest "pre-1.0" line and a real
+tagged release behind `go get github.com/erain/glue@v0.1.0`. Future
+breaking changes are cheap (one minor bump) but visible (one CHANGELOG
+entry per break). Locking to `v1.0.0` remains a future, deliberate
+choice rather than a launch-deadline accident.


### PR DESCRIPTION
## Summary

Pre-announce launch hygiene so the new homepage (`glue-framework-site.vercel.app`) doesn't strand the first strangers in a context-less issue tracker. Five things land together; tag + release + Discussions toggle + repo metadata follow as out-of-PR commands once this merges.

- **[ADR-0013](docs/adr/0013-pre-1-0-stability-stance.md)** — record the stay-on-0.x stance honestly: cut `v0.1.0` now, only lock `v1.0.0` after a deliberate surface-review pass, break API on minor bumps with a `**Breaking:**` CHANGELOG entry — never on a patch release.
- **[SECURITY.md](SECURITY.md)** — GitHub Security Advisory + email reporting; explicit scope (tools, daemon, stores, agents) and out-of-scope (Codex subscription auth is documented-personal-use, "local executor is not a sandbox", model coercion isn't a glue bug, user-side key handling).
- **`.github/ISSUE_TEMPLATE/*`** — `config.yml` redirects general questions to Discussions and security to private advisories; `bug_report.yml` / `feature_request.yml` are GitHub form templates that ask for the things a reviewer would otherwise have to drag out.
- **`.github/pull_request_template.md`** — the one-issue/one-PR + verification contract from CONTRIBUTING.md, distilled.
- **CHANGELOG.md** — dated `v0.1.0` section that captures the M7 dual-track surface plus the public surface stabilized at this tag. README now points at ADR-0013 + SECURITY.md.

Incidentally adds `.gstack/` to `.gitignore` (the gstack browse skill leaves session state in repo dirs by default; harmless but noisy).

Closes #289

## Verification

```
go build ./...        # ok (docs/config only)
go vet ./...          # ok
yaml.safe_load(...)   # ok on all 3 issue-template YAMLs
```

All internal links in the touched docs verified to resolve. (Fixed an inherited broken link to `agents/glue-review/CHANGELOG.md` — that file doesn't exist; release notes live in GitHub Releases.)

## Out-of-PR follow-ups (done immediately after merge)

- `git tag -a v0.1.0` on the merge commit; `git push --tags`; `gh release create v0.1.0`.
- `gh api -X PATCH /repos/erain/glue --field has_discussions=true` to enable Discussions.
- `gh repo edit erain/glue --description ... --homepage https://glue-framework-site.vercel.app --add-topic ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
