### PR TITLE
cmd/glue/tui: input box polish (closes #295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
   one-shot paths (`glue run --prompt ...`, `echo ... | glue run`) are
   preserved exactly. The new charmbracelet dependencies live under
   `cmd/glue/tui/`; the library import graph is unchanged.
+- TUI input layer polish (`cmd/glue/tui`):
+  - Dropped the textarea's internal `│ ` prompt — the box border was the
+    only vertical line you should see.
+  - Default to **1-row input that grows to 6** as you type (was a
+    3-row minimum that felt heavy for short prompts).
+  - **Ctrl+J inserts a newline; Enter submits** (Ctrl+J is ASCII LF and
+    works on every terminal — Shift+Enter does not). The old Alt+Enter
+    binding is gone.
+  - **Accent (purple) rounded border** on the input box so "type here"
+    is unambiguous.
+  - **Italic muted placeholder** ("Ask anything · / for commands") and
+    **accent-colored cursor**.
+  - **Input box capped at 100 columns and centered** on wider terminals
+    so it doesn't feel disconnected from the conversation above.
+  - Bracketed paste was already on by default — pasting multi-line text
+    no longer fires multiple submits.
+  - Welcome card + status bar updated with the new key hints.
 - TUI polish (`cmd/glue/tui` v1.1):
   - **Markdown rendering** for assistant text via `charmbracelet/glamour`,
     applied after each turn completes (streaming stays plain to avoid

--- a/README.md
+++ b/README.md
@@ -361,9 +361,11 @@ moving spinner while running and an inline `[a] [s] [t] [n]` permission
 prompt right inside the card when a side-effecting tool needs approval,
 and a small `edit_file` diff preview. Slash commands: `/help`,
 `/exit`, `/clear` / `/new`, `/usage`, `/tools`, `/model <id>`,
-`/session [id]`. **Esc** cancels the current turn; **Ctrl+C** once
-cancels (and a second press quits); mouse wheel scrolls the transcript;
-PgUp/PgDn does too. The TUI dependencies
+`/session [id]`. **Enter** sends; **Ctrl+J** inserts a newline (works
+on every terminal — Shift+Enter does not). **Esc** cancels the
+current turn; **Ctrl+C** once cancels (and a second press quits);
+mouse wheel scrolls the transcript; PgUp/PgDn does too. The TUI
+dependencies
 (`charmbracelet/{bubbletea,bubbles,lipgloss,glamour}`) live under
 `cmd/glue/tui/` only — `go get github.com/erain/glue` consumers pull
 zero TUI code.

--- a/cmd/glue/tui/input_test.go
+++ b/cmd/glue/tui/input_test.go
@@ -1,0 +1,77 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestInputHasNoInternalPrompt(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	if got := m.input.Prompt; got != "" {
+		t.Fatalf("input prompt = %q, want empty (the box border is the only vertical line)", got)
+	}
+}
+
+func TestInputStartsAtSingleRow(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	if got := m.input.Height(); got != 1 {
+		t.Fatalf("input height = %d, want 1 (grows on multi-line content)", got)
+	}
+}
+
+func TestInputPlaceholderInvitesUser(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	if !strings.Contains(m.input.Placeholder, "Ask") {
+		t.Fatalf("placeholder = %q, want something inviting", m.input.Placeholder)
+	}
+}
+
+func TestInsertNewlineBoundToCtrlJ(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	keys := m.input.KeyMap.InsertNewline.Keys()
+	if len(keys) != 1 || keys[0] != "ctrl+j" {
+		t.Fatalf("InsertNewline keys = %v, want exactly [ctrl+j] (Enter is reserved for submit)", keys)
+	}
+	// Sanity: ensure Enter is NOT in the InsertNewline bindings.
+	for _, k := range keys {
+		if k == "enter" || k == "ctrl+m" {
+			t.Fatalf("Enter still bound to InsertNewline (%q); should submit instead", k)
+		}
+	}
+}
+
+func TestEnterSubmitsAndClearsInput(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.input.SetValue("hello")
+	_, _ = m.handleInputKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.input.Value() != "" {
+		t.Fatalf("input not cleared after submit: %q", m.input.Value())
+	}
+	// A user message should now be the most recent non-welcome entry.
+	found := false
+	for _, it := range m.transcript {
+		if it.Kind == itemUser && it.Text == "hello" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("user message not appended; transcript = %+v", m.transcript)
+	}
+}
+
+func TestEscOutsideTurnIsNoOp(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	before := len(m.transcript)
+	_, _ = m.handleInputKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if len(m.transcript) != before {
+		t.Fatalf("Esc outside a turn modified transcript: before=%d after=%d", before, len(m.transcript))
+	}
+}

--- a/cmd/glue/tui/styles.go
+++ b/cmd/glue/tui/styles.go
@@ -26,9 +26,12 @@ var (
 			Foreground(inkMuted).
 			Padding(0, 1)
 
+	// Accent the input box so "type here" is unambiguous. The textarea
+	// is always focused while the TUI is running so we don't bother with
+	// a blurred variant.
 	inputBoxStyle = lipgloss.NewStyle().
-			Border(lipgloss.NormalBorder()).
-			BorderForeground(border).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(accent).
 			Padding(0, 1)
 
 	userPrefix = lipgloss.NewStyle().Foreground(accent).Bold(true)
@@ -43,11 +46,6 @@ var (
 
 	diffAddSty = lipgloss.NewStyle().Foreground(okColor)
 	diffDelSty = lipgloss.NewStyle().Foreground(errColor)
-
-	permBox = lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		BorderForeground(warnCol).
-		Padding(0, 1)
 
 	// permKey renders a single keyboard key cap inside the in-card
 	// permission prompt: `[a]`, `[s]`, etc.

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -42,7 +43,12 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	m := newModel(ctx, cfg)
-	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	// Note: bracketed paste is on by default in bubbletea v1+; we don't
+	// need an explicit opt-in.
+	p := tea.NewProgram(m,
+		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
+	)
 
 	// Make Send available to the model (for the permission bridge and the
 	// per-turn goroutine), and install the bridge as the agent's
@@ -129,12 +135,34 @@ type Model struct {
 
 func newModel(ctx context.Context, cfg Config) *Model {
 	ta := textarea.New()
-	ta.Placeholder = "Type a message, or /help"
-	ta.Prompt = "│ "
+	ta.Placeholder = "Ask anything · / for commands"
+	// No internal prompt character: the lipgloss box border around the
+	// textarea already provides one vertical line, and "│ │" looked like
+	// a broken double-border.
+	ta.Prompt = ""
 	ta.CharLimit = 0
 	ta.SetWidth(80)
-	ta.SetHeight(3)
+	// Start at 1 row and grow as the user types up to inputMaxRows.
+	// A 3-row minimum made short prompts feel heavy.
+	ta.SetHeight(1)
 	ta.ShowLineNumbers = false
+
+	// Enter submits (intercepted in handleInputKey before the textarea
+	// sees it). Ctrl+J is ASCII LF and works on every terminal, unlike
+	// Shift+Enter which most terminals don't distinguish from Enter.
+	ta.KeyMap.InsertNewline = key.NewBinding(
+		key.WithKeys("ctrl+j"),
+		key.WithHelp("ctrl+j", "newline"),
+	)
+
+	// Strip the highlighted cursor-line background — looks loud on a
+	// one-line input.
+	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	ta.BlurredStyle.CursorLine = lipgloss.NewStyle()
+	ta.FocusedStyle.Placeholder = lipgloss.NewStyle().Foreground(inkMuted).Italic(true)
+	ta.BlurredStyle.Placeholder = ta.FocusedStyle.Placeholder
+	ta.Cursor.Style = lipgloss.NewStyle().Foreground(accent)
+
 	ta.Focus()
 
 	vp := viewport.New(80, 20)
@@ -168,7 +196,7 @@ func (m *Model) appendWelcome() {
 		welcomeAccent.Render("    › ") + "Run the tests and fix the first failure.",
 		welcomeAccent.Render("    › ") + "Summarize the changes in this branch vs main.",
 		"",
-		keyHint.Render("  Enter sends · / for commands · Esc cancels current turn · Ctrl+C exits"),
+		keyHint.Render("  Enter sends · Ctrl+J newline · / for commands · Esc cancels · Ctrl+C exits"),
 		"",
 		keyHint.Render(fmt.Sprintf("  session %s · %s/%s · %s",
 			m.cfg.SessionID,
@@ -293,6 +321,11 @@ func (m *Model) View() string {
 
 // ---------- helpers: layout / rendering ----------
 
+// inputMaxBoxWidth caps the visible input box on wide terminals so it
+// doesn't stretch across a wall and feel disconnected from the
+// conversation centered above it.
+const inputMaxBoxWidth = 100
+
 func (m *Model) layout() {
 	if m.width <= 0 || m.height <= 0 {
 		return
@@ -300,38 +333,42 @@ func (m *Model) layout() {
 	headerH := 1
 	statusH := 1
 	inputH := m.inputHeight()
-	// Borders on the input box add 2.
+	// Border (1 top + 1 bottom) + padding (0,1) on the input box adds 2 rows.
 	bottomH := inputH + 2
-	if m.pending != nil {
-		bottomH += m.permBoxHeight()
-	}
 	bodyH := m.height - headerH - statusH - bottomH
 	if bodyH < 3 {
 		bodyH = 3
 	}
 	m.viewport.Width = m.width
 	m.viewport.Height = bodyH
-	m.input.SetWidth(m.width - 2) // textarea adds its own gutter
+
+	// Inner textarea width is the box width minus border (2) and
+	// padding (2). Cap the box at inputMaxBoxWidth on wide terminals.
+	boxW := m.width - 4
+	if boxW > inputMaxBoxWidth {
+		boxW = inputMaxBoxWidth
+	}
+	if boxW < 20 {
+		boxW = 20
+	}
+	m.input.SetWidth(boxW - 4)
 }
 
 func (m *Model) inputHeight() int {
-	// Grow with content up to 8 rows, then scroll inside the textarea.
-	const min, max = 3, 8
+	// Default to a single row and grow as the user types, up to 6.
+	// Past 6 the textarea scrolls internally.
+	const minH, maxH = 1, 6
 	h := m.input.LineCount()
-	if h < min {
-		h = min
+	if h < minH {
+		h = minH
 	}
-	if h > max {
-		h = max
+	if h > maxH {
+		h = maxH
 	}
 	m.input.SetHeight(h)
 	return h
 }
 
-func (m *Model) permBoxHeight() int {
-	// Header line + buttons + ~2 lines of context = ~5 with borders.
-	return 5
-}
 
 func (m *Model) rerender() {
 	// Sticky scroll: only auto-scroll if the user is already at the
@@ -400,9 +437,21 @@ func (m *Model) headerView() string {
 }
 
 func (m *Model) bottomView() string {
-	// Permission prompts now render inside the relevant tool card in the
-	// transcript, so the input box gets its full width back.
-	return inputBoxStyle.Width(m.width - 2).Render(m.input.View())
+	// Permission prompts render inside the relevant tool card now, so the
+	// input box only carries the textarea. Cap the visual width on wide
+	// terminals so it doesn't feel disconnected from the chat above.
+	boxW := m.width - 4
+	if boxW > inputMaxBoxWidth {
+		boxW = inputMaxBoxWidth
+	}
+	if boxW < 20 {
+		boxW = 20
+	}
+	box := inputBoxStyle.Width(boxW).Render(m.input.View())
+	if boxW < m.width {
+		return lipgloss.PlaceHorizontal(m.width, lipgloss.Center, box)
+	}
+	return box
 }
 
 func (m *Model) statusView() string {
@@ -433,7 +482,7 @@ func (m *Model) statusView() string {
 	if !m.viewport.AtBottom() {
 		parts = append(parts, keyHint.Render("↓ more below"))
 	}
-	parts = append(parts, keyHint.Render("/help · esc cancel · ^C exit"))
+	parts = append(parts, keyHint.Render("Enter send · ^J newline · /help · esc cancel · ^C exit"))
 	return statusStyle.Render(strings.Join(parts, "  ·  "))
 }
 
@@ -496,12 +545,10 @@ func (m *Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.viewport.HalfViewDown()
 		return m, nil
 	case tea.KeyEnter:
-		// Shift+Enter is the textarea's "newline"; bare Enter submits.
-		// bubbles/textarea routes both through Enter; we treat Alt+Enter
-		// as the newline because Shift+Enter is not portable across terms.
-		if msg.Alt {
-			break // fall through to textarea
-		}
+		// Enter submits unconditionally. Multi-line input uses Ctrl+J
+		// (ASCII LF), bound on the textarea's KeyMap.InsertNewline in
+		// newModel. Shift+Enter is intentionally NOT supported — most
+		// terminals don't distinguish it from Enter.
 		return m.submit()
 	}
 

--- a/docs/adr/0014-coding-agent-tui.md
+++ b/docs/adr/0014-coding-agent-tui.md
@@ -191,3 +191,35 @@ Same loopholes still open from the v1 ADR: per-hunk diff approval,
 keyboard expand/collapse of tool cards, slash-command autocomplete,
 copy-to-clipboard, TUI on `glue connect`. Filed as follow-up issues if
 demand surfaces.
+
+## Update — input-layer polish (#295)
+
+A second round addresses the input box specifically. v1 shipped a
+textarea wrapped in a lipgloss-bordered box; that combination produced
+a doubled `│ │` on the left (textarea's internal `Prompt = "│ "`
+duplicated the box border), enforced a 3-row minimum height even for
+one-line prompts, and bound the unfortunate Alt+Enter for newlines.
+
+Changes:
+
+- `ta.Prompt = ""` — the box border is the only vertical line.
+- 1-row default, grows up to 6 (`inputHeight`'s `minH=1, maxH=6`).
+- `ta.KeyMap.InsertNewline` rebound to `ctrl+j` (ASCII LF, terminal-
+  portable). Enter submits unconditionally; the v1 Alt+Enter path is
+  removed.
+- `inputBoxStyle` border is now `RoundedBorder` in accent (purple)
+  rather than the subtle gray that made the input fade into the chrome.
+- `ta.FocusedStyle.CursorLine` is stripped (no highlighted-line band
+  on a one-line input); `ta.FocusedStyle.Placeholder` is italic +
+  `inkMuted`; `ta.Cursor.Style` is accent.
+- Box width is capped at `inputMaxBoxWidth = 100` and centered
+  horizontally via `lipgloss.PlaceHorizontal` on wider terminals.
+- Bracketed paste was already on by default in bubbletea v1+; no
+  explicit option needed (the deferred multi-line-paste concern from
+  v1 is moot).
+- Welcome card + status-bar hint updated:
+  `Enter sends · Ctrl+J newline · Esc cancels · Ctrl+C exits`.
+
+The dead `permBox` style and the unused `permBoxHeight()` method are
+removed (they were carried as no-ops by the v1.1 in-card permission
+refactor).


### PR DESCRIPTION
## Summary

Tightens the input layer specifically. v1 paired a textarea (with its own internal `│ ` prompt) inside a lipgloss bordered box, producing a doubled vertical line; a 3-row minimum felt heavy for short prompts; Alt+Enter as the newline binding was undiscoverable and clashed with users' Shift+Enter reflex.

- `ta.Prompt = ""` — the box border is the only vertical line.
- 1-row default, **grows up to 6** as you type (was `minH=3`).
- `ta.KeyMap.InsertNewline` rebound to **`ctrl+j`** (ASCII LF, works on every terminal — Shift+Enter does not). **Enter submits unconditionally.** Alt+Enter v1 branch is gone.
- **Accent (purple) `RoundedBorder`** on `inputBoxStyle` so "type here" is unambiguous.
- Strip the highlighted `CursorLine` band; italic muted placeholder **"Ask anything · / for commands"**; accent-colored cursor.
- **Cap visible box width at 100 cols, center horizontally** on wider terminals via `lipgloss.PlaceHorizontal`.
- Bracketed paste was already on by default in bubbletea v1+; no explicit option needed (the deferred multi-line-paste concern is moot).
- Welcome card + status bar hint updated: `Enter sends · Ctrl+J newline · Esc cancels · Ctrl+C exits`.
- Drop dead `permBox` style + unused `permBoxHeight()` method (carried as no-ops by the v1.1 in-card permission refactor).

ADR-0014 gets an `## Update — input-layer polish (#295)` section recording each change. No v1 or v1.1 decision reverted.

Closes #295

## Verification

```
go build ./...        # ok
go vet ./...          # ok
go test ./cmd/glue/tui/...  # ok (all v1 + v1.1 tests, plus six new input-layer tests)
```

New tests: `TestInputHasNoInternalPrompt`, `TestInputStartsAtSingleRow`, `TestInputPlaceholderInvitesUser`, `TestInsertNewlineBoundToCtrlJ` (verifies Enter is NOT a newline binding), `TestEnterSubmitsAndClearsInput`, `TestEscOutsideTurnIsNoOp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
