### PR TITLE
providers/gemini: default to gemini-3.1-pro-preview (closes #309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Fix Gemini default id: `gemini-3.1-pro-preview`, not `gemini-3.1-pro`.**
+  v1.4.0 set the default to `gemini-3.1-pro`, which 404s — the public
+  id on `generativelanguage.googleapis.com` v1beta carries the
+  `-preview` suffix. Verified against `ListModels`. Override paths
+  remain unchanged: `--model`, `GLUE_MODEL`, or
+  `gemini.Options.DefaultModel`.
+
+## 1.6.0 — 2026-06-08
+
 - **TUI: cap transcript at 100 cols, center on wide terminals
   (`cmd/glue/tui`).** The viewport used to stretch to the full terminal
   width, so on a 200-col terminal the assistant text wrapped at the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inspired by [Flue](https://github.com/withastro/flue) and
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: gemini.New(gemini.Options{}),
-	Model:    "gemini-3.1-pro",
+	Model:    "gemini-3.1-pro-preview",
 	Tools:    []glue.Tool{weatherTool},
 })
 session, _ := agent.Session(ctx, "demo")
@@ -68,7 +68,7 @@ func main() {
 	ctx := context.Background()
 	agent := glue.NewAgent(glue.AgentOptions{
 		Provider: gemini.New(gemini.Options{}),
-		Model:    "gemini-3.1-pro",
+		Model:    "gemini-3.1-pro-preview",
 	})
 	session, err := agent.Session(ctx, "demo")
 	if err != nil {

--- a/cmd/glue/main_test.go
+++ b/cmd/glue/main_test.go
@@ -2805,7 +2805,7 @@ func TestResolveProvider(t *testing.T) {
 		wantModel string
 		wantErr   string
 	}{
-		{name: "default empty selects gemini", provider: "", model: "", wantName: "gemini", wantModel: "gemini-3.1-pro"},
+		{name: "default empty selects gemini", provider: "", model: "", wantName: "gemini", wantModel: "gemini-3.1-pro-preview"},
 		{name: "codex default model", provider: "codex", model: "", wantName: "codex", wantModel: "gpt-5-codex"},
 		{name: "explicit model overrides default", provider: "gemini", model: "gemini-2.0-pro", wantName: "gemini", wantModel: "gemini-2.0-pro"},
 		{name: "case insensitive name", provider: "CodeX", model: "", wantName: "codex", wantModel: "gpt-5-codex"},

--- a/docs/building-agents.md
+++ b/docs/building-agents.md
@@ -68,7 +68,7 @@ func main() {
 
 	agent := glue.NewAgent(glue.AgentOptions{
 		Provider: gemini.New(gemini.Options{}), // reads GEMINI_API_KEY
-		Model:    "gemini-3.1-pro",
+		Model:    "gemini-3.1-pro-preview",
 	})
 
 	session, err := agent.Session(ctx, "demo")
@@ -132,7 +132,7 @@ Register it on the agent:
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: gemini.New(gemini.Options{}),
-	Model:    "gemini-3.1-pro",
+	Model:    "gemini-3.1-pro-preview",
 	Tools:    []glue.Tool{weatherTool()},
 })
 ```
@@ -158,7 +158,7 @@ import filestore "github.com/erain/glue/stores/file"
 
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: gemini.New(gemini.Options{}),
-	Model:    "gemini-3.1-pro",
+	Model:    "gemini-3.1-pro-preview",
 	Store:    filestore.New(".glue/sessions"),
 })
 ```
@@ -231,7 +231,7 @@ Set `WorkDir` and Glue discovers Markdown context on disk:
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
 	Provider: prov,
-	Model:    "gemini-3.1-pro",
+	Model:    "gemini-3.1-pro-preview",
 	WorkDir:  ".",
 	Roles: []glue.Role{
 		{Name: "reviewer", Model: "gemini-2.5-pro", Instructions: "Review for SQL safety."},
@@ -262,7 +262,7 @@ if err != nil { log.Fatal(err) }
 
 orchestrator := glue.NewAgent(glue.AgentOptions{
 	Provider: prov,
-	Model:    "gemini-3.1-pro",
+	Model:    "gemini-3.1-pro-preview",
 	Tools:    []glue.Tool{researchTool},
 })
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -231,7 +231,7 @@ Target P0 shape:
 ```go
 agent := glue.NewAgent(glue.AgentOptions{
     Provider: gemini.New(gemini.Options{APIKey: os.Getenv("GEMINI_API_KEY")}),
-    Model:    "gemini-3.1-pro",
+    Model:    "gemini-3.1-pro-preview",
     Tools:    []glue.Tool{weatherTool},
 })
 

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -21,12 +21,17 @@ const EnvKey = "GEMINI_API_KEY"
 
 // DefaultModel is the registry-level default model for this provider.
 //
-// gemini-3.1-pro is the daily-driver default per maintainer direction: it
-// is the model the project's primary key has unmetered access to, and it
-// is currently the most capable Gemini for coding-agent workloads. The
-// previous default (gemini-2.5-flash) was removed from the v1beta API and
-// began returning 404 on generateContent.
-const DefaultModel = "gemini-3.1-pro"
+// gemini-3.1-pro-preview is the daily-driver default per maintainer
+// direction: it is the model the project's primary key has unmetered
+// access to, and it is currently the most capable Gemini for coding-
+// agent workloads. Verified against ListModels — the public id carries
+// the -preview suffix (v1.4.0 mistakenly used "gemini-3.1-pro" without
+// it, which 404s). The previous default (gemini-2.5-flash) was removed
+// from the v1beta API outright. The companion id
+// gemini-3.1-pro-preview-customtools is a separate beta surface for
+// Google's CustomTools API; our function-calling path uses the standard
+// Tool spec so the base id is correct.
+const DefaultModel = "gemini-3.1-pro-preview"
 
 const providerName = "gemini"
 


### PR DESCRIPTION
Closes #309. Follow-up to #304 (v1.4.0).

\`gemini-3.1-pro\` 404s on v1beta generateContent. The public id carries the \`-preview\` suffix; \`ListModels\` confirms:

\`\`\`
models/gemini-3.1-pro-preview            <-- this one
models/gemini-3.1-pro-preview-customtools
models/gemini-3-pro-preview
models/gemini-pro-latest
...
\`\`\`

(\`-customtools\` is Google's separate CustomTools beta API. Our path uses standard Tool spec → base id is correct.)

## Change

- \`providers/gemini/gemini.go\`: \`DefaultModel = \"gemini-3.1-pro-preview\"\`
- \`cmd/glue/main_test.go\`: default-resolution expectation
- README + docs: sample snippets
- CHANGELOG: roll Unreleased → \`1.6.0 — 2026-06-08\`, open new Unreleased for v1.7.0

## Override paths still work

- \`glue run --model gemini-2.5-pro\`
- \`GLUE_MODEL=gemini-2.5-pro\`
- \`gemini.Options{DefaultModel: \"gemini-2.5-pro\"}\` or \`loop.ProviderRequest{Model: \"gemini-2.5-pro\"}\`

Tag \`v1.7.0\` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)