### PR TITLE
cmd/glue: close five pi-gap quick wins — @file, --tools, --mode json, /compact, /resume (closes #297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,36 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
   one-shot paths (`glue run --prompt ...`, `echo ... | glue run`) are
   preserved exactly. The new charmbracelet dependencies live under
   `cmd/glue/tui/`; the library import graph is unchanged.
+- Pi-gap quick wins (`cmd/glue`):
+  - **`@file` argument expansion.** In `glue run --prompt`, in piped
+    stdin, and in the interactive TUI's submit handler, `@<path>`
+    inlines the file contents under a `--- @path ---` header so the
+    model sees the actual code. Supports `@"path with space"` and
+    `@@literal` escape. Workspace-rooted and refuses path-escape,
+    secret-shaped (`.env`), symlinks, directories, and oversized
+    files. Lives in the new `cmd/glue/atmentions` package.
+  - **`--tools <list>` and `--no-tools` flags on `glue run`.** Filter
+    the registered tool set: `--tools read_file,grep` restricts the
+    model to that allowlist; `--no-tools` strips them all for a
+    text-only run. Unknown names error with the list of available
+    tools (no silent typos).
+  - **`--mode json` output mode for one-shot runs.** Emits stable
+    JSON-Lines events on stdout (`start`, `text`, `tool_start`,
+    `tool_end`, `done`, `error`) for scripting and IDE integration.
+    The interactive TUI ignores `--mode`; piping or `--prompt` enables
+    it.
+  - **`/compact` slash command in the TUI.** Triggers a token-aware
+    `SummarizingCompactor` over the current session's transcript,
+    persists the compacted state to the store, and reports
+    `before → after` message counts as a system message.
+  - **`/resume` session picker in the TUI.** Opens a modal list of the
+    ten most-recent stored sessions (↑/↓ navigate, Enter select, Esc
+    cancel) and replays the chosen session's transcript into the TUI.
+    Needs a `Store` that implements `SessionLister`; the file store
+    qualifies.
+- Added `glue.Agent.ListSessions` (mirrors `Agent.SearchSessions`):
+  returns `[]SessionSummary` from a `SessionLister`-capable store, or
+  the new `ErrSessionListingNotSupported` sentinel.
 - TUI input layer polish (`cmd/glue/tui`):
   - Dropped the textarea's internal `│ ` prompt — the box border was the
     only vertical line you should see.

--- a/README.md
+++ b/README.md
@@ -361,8 +361,14 @@ moving spinner while running and an inline `[a] [s] [t] [n]` permission
 prompt right inside the card when a side-effecting tool needs approval,
 and a small `edit_file` diff preview. Slash commands: `/help`,
 `/exit`, `/clear` / `/new`, `/usage`, `/tools`, `/model <id>`,
-`/session [id]`. **Enter** sends; **Ctrl+J** inserts a newline (works
-on every terminal — Shift+Enter does not). **Esc** cancels the
+`/session [id]`, **`/compact`** (token-aware summarization of older
+messages to free context window), **`/resume`** (modal picker over
+past sessions; ↑/↓ navigate, Enter replays the chosen one into the
+transcript). Anywhere in a prompt, **`@<path>`** inlines that file's
+contents (`@"path with space"` for spaces, `@@literal` to escape — and
+the workspace blocklist refuses `.env` / `id_rsa` / etc.). **Enter**
+sends; **Ctrl+J** inserts a newline (works on every terminal —
+Shift+Enter does not). **Esc** cancels the
 current turn; **Ctrl+C** once cancels (and a second press quits);
 mouse wheel scrolls the transcript; PgUp/PgDn does too. The TUI
 dependencies
@@ -372,7 +378,9 @@ zero TUI code.
 
 `run` flags include `--provider`, `--model`, `--id`, `--store`,
 `--work`, `--coding` (+ `--allow-binary`, `--coding-allow-overwrite`),
-`--usage`, and repeatable `--env`. `serve` brokers coding-tool
+`--tools name1,name2` (allowlist) / `--no-tools` (text-only),
+`--mode text|json` (one-shot output format; `json` emits stable
+JSONL events for scripting), `--usage`, and repeatable `--env`. `serve` brokers coding-tool
 permission requests to the connected `connect` client; it writes
 connection metadata to the user config dir (never the bearer token).
 The daemon protocol is [ADR-0010](docs/adr/0010-daemon-protocol.md).

--- a/agent.go
+++ b/agent.go
@@ -97,6 +97,23 @@ func NewAgent(options AgentOptions) *Agent {
 	}
 }
 
+// ListSessions returns a metadata-only catalog of stored sessions if
+// the agent's [Store] implements [SessionLister]. Returns
+// [ErrSessionListingNotSupported] when the store does not.
+//
+// Mirrors [Agent.SearchSessions] in shape: provider-free, no transcript
+// content, intended for picker UIs and dashboards.
+func (a *Agent) ListSessions(ctx context.Context, opts ListSessionsOptions) ([]SessionSummary, error) {
+	if a == nil {
+		return nil, errors.New("glue: nil agent")
+	}
+	lister, ok := a.store.(SessionLister)
+	if !ok || a.store == nil {
+		return nil, ErrSessionListingNotSupported
+	}
+	return lister.ListSessions(ctx, opts)
+}
+
 // ToolCatalog returns a cloned provider-visible catalog of the agent's
 // configured tools, including permission metadata for hosts that need to
 // display or expose the tool surface without starting a session.

