### PR TITLE
cmd/glue + tui: cap transcript width, add 'glue version' (closes #307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **TUI: cap transcript at 100 cols, center on wide terminals
+  (`cmd/glue/tui`).** The viewport used to stretch to the full terminal
+  width, so on a 200-col terminal the assistant text wrapped at the
+  right edge and read as a wall. Now `bodyMaxWidth = 100` (locked to
+  the input box width) caps the conversation column and `View()`
+  centers it inside `m.width` via `lipgloss.PlaceHorizontal`. Glamour
+  markdown renderer width inherits the cap so wrapping aligns. Header
+  and status bar stay full-width — they read better edge-to-edge.
+  Closes #307.
+- **`glue version` / `glue --version` / `glue -v`.** Prints the module
+  version, git revision, build time, and Go toolchain from the linker-
+  embedded build info (same data as `go version -m $(which glue)`),
+  reachable as a first-class subcommand so users can self-diagnose a
+  stale binary without a side command.
+
+## 1.5.0 — 2026-06-08
+
 - **Catppuccin TUI theme (`cmd/glue/tui`).** Replaced the slate +
   Tailwind-primary palette with Catppuccin Mocha (dark) and Latte
   (light), picked at construction time by lipgloss's terminal-

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -21,6 +21,8 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -279,6 +281,10 @@ func runCLIWithServe(ctx context.Context, args []string, stdout io.Writer, stder
 func runCLIWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, newProvider providerFactory, serve serveFunc, client httpDoer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printUsage(stdout)
+		return 0
+	}
+	if args[0] == "version" || args[0] == "-v" || args[0] == "--version" {
+		printVersion(stdout)
 		return 0
 	}
 
@@ -2764,6 +2770,42 @@ func httpStatusError(resp *http.Response) string {
 	return resp.Status
 }
 
+// printVersion writes a short version banner sourced from the linker-
+// embedded Go build info: module version, git revision, build time, and
+// Go toolchain version. Identical content to what `go version -m
+// $(which glue)` exposes but reachable as `glue version` / `--version`
+// so users can self-diagnose stale binaries without running a side
+// command.
+func printVersion(w io.Writer) {
+	mod := "(devel)"
+	rev := ""
+	when := ""
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" {
+			mod = v
+		}
+		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				rev = s.Value
+				if len(rev) > 12 {
+					rev = rev[:12]
+				}
+			case "vcs.time":
+				when = s.Value
+			}
+		}
+	}
+	fmt.Fprintf(w, "glue %s", mod)
+	if rev != "" {
+		fmt.Fprintf(w, " (%s)", rev)
+	}
+	if when != "" {
+		fmt.Fprintf(w, " · built %s", when)
+	}
+	fmt.Fprintf(w, " · %s\n", runtime.Version())
+}
+
 func printUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
   glue run --prompt <text> [--provider <name>] [--id <id>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
@@ -2790,6 +2832,7 @@ Commands:
   run      Run a local agent on any registered provider, optionally with coding tools.
   serve    Start a local HTTP+SSE daemon for Glue sessions, optionally with coding tools.
   connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP/recall surfaces.
+  version  Print the binary's version, git revision, and Go toolchain (also: --version, -v).
 
 Flags:
   --id       Session id. Defaults to "default".

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -95,6 +95,32 @@ func TestRunCLIHelp(t *testing.T) {
 	}
 }
 
