### PR TITLE
providers/gemini: default to gemini-3.1-pro (closes #303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Default Gemini model is now `gemini-3.1-pro`** (was `gemini-2.5-flash`).
+  `gemini-2.5-flash` was removed from the v1beta `generateContent`
+  API and began returning 404 for users on the current key surface.
+  `gemini-3.1-pro` is the unmetered daily-driver target for this
+  project. Override at any time with `--model <id>` or `GLUE_MODEL`.
+  Library callers can still pass any model id through
+  `loop.ProviderRequest.Model` or `gemini.Options.DefaultModel`.
+
+## 1.3.0 — 2026-06-08
+
 - Added `cmd/glue` interactive TUI. `glue run` with no `--prompt` and a
   terminal on stdin+stdout now opens a bubbletea-based interactive
   coding agent: scrollable transcript, multi-line input, streaming

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inspired by [Flue](https://github.com/withastro/flue) and
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: gemini.New(gemini.Options{}),
-	Model:    "gemini-2.5-flash",
+	Model:    "gemini-3.1-pro",
 	Tools:    []glue.Tool{weatherTool},
 })
 session, _ := agent.Session(ctx, "demo")
@@ -68,7 +68,7 @@ func main() {
 	ctx := context.Background()
 	agent := glue.NewAgent(glue.AgentOptions{
 		Provider: gemini.New(gemini.Options{}),
-		Model:    "gemini-2.5-flash",
+		Model:    "gemini-3.1-pro",
 	})
 	session, err := agent.Session(ctx, "demo")
 	if err != nil {

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -2779,7 +2779,7 @@ func TestResolveProvider(t *testing.T) {
 		wantModel string
 		wantErr   string
 	}{
-		{name: "default empty selects gemini", provider: "", model: "", wantName: "gemini", wantModel: "gemini-2.5-flash"},
+		{name: "default empty selects gemini", provider: "", model: "", wantName: "gemini", wantModel: "gemini-3.1-pro"},
 		{name: "codex default model", provider: "codex", model: "", wantName: "codex", wantModel: "gpt-5-codex"},
 		{name: "explicit model overrides default", provider: "gemini", model: "gemini-2.0-pro", wantName: "gemini", wantModel: "gemini-2.0-pro"},
 		{name: "case insensitive name", provider: "CodeX", model: "", wantName: "codex", wantModel: "gpt-5-codex"},

--- a/docs/building-agents.md
+++ b/docs/building-agents.md
@@ -68,7 +68,7 @@ func main() {
 
 	agent := glue.NewAgent(glue.AgentOptions{
 		Provider: gemini.New(gemini.Options{}), // reads GEMINI_API_KEY
-		Model:    "gemini-2.5-flash",
+		Model:    "gemini-3.1-pro",
 	})
 
 	session, err := agent.Session(ctx, "demo")
@@ -132,7 +132,7 @@ Register it on the agent:
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: gemini.New(gemini.Options{}),
-	Model:    "gemini-2.5-flash",
+	Model:    "gemini-3.1-pro",
 	Tools:    []glue.Tool{weatherTool()},
 })
 ```
@@ -158,7 +158,7 @@ import filestore "github.com/erain/glue/stores/file"
 
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: gemini.New(gemini.Options{}),
-	Model:    "gemini-2.5-flash",
+	Model:    "gemini-3.1-pro",
 	Store:    filestore.New(".glue/sessions"),
 })
 ```
@@ -231,7 +231,7 @@ Set `WorkDir` and Glue discovers Markdown context on disk:
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: prov,
-	Model:    "gemini-2.5-flash",
+	Model:    "gemini-3.1-pro",
 	WorkDir:  ".",
 	Roles: []glue.Role{
 		{Name: "reviewer", Model: "gemini-2.5-pro", Instructions: "Review for SQL safety."},
@@ -262,7 +262,7 @@ if err != nil { log.Fatal(err) }
 
 orchestrator := glue.NewAgent(glue.AgentOptions{
 	Provider: prov,
-	Model:    "gemini-2.5-flash",
+	Model:    "gemini-3.1-pro",
 	Tools:    []glue.Tool{researchTool},
 })
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -231,7 +231,7 @@ Target P0 shape:
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
     Provider: gemini.New(gemini.Options{APIKey: os.Getenv("GEMINI_API_KEY")}),
-    Model:    "gemini-2.5-flash",
+    Model:    "gemini-3.1-pro",
     Tools:    []glue.Tool{weatherTool},
 })
 

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -20,7 +20,13 @@ import (
 const EnvKey = "GEMINI_API_KEY"
 
 // DefaultModel is the registry-level default model for this provider.
-const DefaultModel = "gemini-2.5-flash"
+//
+// gemini-3.1-pro is the daily-driver default per maintainer direction: it
+// is the model the project's primary key has unmetered access to, and it
+// is currently the most capable Gemini for coding-agent workloads. The
+// previous default (gemini-2.5-flash) was removed from the v1beta API and
+// began returning 404 on generateContent.
+const DefaultModel = "gemini-3.1-pro"
 
 const providerName = "gemini"
 


### PR DESCRIPTION
Closes #303.

\`gemini-2.5-flash\` was removed from \`generativelanguage.googleapis.com\` v1beta and started returning 404 on \`generateContent\` for our key. Switching the registry default to \`gemini-3.1-pro\` — the unmetered daily-driver target for this project and currently the most capable Gemini for coding-agent workloads.

## Change

- \`providers/gemini/gemini.go\`: \`DefaultModel = \"gemini-3.1-pro\"\` with rationale comment.
- \`cmd/glue/main_test.go\`: update default-resolution expectation.
- \`README.md\`, \`docs/building-agents.md\`, \`docs/design.md\`: sample snippets.
- \`CHANGELOG.md\`: roll Unreleased → \`1.3.0 — 2026-06-08\` (the just-shipped tag), open a new Unreleased with the v1.4.0-bound entry.

## Override paths still work

- CLI: \`glue run --model gemini-2.5-pro\`
- Env: \`GLUE_MODEL=gemini-2.5-pro\`
- Library: \`gemini.Options{DefaultModel: \"gemini-2.5-pro\"}\` or \`loop.ProviderRequest{Model: \"gemini-2.5-pro\"}\`

Will tag \`v1.4.0\` on merge per the per-improvement-version protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)