--- a/cmd/glue/atmentions/atmentions.go
+++ b/cmd/glue/atmentions/atmentions.go
@@ -1,0 +1,243 @@
+// Package atmentions implements `@<path>` expansion for the glue CLI:
+// before the prompt is sent to the provider, every recognized @-mention
+// is read off disk and appended to the prompt under a fenced header.
+//
+// The same code is used by `glue run --prompt`, piped stdin, and the
+// interactive TUI's submit handler, so the user can write
+// `tell me about @util.go and @main.go` and the model sees the actual
+// file contents.
+//
+// Safety:
+//   - Paths are resolved relative to a workspace root and refused if
+//     they escape it ("../etc/passwd", "/absolute"...).
+//   - Paths that match a sensitive-file Blocklist (`.env`, `id_rsa`,
+//     etc.) are refused even if they exist.
+//   - Files exceeding MaxBytes are refused so a runaway 100 MB log
+//     doesn't blow the model's context budget.
+package atmentions
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	toolsfs "github.com/erain/glue/tools/fs"
+)
+
+// DefaultMaxBytes is the per-file size ceiling.
+const DefaultMaxBytes = 256 * 1024
+
+// Options configures Expand.
+type Options struct {
+	// WorkDir is the workspace root. @paths are resolved relative to it.
+	// Empty means current process directory.
+	WorkDir string
+
+	// Blocklist refuses sensitive paths (`.env`, `id_rsa`, etc.). Nil
+	// uses tools/fs.Default().
+	Blocklist toolsfs.Blocklist
+
+	// MaxBytes caps per-file content. Zero uses DefaultMaxBytes.
+	MaxBytes int
+}
+
+// Result reports what Expand did.
+type Result struct {
+	// Prompt is the rewritten prompt: the original verbatim, with file
+	// contents appended under per-file headers.
+	Prompt string
+	// Included are the workspace-relative paths whose contents were
+	// inlined.
+	Included []string
+	// Skipped are @-mentions that did not turn into content, paired with
+	// the reason (file missing, blocked, oversize, etc.). Expand does
+	// NOT fail on skipped paths; the caller surfaces them however it likes
+	// (the TUI prints a system message; the one-shot path prints to stderr).
+	Skipped []Skip
+}
+
+// Skip describes a single @-mention that was not inlined.
+type Skip struct {
+	Mention string // the literal "@<path>" the user typed
+	Reason  string // human-readable explanation
+}
+
+// Expand walks a user-supplied prompt, locates @<path> tokens, reads
+// the workspace-rooted files, and returns the rewritten prompt with the
+// contents appended.
+//
+// Behavior matches what a human reviewer would expect:
+//   - "@util.go" → relative to WorkDir.
+//   - "@\"path with space\"" → quoted form supports spaces.
+//   - "@@literal" → escape: a leading "@@" in a word is reduced to "@"
+//     and not treated as a mention. Useful for prose like "use @@param".
+//   - An @-mention that points at a directory is refused (no recursive
+//     inlining; ask `list_dir` or `find_files`).
+func Expand(prompt string, opts Options) (Result, error) {
+	res := Result{Prompt: prompt}
+	if !strings.Contains(prompt, "@") {
+		return res, nil
+	}
+
+	mentions := scanMentions(prompt)
+	if len(mentions) == 0 {
+		return res, nil
+	}
+
+	workDir, err := resolveWorkDir(opts.WorkDir)
+	if err != nil {
+		return res, err
+	}
+	blocklist := opts.Blocklist
+	if blocklist == nil {
+		blocklist = toolsfs.Default()
+	}
+	maxBytes := opts.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+
+	var sections []string
+	seen := map[string]struct{}{}
+	for _, raw := range mentions {
+		path := raw
+		// De-duplicate identical mentions; one section per file.
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+
+		content, skip := readMention(workDir, path, blocklist, maxBytes)
+		if skip != "" {
+			res.Skipped = append(res.Skipped, Skip{Mention: "@" + path, Reason: skip})
+			continue
+		}
+		res.Included = append(res.Included, path)
+		sections = append(sections, fmt.Sprintf("--- @%s ---\n%s", path, content))
+	}
+	sort.Strings(res.Included)
+
+	if len(sections) > 0 {
+		res.Prompt = strings.TrimRight(prompt, "\n") + "\n\n" + strings.Join(sections, "\n\n")
+	}
+	return res, nil
+}
+
+// scanMentions walks the prompt and returns the unquoted paths of every
+// recognized @-mention, in order of first appearance.
+func scanMentions(prompt string) []string {
+	var out []string
+	i := 0
+	for i < len(prompt) {
+		c := prompt[i]
+		if c != '@' {
+			i++
+			continue
+		}
+		// Escape: "@@" reduces to a literal "@" — skip.
+		if i+1 < len(prompt) && prompt[i+1] == '@' {
+			i += 2
+			continue
+		}
+		// Must be at start-of-string or follow whitespace/punctuation —
+		// avoids matching emails like alice@example.com.
+		if i > 0 && !isMentionBoundary(prompt[i-1]) {
+			i++
+			continue
+		}
+		// Quoted form: @"path with space".
+		if i+1 < len(prompt) && prompt[i+1] == '"' {
+			end := strings.IndexByte(prompt[i+2:], '"')
+			if end < 0 {
+				i++
+				continue
+			}
+			out = append(out, prompt[i+2:i+2+end])
+			i = i + 2 + end + 1
+			continue
+		}
+		// Bare form: @path — terminate on whitespace or comma/parens/etc.
+		end := i + 1
+		for end < len(prompt) && !isMentionStop(prompt[end]) {
+			end++
+		}
+		if end > i+1 {
+			out = append(out, prompt[i+1:end])
+		}
+		i = end
+	}
+	return out
+}
+
+func isMentionBoundary(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '(', '[', '{', ',', ';', ':', '"', '\'':
+		return true
+	}
+	return false
+}
+
+func isMentionStop(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', ',', ';', ')', ']', '}', '"', '\'':
+		return true
+	}
+	return false
+}
+
+// resolveWorkDir picks the workspace root for resolution.
+func resolveWorkDir(work string) (string, error) {
+	work = strings.TrimSpace(work)
+	if work == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("atmentions: workdir: %w", err)
+		}
+		work = cwd
+	}
+	abs, err := filepath.Abs(work)
+	if err != nil {
+		return "", fmt.Errorf("atmentions: workdir: %w", err)
+	}
+	return abs, nil
+}
+
+// readMention reads one file relative to workDir and returns its
+// content. Returns content="" and a non-empty skip reason on any
+// problem.
+func readMention(workDir, rel string, blocklist toolsfs.Blocklist, maxBytes int) (string, string) {
+	if rel == "" {
+		return "", "empty path"
+	}
+	if blocked, pat := blocklist.Match(rel); blocked {
+		return "", "blocked by sensitive-file pattern " + pat
+	}
+	resolved, err := toolsfs.SafeJoin(workDir, rel)
+	if err != nil {
+		return "", err.Error()
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", "file not found"
+		}
+		return "", err.Error()
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", "refusing to follow symlink"
+	}
+	if info.IsDir() {
+		return "", "is a directory (use list_dir or find_files)"
+	}
+	if info.Size() > int64(maxBytes) {
+		return "", fmt.Sprintf("file is %d bytes, exceeds %d-byte cap", info.Size(), maxBytes)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return "", err.Error()
+	}
+	return string(data), ""
+}