+func TestRunCLIVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, arg := range []string{"version", "--version", "-v"} {
+		arg := arg
+		t.Run(arg, func(t *testing.T) {
+			t.Parallel()
+			var stdout bytes.Buffer
+			code := runCLI(context.Background(), []string{arg}, &stdout, io.Discard, fakeFactory(nil))
+			if code != 0 {
+				t.Fatalf("code = %d, want 0", code)
+			}
+			out := stdout.String()
+			if !strings.HasPrefix(out, "glue ") {
+				t.Fatalf("version output should start with 'glue ': %q", out)
+			}
+			// The Go toolchain banner always lands; everything else (module
+			// version, vcs revision, build time) is conditional on how the
+			// binary was produced.
+			if !strings.Contains(out, "go") {
+				t.Fatalf("version output missing toolchain: %q", out)
+			}
+		})
+	}
+}
+
 func TestRunCLINoArgsPrintsHelp(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/glue/tui/layout_test.go
+++ b/cmd/glue/tui/layout_test.go
@@ -1,0 +1,105 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestLayoutCapsViewportAtBodyMaxWidth asserts that on a wide terminal
+// the transcript viewport gets capped at bodyMaxWidth instead of
+// stretching across the screen — fixes #307.
+func TestLayoutCapsViewportAtBodyMaxWidth(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		termW    int
+		wantVPW  int
+	}{
+		{"narrow stays uncapped", 60, 60},
+		{"at exactly cap", bodyMaxWidth, bodyMaxWidth},
+		{"wide gets capped", 200, bodyMaxWidth},
+		{"very wide gets capped", 400, bodyMaxWidth},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			m := newTestModel(t)
+			m.width = c.termW
+			m.height = 40
+			m.layout()
+			if m.viewport.Width != c.wantVPW {
+				t.Fatalf("viewport.Width = %d, want %d (term=%d)",
+					m.viewport.Width, c.wantVPW, c.termW)
+			}
+		})
+	}
+}
+
+// TestViewCentersBodyOnWideTerminal asserts that when the terminal is
+// wider than bodyMaxWidth, the rendered View output has leading
+// horizontal padding (lipgloss centers the body) so the conversation
+// doesn't pin to the left edge.
+func TestViewCentersBodyOnWideTerminal(t *testing.T) {
+	t.Parallel()
+	m := newTestModel(t)
+	// Simulate WindowSizeMsg for a wide terminal.
+	m.Update(tea.WindowSizeMsg{Width: 200, Height: 40})
+
+	out := m.View()
+	if out == "" {
+		t.Fatal("View returned empty on a ready model")
+	}
+	// On a 200-col terminal the body is rendered at 100 cols and centered.
+	// We check that at least one of the body rows starts with whitespace
+	// (the centering pad) rather than a glyph at column 0.
+	lines := strings.Split(out, "\n")
+	hasLeadingPad := false
+	for _, line := range lines {
+		// Skip header and status which run edge-to-edge.
+		if line == "" || strings.HasPrefix(line, " glue") {
+			continue
+		}
+		// Strip ANSI escape sequences before checking the leading column.
+		stripped := stripANSI(line)
+		if stripped == "" {
+			continue
+		}
+		if strings.HasPrefix(stripped, "          ") { // 10+ spaces = centered pad
+			hasLeadingPad = true
+			break
+		}
+	}
+	if !hasLeadingPad {
+		t.Errorf("expected centering pad on wide terminal; got View:\n%s",
+			truncate(out, 400))
+	}
+}
+
+// TestLayoutKeepsViewportFullOnNarrowTerminal asserts that a terminal
+// narrower than bodyMaxWidth still gets the viewport at full width —
+// no horizontal pad on narrow terminals.
+func TestLayoutKeepsViewportFullOnNarrowTerminal(t *testing.T) {
+	t.Parallel()
+	m := newTestModel(t)
+	m.width = 80
+	m.height = 40
+	m.layout()
+	if m.viewport.Width != 80 {
+		t.Fatalf("viewport.Width = %d, want 80 (no pad on narrow)", m.viewport.Width)
+	}
+}
+
+// newTestModel builds a minimal Model wired enough to call Update and
+// View without panicking — no real Agent, no real store. We rely on
+// the fact that layout/view paths only need the textarea, viewport,
+// spinner, and width fields to be initialized.
+func newTestModel(t *testing.T) *Model {
+	t.Helper()
+	return newModel(context.Background(), Config{})
+}
+
+// (uses stripANSI from transcript_test.go)

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -261,12 +261,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		// Glamour needs a width; we compute the assistant-render width to
-		// match the transcript body so wrapping aligns with what the user sees.
+		// Glamour needs a width; match the transcript body so wrapping
+		// aligns with what the user sees. We cap at bodyMaxWidth for the
+		// same reason layout() does — see the constant's doc.
+		mdW := msg.Width
+		if mdW > bodyMaxWidth {
+			mdW = bodyMaxWidth
+		}
 		if m.md == nil {
-			m.md = newMarkdownRenderer(msg.Width)
+			m.md = newMarkdownRenderer(mdW)
 		} else {
-			m.md.Resize(msg.Width)
+			m.md.Resize(mdW)
 		}
 		m.layout()
 		m.ready = true
@@ -368,6 +373,12 @@ func (m *Model) View() string {
 	}
 	header := m.headerView()
 	body := m.viewport.View()
+	// Center the transcript body inside the full terminal width on wide
+	// terminals — viewport itself is capped at bodyMaxWidth by layout(),
+	// so without this it would sit pinned to the left edge.
+	if m.width > bodyMaxWidth {
+		body = lipgloss.PlaceHorizontal(m.width, lipgloss.Center, body)
+	}
 	bottom := m.bottomView()
 	status := m.statusView()
 
@@ -386,6 +397,13 @@ func (m *Model) View() string {
 // doesn't stretch across a wall and feel disconnected from the
 // conversation centered above it.
 const inputMaxBoxWidth = 100
+
+// bodyMaxWidth caps the transcript viewport on wide terminals. Locked
+// to the input box width so the conversation column and the input box
+// align. Without this cap, assistant text wraps at the right edge of a
+// 200-col terminal and reads as a wall of text. Header and status bar
+// keep full width — they read better edge-to-edge.
+const bodyMaxWidth = inputMaxBoxWidth
 
 func (m *Model) layout() {
 	if m.width <= 0 || m.height <= 0 {
@@ -413,7 +431,13 @@ func (m *Model) layout() {
 	if bodyH < 3 {
 		bodyH = 3
 	}
-	m.viewport.Width = m.width
+	// Cap the viewport at bodyMaxWidth and let View() center it inside
+	// m.width on wide terminals. Keeps the conversation column readable.
+	vpW := m.width
+	if vpW > bodyMaxWidth {
+		vpW = bodyMaxWidth
+	}
+	m.viewport.Width = vpW
 	m.viewport.Height = bodyH
 
 	// Inner textarea width is the box width minus border (2) and


### PR DESCRIPTION
Closes #307.

Two daily-driver fixes bundled because they're both surfaced by the user-reported friction "output is too wide" + "binary not updated yet."

## 1. Transcript width cap + center

The TUI viewport was rendering at \`m.width\`. On wide terminals (≥120 cols) the assistant text wrapped at the right edge and read as a wall. The input box already had \`inputMaxBoxWidth = 100\` (#296); the transcript now follows via \`bodyMaxWidth = inputMaxBoxWidth\` so the two stay locked.

- \`layout()\` caps \`viewport.Width\` at \`bodyMaxWidth\`.
- \`WindowSizeMsg\` caps the markdown renderer width too so glamour wrapping aligns.
- \`View()\` wraps \`body\` in \`lipgloss.PlaceHorizontal(m.width, .Center, body)\` when terminal is wider than \`bodyMaxWidth\`.
- Header + status bar keep full width — they read better edge-to-edge.

## 2. \`glue version\` subcommand

User had to run \`go version -m \$(which glue)\` to diagnose a stale binary. That's a foot-gun for daily-driver use. Now:

\`\`\`
$ glue version
glue v1.6.0 (88126f1...) · built 2026-06-08T... · go1.25
\`\`\`

Sourced from \`runtime/debug.ReadBuildInfo\` — same module/vcs/time fields \`go version -m\` reads, no Makefile-baked ldflags needed.

Also reachable as \`--version\` and \`-v\`.

## Tests

- \`TestLayoutCapsViewportAtBodyMaxWidth\` (4 subcases)
- \`TestViewCentersBodyOnWideTerminal\`
- \`TestLayoutKeepsViewportFullOnNarrowTerminal\`
- \`TestRunCLIVersion\` (3 subcases: \`version\`, \`--version\`, \`-v\`)

Tag \`v1.6.0\` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)