--- a/cmd/glue/atmentions/atmentions_test.go
+++ b/cmd/glue/atmentions/atmentions_test.go
@@ -1,0 +1,202 @@
+package atmentions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	toolsfs "github.com/erain/glue/tools/fs"
+)
+
+func mustWrite(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoMentionsIsNoOp(t *testing.T) {
+	t.Parallel()
+	res, err := Expand("just a plain prompt with no at signs", Options{WorkDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Prompt != "just a plain prompt with no at signs" {
+		t.Fatalf("prompt mutated: %q", res.Prompt)
+	}
+	if len(res.Included) != 0 || len(res.Skipped) != 0 {
+		t.Fatalf("expected zero mentions, got %+v", res)
+	}
+}
+
+func TestExpandBareMention(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "util.go", "package util\n")
+	res, err := Expand("explain @util.go", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Prompt, "--- @util.go ---") {
+		t.Fatalf("missing header in:\n%s", res.Prompt)
+	}
+	if !strings.Contains(res.Prompt, "package util") {
+		t.Fatalf("missing content in:\n%s", res.Prompt)
+	}
+	if len(res.Included) != 1 || res.Included[0] != "util.go" {
+		t.Fatalf("included = %v", res.Included)
+	}
+}
+
+func TestExpandMultipleMentionsDedup(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "a.go", "AAA")
+	mustWrite(t, dir, "b.go", "BBB")
+	// Two mentions of a.go should produce one section.
+	res, err := Expand("see @a.go, also @a.go and @b.go too", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(res.Prompt, "--- @a.go ---") != 1 {
+		t.Fatalf("a.go appeared more than once:\n%s", res.Prompt)
+	}
+	if !strings.Contains(res.Prompt, "BBB") {
+		t.Fatalf("b.go missing:\n%s", res.Prompt)
+	}
+}
+
+func TestExpandQuotedPathWithSpaces(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "with space.txt", "spaced!")
+	res, err := Expand(`open @"with space.txt"`, Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Prompt, "spaced!") {
+		t.Fatalf("quoted path not resolved:\n%s", res.Prompt)
+	}
+}
+
+func TestExpandIgnoresEmailLikeText(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "example.com", "would be a problem")
+	res, err := Expand("contact alice@example.com please", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.Prompt, "would be a problem") {
+		t.Fatalf("email accidentally inlined:\n%s", res.Prompt)
+	}
+	if len(res.Included) != 0 {
+		t.Fatalf("email accidentally treated as mention: %v", res.Included)
+	}
+}
+
+func TestExpandEscapedDoubleAt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "param", "should not appear")
+	res, err := Expand("use @@param in prose", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.Prompt, "should not appear") {
+		t.Fatalf("@@ escape failed:\n%s", res.Prompt)
+	}
+}
+
+func TestExpandRefusesBlockedPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, ".env", "SECRET=1")
+	res, err := Expand("leak @.env please", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.Prompt, "SECRET=1") {
+		t.Fatalf(".env content leaked:\n%s", res.Prompt)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("skipped = %v, want 1", res.Skipped)
+	}
+	if !strings.Contains(res.Skipped[0].Reason, "blocked") {
+		t.Fatalf("skip reason = %q", res.Skipped[0].Reason)
+	}
+}
+
+func TestExpandRefusesPathEscape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	res, err := Expand("try @../../etc/passwd", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("skipped = %v, want 1", res.Skipped)
+	}
+}
+
+func TestExpandRefusesDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Expand("inline @sub", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 || !strings.Contains(res.Skipped[0].Reason, "directory") {
+		t.Fatalf("skipped = %+v", res.Skipped)
+	}
+}
+
+func TestExpandRefusesOversizeFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "big.txt", strings.Repeat("x", 4096))
+	res, err := Expand("inline @big.txt", Options{WorkDir: dir, MaxBytes: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 || !strings.Contains(res.Skipped[0].Reason, "exceeds") {
+		t.Fatalf("skipped = %+v", res.Skipped)
+	}
+}
+
+func TestExpandMissingFileIsSkippedNotErrored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	res, err := Expand("see @does-not-exist.go", Options{WorkDir: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 || !strings.Contains(res.Skipped[0].Reason, "not found") {
+		t.Fatalf("skipped = %+v", res.Skipped)
+	}
+	if !strings.Contains(res.Prompt, "see @does-not-exist.go") {
+		t.Fatalf("original mention should remain in prompt: %q", res.Prompt)
+	}
+}
+
+func TestBlocklistInjectable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWrite(t, dir, "internal.txt", "INTERNAL")
+	bl := toolsfs.Default().Merge("internal.txt")
+	res, err := Expand("see @internal.txt", Options{WorkDir: dir, Blocklist: bl})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("custom blocklist ignored: %+v", res)
+	}
+}

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -25,9 +25,12 @@ import (
 	"syscall"
 	"time"
 
+	"sort"
+
 	"golang.org/x/term"
 
 	"github.com/erain/glue"
+	"github.com/erain/glue/cmd/glue/atmentions"
 	"github.com/erain/glue/cmd/glue/tui"
 	"github.com/erain/glue/daemon"
 	"github.com/erain/glue/providers"
@@ -318,6 +321,9 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 	coding := flags.Bool("coding", false, "enable local coding tools for this run")
 	codingAllowOverwrite := flags.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
 	showUsage := flags.Bool("usage", false, "print token usage summary to stderr when available")
+	mode := flags.String("mode", "text", `output mode for one-shot runs: "text" (default streamed text) or "json" (JSON-Lines events)`)
+	toolsAllow := flags.String("tools", "", "comma-separated allowlist of tool names to register (empty = all configured)")
+	noTools := flags.Bool("no-tools", false, "register zero tools (read-only/text-only run)")
 	usagePricing := registerUsagePricingFlags(flags)
 	var envs envFiles
 	flags.Var(&envs, "env", "env file path; repeatable")
@@ -372,6 +378,19 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 	if err != nil {
 		return err
 	}
+	// Validate output mode. The TUI ignores --mode (it has its own
+	// rendering); --mode json applies to one-shot text-streaming runs.
+	switch strings.ToLower(*mode) {
+	case "", "text", "json":
+		// ok
+	default:
+		return fmt.Errorf("unknown --mode %q (want text or json)", *mode)
+	}
+	if interactive && strings.ToLower(*mode) == "json" {
+		return errors.New("--mode json is only valid with --prompt or piped stdin (interactive TUI has its own output)")
+	}
+	jsonMode := strings.EqualFold(*mode, "json")
+
 	if err := loadEnvFiles(envs); err != nil {
 		return err
 	}
@@ -385,6 +404,27 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 	if err != nil {
 		return err
 	}
+	// Filter the tool set down: --no-tools strips them all (a "text-only"
+	// run with no agentic capabilities); --tools is an allowlist by name.
+	// Both apply on top of --coding so the user can say
+	// `--coding --tools read_file,grep` for a read-only coding agent.
+	tools, err = filterTools(tools, *toolsAllow, *noTools)
+	if err != nil {
+		return err
+	}
+	// @file expansion happens after env load (so any path side-effects
+	// are honored) and before agent construction. Skipped mentions are
+	// reported to stderr; the user's original "@path" stays in the
+	// prompt verbatim so the model can see they asked.
+	atRes, err := atmentions.Expand(effectivePrompt, atmentions.Options{WorkDir: *workDir})
+	if err != nil {
+		return fmt.Errorf("expand @-mentions: %w", err)
+	}
+	effectivePrompt = atRes.Prompt
+	for _, skip := range atRes.Skipped {
+		fmt.Fprintf(stderr, "glue run: %s: %s\n", skip.Mention, skip.Reason)
+	}
+
 	// In interactive mode the TUI installs its own permission bridge
 	// per-prompt; the agent-level Permission is left nil so the bridge
 	// gets to render the prompt instead of fighting with the readline
@@ -395,31 +435,43 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 		fmt.Fprintf(stderr, "glue run: coding tools enabled for %s\n", *workDir)
 	}
 
-	agent, err := newAgent(newProvider, agentConfig{
-		Provider:   providerName,
-		Model:      effectiveModel,
-		StoreDir:   *storeDir,
-		WorkDir:    *workDir,
-		Tools:      tools,
-		Permission: permission,
-	})
+	// Construct the provider and store once so the TUI can reuse them
+	// for /compact (needs a Provider for SummarizingCompactor) and
+	// /resume (needs the Store to list sessions). The agent then takes
+	// the same pair via AgentOptions.
+	providerImpl, err := newProvider(providerName)
 	if err != nil {
 		return err
 	}
+	storeImpl := filestore.New(*storeDir)
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider:   providerImpl,
+		Model:      normalizeModel(effectiveModel),
+		Tools:      append([]glue.Tool(nil), tools...),
+		Store:      storeImpl,
+		WorkDir:    *workDir,
+		Permission: permission,
+	})
 
 	if interactive {
 		return tui.Run(ctx, tui.Config{
-			Agent:     agent,
-			SessionID: *id,
-			Provider:  providerName,
-			Model:     effectiveModel,
-			WorkDir:   *workDir,
-			Tools:     tools,
+			Agent:        agent,
+			SessionID:    *id,
+			Provider:     providerName,
+			Model:        effectiveModel,
+			WorkDir:      *workDir,
+			Tools:        tools,
+			Store:        storeImpl,
+			ProviderImpl: providerImpl,
 		})
 	}
 	session, err := agent.Session(ctx, *id)
 	if err != nil {
 		return err
+	}
+
+	if jsonMode {
+		return runOneShotJSON(ctx, session, effectivePrompt, *id, providerName, effectiveModel, stdout, *showUsage, usagePricing, stderr)
 	}
 
 	wroteDelta := false
@@ -444,6 +496,151 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 		writeUsageSummary(stderr, summarizeUsage(response.NewMessages), *usagePricing)
 	}
 	return nil
+}
+
+// runOneShotJSON streams loop events to stdout as JSON Lines. Event
+// shape is intentionally small and stable across releases so scripts
+// (editors, CI, /codeagent integrations) can consume it:
+//
+//	{"type":"start","session":"...","provider":"...","model":"..."}
+//	{"type":"text","delta":"..."}
+//	{"type":"tool_start","call_id":"...","name":"...","args":{...}}
+//	{"type":"tool_end","call_id":"...","is_error":false,"text":"..."}
+//	{"type":"done","text":"...","stop_reason":"..."}
+//	{"type":"error","message":"..."}
+func runOneShotJSON(
+	ctx context.Context,
+	session *glue.Session,
+	prompt, sessionID, providerName, modelName string,
+	stdout io.Writer,
+	showUsage bool,
+	pricing *usagePricing,
+	stderr io.Writer,
+) error {
+	enc := json.NewEncoder(stdout)
+	emit := func(event map[string]any) {
+		_ = enc.Encode(event)
+	}
+	emit(map[string]any{
+		"type":     "start",
+		"session":  sessionID,
+		"provider": providerName,
+		"model":    modelName,
+	})
+	response, err := session.Prompt(ctx, prompt, glue.WithEvents(func(event glue.Event) {
+		switch event.Type {
+		case glue.EventTextDelta:
+			if event.Delta == "" {
+				return
+			}
+			emit(map[string]any{"type": "text", "delta": event.Delta})
+		case glue.EventToolStart:
+			if event.ToolCall == nil {
+				return
+			}
+			var args any
+			if len(event.ToolCall.Arguments) > 0 {
+				_ = json.Unmarshal(event.ToolCall.Arguments, &args)
+			}
+			emit(map[string]any{
+				"type":    "tool_start",
+				"call_id": event.ToolCall.ID,
+				"name":    event.ToolCall.Name,
+				"args":    args,
+			})
+		case glue.EventToolEnd:
+			text := ""
+			isErr := false
+			if event.ToolResult != nil {
+				isErr = event.ToolResult.IsError
+				var parts []string
+				for _, p := range event.ToolResult.Content {
+					if p.Type == glue.ContentTypeText && p.Text != "" {
+						parts = append(parts, p.Text)
+					}
+				}
+				text = strings.Join(parts, "\n")
+			}
+			emit(map[string]any{
+				"type":     "tool_end",
+				"call_id":  event.ToolCallID,
+				"is_error": isErr,
+				"text":     text,
+			})
+		case glue.EventError:
+			if event.Error != "" {
+				emit(map[string]any{"type": "error", "message": event.Error})
+			}
+		}
+	}))
+	if err != nil {
+		emit(map[string]any{"type": "error", "message": err.Error()})
+		return err
+	}
+	stopReason := ""
+	if len(response.NewMessages) > 0 {
+		last := response.NewMessages[len(response.NewMessages)-1]
+		stopReason = string(last.StopReason)
+	}
+	emit(map[string]any{
+		"type":        "done",
+		"text":        response.Text,
+		"stop_reason": stopReason,
+	})
+	if showUsage {
+		writeUsageSummary(stderr, summarizeUsage(response.NewMessages), *pricing)
+	}
+	return nil
+}
+
+// filterTools applies --tools / --no-tools to the configured tool set.
+func filterTools(in []glue.Tool, allowCSV string, noTools bool) ([]glue.Tool, error) {
+	if noTools {
+		if strings.TrimSpace(allowCSV) != "" {
+			return nil, errors.New("--tools and --no-tools are mutually exclusive")
+		}
+		return nil, nil
+	}
+	allowCSV = strings.TrimSpace(allowCSV)
+	if allowCSV == "" {
+		return in, nil
+	}
+	want := map[string]bool{}
+	for _, raw := range strings.Split(allowCSV, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		want[name] = true
+	}
+	if len(want) == 0 {
+		return nil, nil
+	}
+	var out []glue.Tool
+	seen := map[string]bool{}
+	for _, t := range in {
+		if want[t.Name] {
+			out = append(out, t)
+			seen[t.Name] = true
+		}
+	}
+	// Refuse unknown names so a typo doesn't silently produce zero tools.
+	var missing []string
+	for name := range want {
+		if !seen[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		available := make([]string, 0, len(in))
+		for _, t := range in {
+			available = append(available, t.Name)
+		}
+		sort.Strings(available)
+		return nil, fmt.Errorf("--tools: unknown tool name(s) %v (available: %v)", missing, available)
+	}
+	return out, nil
 }
 
 func serveCommand(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, newProvider providerFactory, serve serveFunc) error {

--- a/cmd/glue/main_filtertools_test.go
+++ b/cmd/glue/main_filtertools_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func t(name string) glue.Tool {
+	return glue.Tool{ToolSpec: glue.ToolSpec{Name: name}}
+}
+
+func TestFilterToolsNoFlagsReturnsInputUnchanged(t_ *testing.T) {
+	t_.Parallel()
+	in := []glue.Tool{t("read_file"), t("write_file")}
+	out, err := filterTools(in, "", false)
+	if err != nil {
+		t_.Fatal(err)
+	}
+	if len(out) != 2 {
+		t_.Fatalf("out = %d items, want 2", len(out))
+	}
+}
+
+func TestFilterToolsNoToolsStripsAll(t_ *testing.T) {
+	t_.Parallel()
+	in := []glue.Tool{t("read_file"), t("write_file")}
+	out, err := filterTools(in, "", true)
+	if err != nil {
+		t_.Fatal(err)
+	}
+	if out != nil {
+		t_.Fatalf("out = %#v, want nil", out)
+	}
+}
+
+func TestFilterToolsAllowlistPicks(t_ *testing.T) {
+	t_.Parallel()
+	in := []glue.Tool{t("read_file"), t("write_file"), t("grep"), t("shell_exec")}
+	out, err := filterTools(in, "read_file,grep", false)
+	if err != nil {
+		t_.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, x := range out {
+		names[x.Name] = true
+	}
+	if len(out) != 2 || !names["read_file"] || !names["grep"] {
+		t_.Fatalf("out names = %v, want read_file+grep", names)
+	}
+}
+
+func TestFilterToolsAllowlistUnknownErrors(t_ *testing.T) {
+	t_.Parallel()
+	in := []glue.Tool{t("read_file")}
+	_, err := filterTools(in, "read_file,does_not_exist", false)
+	if err == nil || !strings.Contains(err.Error(), "does_not_exist") {
+		t_.Fatalf("err = %v, want unknown-tool error", err)
+	}
+}
+
+func TestFilterToolsConflictingFlagsError(t_ *testing.T) {
+	t_.Parallel()
+	in := []glue.Tool{t("read_file")}
+	_, err := filterTools(in, "read_file", true)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t_.Fatalf("err = %v, want mutual-exclusion error", err)
+	}
+}
+
+func TestFilterToolsIgnoresEmptyAndWhitespace(t_ *testing.T) {
+	t_.Parallel()
+	in := []glue.Tool{t("read_file"), t("write_file")}
+	out, err := filterTools(in, "  read_file ,, write_file  ", false)
+	if err != nil {
+		t_.Fatal(err)
+	}
+	if len(out) != 2 {
+		t_.Fatalf("out = %d items, want 2", len(out))
+	}
+}

--- a/cmd/glue/tui/commands.go
+++ b/cmd/glue/tui/commands.go
@@ -34,11 +34,13 @@ func describeCommands() string {
 	rows := []row{
 		{"/help", "show this list"},
 		{"/exit, /quit, /q", "leave the TUI"},
-		{"/clear", "start a fresh session id (transcript stays)"},
+		{"/clear, /new", "clear the transcript and start a fresh session id"},
 		{"/usage", "show this turn's token usage (when the provider reports it)"},
 		{"/tools", "list registered tools"},
 		{"/model <id>", "switch model for subsequent turns"},
 		{"/session [id]", "print current session id, or switch to <id>"},
+		{"/compact", "summarize older messages to free context window"},
+		{"/resume", "pick a past session and replay it into the transcript"},
 	}
 	sort.SliceStable(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
 	var b strings.Builder

--- a/cmd/glue/tui/sessions.go
+++ b/cmd/glue/tui/sessions.go
@@ -1,0 +1,174 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/erain/glue"
+)
+
+// sessionPicker is the modal state used by /resume: a small list view
+// pinned where the input box normally lives, navigated with ↑/↓ and
+// committed with Enter (or canceled with Esc).
+type sessionPicker struct {
+	items  []glue.SessionSummary
+	cursor int
+}
+
+func (p *sessionPicker) up() {
+	if p == nil || len(p.items) == 0 {
+		return
+	}
+	if p.cursor > 0 {
+		p.cursor--
+	}
+}
+
+func (p *sessionPicker) down() {
+	if p == nil || len(p.items) == 0 {
+		return
+	}
+	if p.cursor < len(p.items)-1 {
+		p.cursor++
+	}
+}
+
+func (p *sessionPicker) selected() (glue.SessionSummary, bool) {
+	if p == nil || p.cursor < 0 || p.cursor >= len(p.items) {
+		return glue.SessionSummary{}, false
+	}
+	return p.items[p.cursor], true
+}
+
+// pickerStyles & rendering --------------------------------------------------
+
+var (
+	pickerBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(accent).
+			Padding(0, 1)
+	pickerTitle = lipgloss.NewStyle().Foreground(accent).Bold(true)
+	pickerRow   = lipgloss.NewStyle().Foreground(inkSoft)
+	pickerSel   = lipgloss.NewStyle().Foreground(accent).Bold(true)
+	pickerHint  = lipgloss.NewStyle().Foreground(inkMuted)
+)
+
+// renderPicker returns the picker overlay. width is the full TUI width.
+func renderPicker(p *sessionPicker, width int) string {
+	w := width - 4
+	if w > 100 {
+		w = 100
+	}
+	if w < 30 {
+		w = 30
+	}
+	var b strings.Builder
+	b.WriteString(pickerTitle.Render(" Resume session "))
+	b.WriteByte('\n')
+	if len(p.items) == 0 {
+		b.WriteString(pickerRow.Render("  (no past sessions found)"))
+	} else {
+		for i, s := range p.items {
+			line := formatPickerRow(s, w-4)
+			if i == p.cursor {
+				b.WriteString(pickerSel.Render("› " + line))
+			} else {
+				b.WriteString(pickerRow.Render("  " + line))
+			}
+			if i < len(p.items)-1 {
+				b.WriteByte('\n')
+			}
+		}
+	}
+	b.WriteByte('\n')
+	b.WriteString(pickerHint.Render("  ↑/↓ navigate · Enter select · Esc cancel"))
+
+	rendered := pickerBox.Width(w).Render(b.String())
+	if w < width {
+		return lipgloss.PlaceHorizontal(width, lipgloss.Center, rendered)
+	}
+	return rendered
+}
+
+func formatPickerRow(s glue.SessionSummary, max int) string {
+	updated := "unknown"
+	if !s.UpdatedAt.IsZero() {
+		updated = humanAge(time.Since(s.UpdatedAt))
+	}
+	stats := fmt.Sprintf("%d msg", s.Messages)
+	row := fmt.Sprintf("%-32s  %12s  %s", truncate(s.ID, 32), updated, stats)
+	return truncate(row, max)
+}
+
+func humanAge(d time.Duration) string {
+	if d < time.Minute {
+		return "just now"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	}
+	days := int(d.Hours() / 24)
+	if days < 30 {
+		return fmt.Sprintf("%dd ago", days)
+	}
+	return fmt.Sprintf("%dmo ago", days/30)
+}
+
+// transcriptFromMessages converts a loaded session's messages into the
+// TUI's display transcript so /resume's selected session reads
+// naturally. Tool messages are collapsed into the preceding assistant
+// message's tool card (a single round of tool calls per assistant turn).
+func transcriptFromMessages(msgs []glue.Message) []transcriptItem {
+	out := make([]transcriptItem, 0, len(msgs))
+	for _, m := range msgs {
+		switch m.Role {
+		case glue.MessageRoleUser:
+			out = append(out, transcriptItem{Kind: itemUser, Text: collectText(m.Content)})
+		case glue.MessageRoleAssistant:
+			text := collectText(m.Content)
+			if strings.TrimSpace(text) != "" {
+				out = append(out, transcriptItem{Kind: itemAssistant, Text: text})
+			}
+			// Tool calls emitted in the assistant message arrive as
+			// content parts. Render each as a "done" card; the next tool
+			// message will fill the result.
+			for _, p := range m.Content {
+				if p.Type == glue.ContentTypeToolCall && p.ToolCall != nil {
+					out = append(out, transcriptItem{
+						Kind:       itemTool,
+						ToolCallID: p.ToolCall.ID,
+						ToolName:   p.ToolCall.Name,
+						ToolArgs:   string(p.ToolCall.Arguments),
+						ToolPhase:  tsDone,
+					})
+				}
+			}
+		case glue.MessageRoleTool:
+			// Match this tool result back to the pending tool card.
+			text := collectText(m.Content)
+			for i := len(out) - 1; i >= 0; i-- {
+				if out[i].Kind == itemTool && out[i].ToolCallID == m.ToolCallID && out[i].ToolResult == "" {
+					out[i].ToolResult = text
+					out[i].ToolErr = m.IsError
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+func collectText(parts []glue.ContentPart) string {
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Type == glue.ContentTypeText && p.Text != "" {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}

--- a/cmd/glue/tui/sessions_test.go
+++ b/cmd/glue/tui/sessions_test.go
@@ -1,0 +1,103 @@
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+func TestPickerNavigationClampsAtBounds(t *testing.T) {
+	t.Parallel()
+	p := &sessionPicker{items: []glue.SessionSummary{{ID: "a"}, {ID: "b"}, {ID: "c"}}}
+	p.up() // already at top
+	if p.cursor != 0 {
+		t.Fatalf("up at top: cursor = %d, want 0", p.cursor)
+	}
+	p.down()
+	p.down()
+	p.down() // past end
+	if p.cursor != 2 {
+		t.Fatalf("down past end: cursor = %d, want 2", p.cursor)
+	}
+	s, ok := p.selected()
+	if !ok || s.ID != "c" {
+		t.Fatalf("selected = %+v, want id=c", s)
+	}
+}
+
+func TestPickerSelectedEmpty(t *testing.T) {
+	t.Parallel()
+	p := &sessionPicker{}
+	if _, ok := p.selected(); ok {
+		t.Fatal("selected on empty picker should be !ok")
+	}
+}
+
+func TestTranscriptFromMessagesUserAssistantPair(t *testing.T) {
+	t.Parallel()
+	msgs := []glue.Message{
+		{Role: glue.MessageRoleUser, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "hello"}}},
+		{Role: glue.MessageRoleAssistant, Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "hi back"}}},
+	}
+	out := transcriptFromMessages(msgs)
+	if len(out) != 2 {
+		t.Fatalf("got %d items, want 2", len(out))
+	}
+	if out[0].Kind != itemUser || out[0].Text != "hello" {
+		t.Fatalf("user item = %+v", out[0])
+	}
+	if out[1].Kind != itemAssistant || out[1].Text != "hi back" {
+		t.Fatalf("assistant item = %+v", out[1])
+	}
+}
+
+func TestTranscriptFromMessagesPairsToolCallWithResult(t *testing.T) {
+	t.Parallel()
+	args, _ := json.Marshal(map[string]string{"path": "x.go"})
+	msgs := []glue.Message{
+		{Role: glue.MessageRoleAssistant, Content: []glue.ContentPart{
+			{Type: glue.ContentTypeText, Text: "reading the file"},
+			{Type: glue.ContentTypeToolCall, ToolCall: &glue.ToolCall{ID: "c1", Name: "read_file", Arguments: args}},
+		}},
+		{Role: glue.MessageRoleTool, ToolCallID: "c1", Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "package x"}}},
+	}
+	out := transcriptFromMessages(msgs)
+	// Expect: assistant text item, tool item with result paired in.
+	var asst, tool *transcriptItem
+	for i := range out {
+		switch out[i].Kind {
+		case itemAssistant:
+			asst = &out[i]
+		case itemTool:
+			tool = &out[i]
+		}
+	}
+	if asst == nil || tool == nil {
+		t.Fatalf("missing items: %+v", out)
+	}
+	if !strings.Contains(asst.Text, "reading the file") {
+		t.Fatalf("assistant text = %q", asst.Text)
+	}
+	if tool.ToolName != "read_file" || tool.ToolResult != "package x" || tool.ToolPhase != tsDone {
+		t.Fatalf("tool item = %+v", tool)
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	t.Parallel()
+	// Just sanity: cover the buckets so we don't regress them.
+	cases := []string{"just now", "m ago", "h ago", "d ago"}
+	got := []string{
+		humanAge(30_000_000_000),       // 30s
+		humanAge(30 * 60 * 1_000_000_000), // 30 min
+		humanAge(3 * 3600 * 1_000_000_000),
+		humanAge(48 * 3600 * 1_000_000_000),
+	}
+	for i, want := range cases {
+		if !strings.Contains(got[i], want) {
+			t.Errorf("humanAge case %d = %q, want substring %q", i, got[i], want)
+		}
+	}
+}

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"time"
+
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textarea"
@@ -18,18 +20,31 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/erain/glue"
+	"github.com/erain/glue/cmd/glue/atmentions"
 )
 
 // Config wires the TUI to a glue agent. Provider/Model/WorkDir are
 // display-only — the agent already owns them, the TUI just labels them.
 type Config struct {
-	Agent         *glue.Agent
-	SessionID     string
-	Provider      string
-	Model         string
-	WorkDir       string
-	Tools         []glue.Tool       // already registered on the agent; for /tools listing
-	BasePermission glue.Permission  // wrapped under permissionBridge so the TUI can prompt first
+	Agent          *glue.Agent
+	SessionID      string
+	Provider       string
+	Model          string
+	WorkDir        string
+	Tools          []glue.Tool     // already registered on the agent; for /tools listing
+	BasePermission glue.Permission // wrapped under permissionBridge so the TUI can prompt first
+
+	// Store is the agent's session store, passed through so /compact can
+	// write a compacted state back without reaching into Agent
+	// internals. Nil disables /compact and /resume's "load transcript"
+	// path with a friendly system message; the slash commands still
+	// parse so users discover them via /help.
+	Store glue.Store
+
+	// Provider is the live provider instance, needed only by /compact
+	// (which constructs a SummarizingCompactor on the fly). Nil disables
+	// /compact with the same friendly degradation as a missing Store.
+	ProviderImpl glue.Provider
 }
 
 // Run launches the TUI and blocks until the user quits. It returns
@@ -125,6 +140,9 @@ type Model struct {
 	// the active turn. Used to gate "thinking…" vs the actual state name
 	// in the status bar.
 	firstChunkSeen bool
+
+	// picker is the /resume modal state. Nil means "no picker open."
+	picker *sessionPicker
 
 	// Cancel-on-second-ctrl-c semantics
 	armedQuit bool
@@ -231,7 +249,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// Permission prompt takes keyboard precedence.
+		// The /resume picker, when open, owns the keyboard. It's a modal
+		// overlay; arrow keys navigate, Enter selects, Esc cancels.
+		if m.picker != nil {
+			return m.handlePickerKey(msg)
+		}
+		// Permission prompt takes keyboard precedence over normal input.
 		if m.pending != nil {
 			return m.handlePermissionKey(msg)
 		}
@@ -437,6 +460,10 @@ func (m *Model) headerView() string {
 }
 
 func (m *Model) bottomView() string {
+	// /resume picker takes over the bottom region while open.
+	if m.picker != nil {
+		return renderPicker(m.picker, m.width)
+	}
 	// Permission prompts render inside the relevant tool card now, so the
 	// input box only carries the textarea. Cap the visual width on wide
 	// terminals so it doesn't feel disconnected from the chat above.
@@ -599,8 +626,23 @@ func (m *Model) submit() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Expand @file mentions into the prompt before it's sent to the
+	// model. The user sees their original `@util.go` in the transcript;
+	// the agent sees the rewritten prompt with the file contents
+	// appended. Skipped mentions become system messages so the user
+	// knows why a file didn't get inlined.
+	atRes, atErr := atmentions.Expand(text, atmentions.Options{WorkDir: m.cfg.WorkDir})
+	if atErr != nil {
+		m.appendSystem("@-mention error: " + atErr.Error())
+		m.rerender()
+		return m, nil
+	}
+	for _, skip := range atRes.Skipped {
+		m.appendSystem(skip.Mention + ": " + skip.Reason)
+	}
+
 	m.transcript = append(m.transcript, transcriptItem{Kind: itemUser, Text: text})
-	cmd := m.startTurn(text)
+	cmd := m.startTurn(atRes.Prompt)
 	m.rerender()
 	return m, cmd
 }
@@ -665,6 +707,10 @@ func (m *Model) handleSlash(cmd slashCommand) (tea.Model, tea.Cmd) {
 		}
 		m.rerender()
 		return m, nil
+	case "compact":
+		return m.runSlashCompact()
+	case "resume":
+		return m.runSlashResume()
 	default:
 		m.appendSystem("unknown command: /" + cmd.Name + " (try /help)")
 		m.rerender()
@@ -966,4 +1012,126 @@ func workOrDot(d string) string {
 		return "."
 	}
 	return d
+}
+
+// ---------- /compact ----------
+
+func (m *Model) runSlashCompact() (tea.Model, tea.Cmd) {
+	if m.cfg.Store == nil || m.cfg.ProviderImpl == nil {
+		m.appendSystem("/compact unavailable: store or provider not wired into the TUI")
+		m.rerender()
+		return m, nil
+	}
+	if m.turn != nil {
+		m.appendSystem("/compact: a turn is running; Esc to cancel first.")
+		m.rerender()
+		return m, nil
+	}
+	cfg := m.cfg
+	parentCtx := m.ctx
+	return m, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
+		defer cancel()
+		session, err := cfg.Agent.Session(ctx, cfg.SessionID)
+		if err != nil {
+			return systemMsg("/compact: " + err.Error())
+		}
+		before := len(session.Messages())
+		comp := &glue.SummarizingCompactor{
+			Provider: cfg.ProviderImpl,
+			Model:    cfg.Model,
+		}
+		out, err := comp.Compact(ctx, session.Messages())
+		if err != nil {
+			return systemMsg("/compact failed: " + err.Error())
+		}
+		after := len(out)
+		if after >= before {
+			return systemMsg(fmt.Sprintf("/compact: nothing to compact (%d messages)", before))
+		}
+		state := session.State()
+		state.Messages = out
+		state.UpdatedAt = time.Now()
+		if err := cfg.Store.Save(ctx, cfg.SessionID, state); err != nil {
+			return systemMsg("/compact: save failed: " + err.Error())
+		}
+		return systemMsg(fmt.Sprintf("/compact: summarized %d → %d messages", before, after))
+	}
+}
+
+// ---------- /resume ----------
+
+func (m *Model) runSlashResume() (tea.Model, tea.Cmd) {
+	if m.cfg.Agent == nil {
+		m.appendSystem("/resume unavailable: no agent")
+		m.rerender()
+		return m, nil
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+	items, err := m.cfg.Agent.ListSessions(ctx, glue.ListSessionsOptions{Limit: 10})
+	if err != nil {
+		m.appendSystem("/resume: " + err.Error())
+		m.rerender()
+		return m, nil
+	}
+	// Hide the currently-active session from the picker — picking it
+	// would be a no-op.
+	filtered := make([]glue.SessionSummary, 0, len(items))
+	for _, s := range items {
+		if s.ID != m.cfg.SessionID {
+			filtered = append(filtered, s)
+		}
+	}
+	if len(filtered) == 0 {
+		m.appendSystem("/resume: no other sessions on the store.")
+		m.rerender()
+		return m, nil
+	}
+	m.picker = &sessionPicker{items: filtered}
+	m.rerender()
+	return m, nil
+}
+
+func (m *Model) handlePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc, tea.KeyCtrlC:
+		m.picker = nil
+		m.appendSystem("/resume cancelled.")
+		m.rerender()
+		return m, nil
+	case tea.KeyUp:
+		m.picker.up()
+		m.rerender()
+		return m, nil
+	case tea.KeyDown:
+		m.picker.down()
+		m.rerender()
+		return m, nil
+	case tea.KeyEnter:
+		s, ok := m.picker.selected()
+		m.picker = nil
+		if !ok {
+			m.rerender()
+			return m, nil
+		}
+		// Switch to the picked session and replay its transcript.
+		ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+		defer cancel()
+		sess, err := m.cfg.Agent.Session(ctx, s.ID)
+		if err != nil {
+			m.appendSystem("/resume: " + err.Error())
+			m.rerender()
+			return m, nil
+		}
+		m.cfg.SessionID = s.ID
+		m.transcript = nil
+		m.appendSystem("resumed: " + s.ID)
+		m.transcript = append(m.transcript, transcriptFromMessages(sess.Messages())...)
+		m.turnNum = 0
+		m.lastUsage = nil
+		m.rerender()
+		return m, nil
+	}
+	return m, nil
 }

--- a/store.go
+++ b/store.go
@@ -2,8 +2,16 @@ package glue
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrSessionListingNotSupported is returned when the active [Store]
+// does not implement [SessionLister]. Callers (e.g. a TUI session
+// picker) should treat this as "no session catalog available" and
+// degrade gracefully — show only the current session id, hide the
+// picker, etc.
+var ErrSessionListingNotSupported = errors.New("glue: store does not support session listing")
 
 // SessionStateVersion is the on-disk version tag for [SessionState].
 const SessionStateVersion = 1


### PR DESCRIPTION
## Summary

Closes the five highest-leverage gaps between `glue` and `earendil-works/pi`'s `pi-coding-agent`. The three architectural pieces (session tree / RPC mode / Anthropic provider) stay out of scope; each deserves its own focused PR.

### What lands

- **`@file` argument expansion.** New `cmd/glue/atmentions` package. Used by both the one-shot `--prompt` path in `main.go` and the TUI submit handler, so the user writes `tell me about @util.go and @main.go` and the model sees the file contents under `--- @path ---` headers. Supports `@"path with space"` for spaces and `@@literal` to escape. Workspace-rooted; refuses path-escape, secret-shaped (`tools/fs` `Blocklist`), symlinks, directories, and oversized files. Skipped mentions surface as stderr lines or system messages — never silent.
- **`--tools <name,name,...>` allowlist + `--no-tools` strip on `glue run`.** Unknown names error with the available list (no silent typos). Mutually exclusive.
- **`--mode json` one-shot output mode.** Stable JSONL events on stdout (`start`, `text`, `tool_start`, `tool_end`, `done`, `error`) for scripting and IDE integration. Interactive TUI ignores `--mode`.
- **`/compact` slash command in the TUI.** Runs a `SummarizingCompactor` over the current session, saves the compacted state back via `Store.Save`, and reports `before → after` message counts as a system message.
- **`/resume` session picker in the TUI.** Modal list of the ten most-recent stored sessions (`↑/↓` navigate, `Enter` select, `Esc` cancel); replays the picked session's transcript into the TUI. Requires a `SessionLister`-capable store.

### Library additions (needed only by `/resume`)

- `glue.Agent.ListSessions(ctx, opts)` mirrors `Agent.SearchSessions`: delegates to a `SessionLister`-capable store, or returns the new `ErrSessionListingNotSupported` sentinel.

`tui.Config` gains optional `Store` + `ProviderImpl` fields (named `*Impl` to avoid colliding with the display-only `Provider` string already there). `cmd/glue/main.go` now constructs the provider + store once and shares them between the agent and the TUI.

Closes #297

## Verification

```
go build ./...      # ok
go vet ./...        # ok
go test ./...       # ok (existing + 22 new tests)
```

Manual smoke confirms the four guardrails fire cleanly:

```
$ glue run --mode bogus --prompt x
unknown --mode "bogus" (want text or json)

$ glue run --tools read_file --no-tools --prompt x ...
--tools and --no-tools are mutually exclusive

$ glue run --tools nope --prompt x ...
--tools: unknown tool name(s) [nope] (available: [...])

$ glue run --work /tmp/x --prompt "summarize @x.go and @missing.go" ...
glue run: @missing.go: file not found
(then proceeds with @x.go inlined)
```

### New tests

- `cmd/glue/atmentions` (13): no-mentions no-op, bare/quoted mentions, dedup, email-like text ignored, `@@` escape, blocked/escape/directory/oversize/missing/custom-blocklist skip paths.
- `cmd/glue` (6): `filterTools` exercise for empty / `--no-tools` / allowlist / unknown-error / mutex-error / whitespace-trim.
- `cmd/glue/tui` (3 + helpers): picker clamping, picker on empty, `transcriptFromMessages` user/assistant + tool-pair, `humanAge` bucket sanity.

## Out of scope (filed as follow-ups when desired)

- Session tree / fork / clone (`/tree`, `/fork`, `/clone`) — needs an ADR.
- RPC mode (`--mode rpc`).
- `providers/anthropic`.
- Differential TUI rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
