### PR TITLE
providers/gemini: round-trip thoughtSignature + enable includeThoughts (closes #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Fix Gemini 3.x tool calls: round-trip `thoughtSignature` (`providers/gemini`).**
+  Gemini 3.x (incl. the default `gemini-3.1-pro-preview`) returns an opaque
+  `thoughtSignature` on the parts it produces and **requires** it echoed back
+  on replay; without it the second turn of any tool-using conversation failed
+  with `400 … Function call is missing a thought_signature in functionCall
+  parts`. The provider now captures the signature from function-call and
+  thought parts (stored base64 on `ContentPart.Signature`) and replays it
+  verbatim, sends prior thinking back as real `thought` parts, and enables
+  `includeThoughts` on Gemini 3.x so reasoning streams through. Verified live
+  with a two-turn tool loop. (Also points the gated live smoke test at the
+  provider default; it hardcoded the now-removed `gemini-2.5-flash`.)
+
 - **Fix Gemini default id: `gemini-3.1-pro-preview`, not `gemini-3.1-pro`.**
   v1.4.0 set the default to `gemini-3.1-pro`, which 404s — the public
   id on `generativelanguage.googleapis.com` v1beta carries the

--- a/providers/gemini/convert.go
+++ b/providers/gemini/convert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/erain/glue/loop"
 
@@ -68,7 +69,11 @@ func convertMessage(message loop.Message) (*genai.Content, error) {
 			}
 		case loop.ContentTypeThinking:
 			if part.Thinking != "" {
-				parts = append(parts, genai.NewPartFromText(part.Thinking))
+				thought := &genai.Part{Text: part.Thinking, Thought: true}
+				if sig := decodeSignature(part.Signature); len(sig) > 0 {
+					thought.ThoughtSignature = sig
+				}
+				parts = append(parts, thought)
 			}
 		case loop.ContentTypeImage:
 			if part.Image == nil {
@@ -87,11 +92,17 @@ func convertMessage(message loop.Message) (*genai.Content, error) {
 			if err != nil {
 				return nil, fmt.Errorf("gemini: tool call %q arguments: %w", part.ToolCall.Name, err)
 			}
-			parts = append(parts, &genai.Part{FunctionCall: &genai.FunctionCall{
+			call := &genai.Part{FunctionCall: &genai.FunctionCall{
 				ID:   part.ToolCall.ID,
 				Name: part.ToolCall.Name,
 				Args: args,
-			}})
+			}}
+			// Echo the thought signature the model produced for this call.
+			// Gemini 3.x rejects a replayed function call that has lost it.
+			if sig := decodeSignature(part.Signature); len(sig) > 0 {
+				call.ThoughtSignature = sig
+			}
+			parts = append(parts, call)
 		default:
 			return nil, fmt.Errorf("gemini: unsupported content type %q", part.Type)
 		}
@@ -155,6 +166,39 @@ func ConvertTools(tools []loop.ToolSpec) ([]*genai.Tool, error) {
 	return []*genai.Tool{{FunctionDeclarations: declarations}}, nil
 }
 
+// encodeSignature base64-encodes an opaque thought signature for storage on a
+// loop.ContentPart. Empty signatures stay empty so transcripts don't carry
+// noise.
+func encodeSignature(sig []byte) string {
+	if len(sig) == 0 {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+// decodeSignature reverses encodeSignature. A corrupt or non-base64 value
+// (e.g. a hand-edited transcript) decodes to nil rather than failing the whole
+// request — a missing signature is recoverable, a hard error is not.
+func decodeSignature(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	sig, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil
+	}
+	return sig
+}
+
+// isModernGeminiModel reports whether the model belongs to the Gemini 3.x
+// family. Those ids emit opaque thought signatures that the API requires
+// echoed back on replay and benefit from includeThoughts; 2.5 and earlier do
+// neither. The id may carry suffixes (e.g. "gemini-3.1-pro-preview"), so match
+// on the family prefix.
+func isModernGeminiModel(model string) bool {
+	return strings.Contains(model, "gemini-3")
+}
+
 func rawObject(raw json.RawMessage) (map[string]any, error) {
 	if len(raw) == 0 {
 		return map[string]any{}, nil
@@ -180,7 +224,7 @@ func rawSchema(raw json.RawMessage) (any, error) {
 	return schema, nil
 }
 
-func buildGenerateConfig(req loop.ProviderRequest) (*genai.GenerateContentConfig, error) {
+func buildGenerateConfig(req loop.ProviderRequest, model string) (*genai.GenerateContentConfig, error) {
 	config := &genai.GenerateContentConfig{}
 	if req.SystemPrompt != "" {
 		config.SystemInstruction = genai.NewContentFromText(req.SystemPrompt, genai.RoleUser)
@@ -190,6 +234,16 @@ func buildGenerateConfig(req loop.ProviderRequest) (*genai.GenerateContentConfig
 		return nil, err
 	}
 	config.Tools = tools
+
+	// Surface the model's reasoning on Gemini 3.x: includeThoughts streams
+	// thought parts (and the signatures attached to them) so callers can show
+	// thinking and so signed thoughts round-trip. The function-call signature
+	// the API requires on replay is returned regardless of this flag, so it is
+	// complementary, not load-bearing. Older ids neither emit thoughts nor
+	// need the flag, so leave them untouched.
+	if isModernGeminiModel(model) {
+		config.ThinkingConfig = &genai.ThinkingConfig{IncludeThoughts: true}
+	}
 
 	for key, value := range req.Options {
 		switch key {

--- a/providers/gemini/doc.go
+++ b/providers/gemini/doc.go
@@ -6,4 +6,9 @@
 // normalized loop types. The model comes from AgentOptions.Model, a
 // per-call WithModel, or the provider default. The API key is taken from
 // Options.APIKey or the GEMINI_API_KEY environment variable.
+//
+// Gemini 3.x returns an opaque thought signature on the parts it produces and
+// requires it echoed back on replay; the provider captures it (base64-encoded
+// on loop.ContentPart.Signature) and restores it on the next request so
+// multi-turn tool conversations do not fail validation.
 package gemini

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -94,7 +94,7 @@ func (p *Provider) Stream(ctx context.Context, req loop.ProviderRequest) (<-chan
 	if err != nil {
 		return nil, err
 	}
-	config, err := buildGenerateConfig(req)
+	config, err := buildGenerateConfig(req, model)
 	if err != nil {
 		return nil, err
 	}
@@ -169,6 +169,13 @@ func (p *Provider) stream(
 			if part == nil {
 				continue
 			}
+			// Gemini 3.x returns an opaque thought signature on the part it
+			// produced (typically the function call, sometimes a thought).
+			// It must be echoed back verbatim on replay or the next request
+			// 400s with "Function call is missing a thought_signature". We
+			// store it base64-encoded so file-backed transcripts stay
+			// JSON-clean; convert.go decodes it on the way back out.
+			signature := encodeSignature(part.ThoughtSignature)
 			if part.FunctionCall != nil {
 				toolCallCount++
 				toolCall, err := convertFunctionCall(part.FunctionCall, toolCallCount)
@@ -176,20 +183,26 @@ func (p *Provider) stream(
 					send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventError, Error: err.Error()})
 					return
 				}
-				output.Content = append(output.Content, loop.ContentPart{Type: loop.ContentTypeToolCall, ToolCall: &toolCall})
+				output.Content = append(output.Content, loop.ContentPart{Type: loop.ContentTypeToolCall, ToolCall: &toolCall, Signature: signature})
 				if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventToolCall, ToolCall: &toolCall}) {
 					return
 				}
 				continue
 			}
-			if part.Text == "" {
+			if part.Thought {
+				// A thought part may carry text, a signature, or both; the
+				// signature sometimes arrives on a later text-less delta, so
+				// latch it onto the coalesced thinking block rather than
+				// dropping it with the empty text.
+				appendThinking(&output, part.Text, signature)
+				if part.Text != "" {
+					if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventThinkingDelta, Delta: part.Text}) {
+						return
+					}
+				}
 				continue
 			}
-			if part.Thought {
-				appendThinking(&output, part.Text)
-				if !send(ctx, events, loop.ProviderEvent{Type: loop.ProviderEventThinkingDelta, Delta: part.Text}) {
-					return
-				}
+			if part.Text == "" {
 				continue
 			}
 			appendText(&output, part.Text)
@@ -221,32 +234,32 @@ func send(ctx context.Context, events chan<- loop.ProviderEvent, event loop.Prov
 }
 
 func appendText(message *loop.Message, delta string) {
-	appendPart(message, loop.ContentTypeText, delta)
-}
-
-func appendThinking(message *loop.Message, delta string) {
-	appendPart(message, loop.ContentTypeThinking, delta)
-}
-
-func appendPart(message *loop.Message, kind loop.ContentType, delta string) {
 	last := len(message.Content) - 1
-	if last >= 0 && message.Content[last].Type == kind {
-		switch kind {
-		case loop.ContentTypeText:
-			message.Content[last].Text += delta
-		case loop.ContentTypeThinking:
-			message.Content[last].Thinking += delta
+	if last >= 0 && message.Content[last].Type == loop.ContentTypeText {
+		message.Content[last].Text += delta
+		return
+	}
+	message.Content = append(message.Content, loop.ContentPart{Type: loop.ContentTypeText, Text: delta})
+}
+
+// appendThinking coalesces consecutive thinking deltas into one content part
+// and latches the most recent non-empty thought signature onto it. A signed
+// but text-less delta updates the signature without creating an empty block;
+// a signature with no prior thinking block opens one so the signature is not
+// lost.
+func appendThinking(message *loop.Message, delta, signature string) {
+	last := len(message.Content) - 1
+	if last >= 0 && message.Content[last].Type == loop.ContentTypeThinking {
+		message.Content[last].Thinking += delta
+		if signature != "" {
+			message.Content[last].Signature = signature
 		}
 		return
 	}
-	part := loop.ContentPart{Type: kind}
-	switch kind {
-	case loop.ContentTypeText:
-		part.Text = delta
-	case loop.ContentTypeThinking:
-		part.Thinking = delta
+	if delta == "" && signature == "" {
+		return
 	}
-	message.Content = append(message.Content, part)
+	message.Content = append(message.Content, loop.ContentPart{Type: loop.ContentTypeThinking, Thinking: delta, Signature: signature})
 }
 
 func applyResponseMetadata(message *loop.Message, response *genai.GenerateContentResponse) {

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -198,7 +198,7 @@ func TestBuildGenerateConfigSetsSystemAndOptions(t *testing.T) {
 			"temperature":       0.5,
 			"max_output_tokens": 256,
 		},
-	})
+	}, "gemini-2.5-flash")
 	if err != nil {
 		t.Fatalf("buildGenerateConfig: %v", err)
 	}
@@ -216,11 +216,11 @@ func TestBuildGenerateConfigSetsSystemAndOptions(t *testing.T) {
 func TestBuildGenerateConfigInvalidNumeric(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"temperature": "hot"}})
+	_, err := buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"temperature": "hot"}}, "gemini-2.5-flash")
 	if err == nil || !strings.Contains(err.Error(), "temperature") {
 		t.Fatalf("err = %v, want temperature error", err)
 	}
-	_, err = buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"max_tokens": "lots"}})
+	_, err = buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"max_tokens": "lots"}}, "gemini-2.5-flash")
 	if err == nil || !strings.Contains(err.Error(), "max_tokens") {
 		t.Fatalf("err = %v, want max_tokens error", err)
 	}
@@ -234,7 +234,7 @@ func TestBuildGenerateConfigStructuredOutput(t *testing.T) {
 			"response_mime_type":   "application/json",
 			"response_json_schema": map[string]any{"type": "object"},
 		},
-	})
+	}, "gemini-2.5-flash")
 	if err != nil {
 		t.Fatalf("buildGenerateConfig: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestBuildGenerateConfigStructuredOutput(t *testing.T) {
 func TestBuildGenerateConfigBadResponseMIMEType(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"response_mime_type": 42}})
+	_, err := buildGenerateConfig(loop.ProviderRequest{Options: map[string]any{"response_mime_type": 42}}, "gemini-2.5-flash")
 	if err == nil || !strings.Contains(err.Error(), "response_mime_type") {
 		t.Fatalf("err = %v, want response_mime_type error", err)
 	}
@@ -342,6 +342,218 @@ func TestNewWithoutOptionsDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeSignatureRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	if encodeSignature(nil) != "" || encodeSignature([]byte{}) != "" {
+		t.Fatal("empty signature should encode to empty string")
+	}
+	sig := []byte{0x00, 0x01, 0xfe, 0xff, 'a', 'b'}
+	enc := encodeSignature(sig)
+	if enc == "" {
+		t.Fatal("non-empty signature encoded to empty string")
+	}
+	if got := decodeSignature(enc); string(got) != string(sig) {
+		t.Fatalf("round-trip = %v, want %v", got, sig)
+	}
+	if decodeSignature("") != nil {
+		t.Fatal("empty string should decode to nil")
+	}
+	if decodeSignature("not!base64!!") != nil {
+		t.Fatal("corrupt signature should decode to nil, not panic")
+	}
+}
+
+func TestIsModernGeminiModel(t *testing.T) {
+	t.Parallel()
+
+	modern := []string{"gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash"}
+	legacy := []string{"gemini-2.5-flash", "gemini-2.5-pro", "gemini-pro-latest", ""}
+	for _, m := range modern {
+		if !isModernGeminiModel(m) {
+			t.Errorf("isModernGeminiModel(%q) = false, want true", m)
+		}
+	}
+	for _, m := range legacy {
+		if isModernGeminiModel(m) {
+			t.Errorf("isModernGeminiModel(%q) = true, want false", m)
+		}
+	}
+}
+
+func TestBuildGenerateConfigIncludeThoughts(t *testing.T) {
+	t.Parallel()
+
+	modern, err := buildGenerateConfig(loop.ProviderRequest{}, "gemini-3.1-pro-preview")
+	if err != nil {
+		t.Fatalf("buildGenerateConfig modern: %v", err)
+	}
+	if modern.ThinkingConfig == nil || !modern.ThinkingConfig.IncludeThoughts {
+		t.Fatalf("ThinkingConfig = %#v, want IncludeThoughts=true for gemini-3.x", modern.ThinkingConfig)
+	}
+
+	legacy, err := buildGenerateConfig(loop.ProviderRequest{}, "gemini-2.5-flash")
+	if err != nil {
+		t.Fatalf("buildGenerateConfig legacy: %v", err)
+	}
+	if legacy.ThinkingConfig != nil {
+		t.Fatalf("ThinkingConfig = %#v, want nil for non-reasoning id", legacy.ThinkingConfig)
+	}
+}
+
+func TestConvertMessagesEchoesToolCallSignature(t *testing.T) {
+	t.Parallel()
+
+	sig := []byte("the-opaque-signature-bytes")
+	contents, err := ConvertMessages([]loop.Message{
+		{Role: loop.MessageRoleAssistant, Content: []loop.ContentPart{
+			{Type: loop.ContentTypeToolCall, Signature: encodeSignature(sig), ToolCall: &loop.ToolCall{
+				ID: "c1", Name: "weather", Arguments: json.RawMessage(`{"city":"T"}`),
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ConvertMessages: %v", err)
+	}
+	part := contents[0].Parts[0]
+	if part.FunctionCall == nil {
+		t.Fatal("FunctionCall part missing")
+	}
+	if string(part.ThoughtSignature) != string(sig) {
+		t.Fatalf("ThoughtSignature = %q, want %q", part.ThoughtSignature, sig)
+	}
+}
+
+func TestConvertMessagesEchoesThinkingSignatureAsThought(t *testing.T) {
+	t.Parallel()
+
+	sig := []byte("thinking-signature")
+	contents, err := ConvertMessages([]loop.Message{
+		{Role: loop.MessageRoleAssistant, Content: []loop.ContentPart{
+			{Type: loop.ContentTypeThinking, Thinking: "let me think", Signature: encodeSignature(sig)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ConvertMessages: %v", err)
+	}
+	part := contents[0].Parts[0]
+	if !part.Thought {
+		t.Fatal("thinking content must convert to a part with Thought=true")
+	}
+	if part.Text != "let me think" {
+		t.Fatalf("Text = %q, want 'let me think'", part.Text)
+	}
+	if string(part.ThoughtSignature) != string(sig) {
+		t.Fatalf("ThoughtSignature = %q, want %q", part.ThoughtSignature, sig)
+	}
+}
+
+func TestAppendThinkingLatchesSignature(t *testing.T) {
+	t.Parallel()
+
+	msg := &loop.Message{}
+	appendThinking(msg, "reasoning ", "")    // text, no signature yet
+	appendThinking(msg, "continues", "")     // coalesces
+	appendThinking(msg, "", "c2ln")          // signature-only terminator latches
+	if len(msg.Content) != 1 {
+		t.Fatalf("len(Content) = %d, want 1 coalesced thinking block", len(msg.Content))
+	}
+	if msg.Content[0].Thinking != "reasoning continues" {
+		t.Fatalf("Thinking = %q, want 'reasoning continues'", msg.Content[0].Thinking)
+	}
+	if msg.Content[0].Signature != "c2ln" {
+		t.Fatalf("Signature = %q, want latched c2ln", msg.Content[0].Signature)
+	}
+
+	// A lone empty delta with no signature and no prior block is a no-op.
+	empty := &loop.Message{}
+	appendThinking(empty, "", "")
+	if len(empty.Content) != 0 {
+		t.Fatalf("empty thinking delta created %d parts, want 0", len(empty.Content))
+	}
+}
+
+// TestLiveToolLoopRoundTripsSignature reproduces the original failure: a
+// second turn that replays a Gemini 3.x function call. Without the signature
+// round-trip the API returns "Function call is missing a thought_signature".
+// Gated on GEMINI_API_KEY; CI never sets it.
+func TestLiveToolLoopRoundTripsSignature(t *testing.T) {
+	if os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("GEMINI_API_KEY not set; skipping live tool-loop test")
+	}
+
+	p := New(Options{})
+	tools := []loop.ToolSpec{{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+	}}
+
+	// Turn 1: force a tool call and capture the assistant message verbatim
+	// (including the signature stored on the tool-call content part).
+	events, err := p.Stream(context.Background(), loop.ProviderRequest{
+		Model:    "gemini-3.1-pro-preview",
+		Tools:    tools,
+		Messages: []loop.Message{{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "What's the weather in Toronto? Use the get_weather tool."}}}},
+	})
+	if err != nil {
+		t.Fatalf("turn 1 Stream: %v", err)
+	}
+	var assistant *loop.Message
+	var call *loop.ToolCall
+	for ev := range events {
+		switch ev.Type {
+		case loop.ProviderEventToolCall:
+			call = ev.ToolCall
+		case loop.ProviderEventDone:
+			assistant = ev.Message
+		case loop.ProviderEventError:
+			t.Fatalf("turn 1 provider error: %s", ev.Error)
+		}
+	}
+	if assistant == nil || call == nil {
+		t.Fatal("turn 1 did not produce an assistant message with a tool call")
+	}
+	var gotSig bool
+	for _, part := range assistant.Content {
+		if part.Type == loop.ContentTypeToolCall && part.Signature != "" {
+			gotSig = true
+		}
+	}
+	if !gotSig {
+		t.Fatal("turn 1 tool call did not capture a thought signature")
+	}
+
+	// Turn 2: replay turn 1 plus a tool result. This is the request that
+	// previously 400'd.
+	events2, err := p.Stream(context.Background(), loop.ProviderRequest{
+		Model: "gemini-3.1-pro-preview",
+		Tools: tools,
+		Messages: []loop.Message{
+			{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "What's the weather in Toronto? Use the get_weather tool."}}},
+			*assistant,
+			{Role: loop.MessageRoleTool, ToolCallID: call.ID, ToolName: call.Name, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "sunny, 22C"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("turn 2 Stream: %v", err)
+	}
+	var sawText bool
+	for ev := range events2 {
+		switch ev.Type {
+		case loop.ProviderEventTextDelta:
+			if ev.Delta != "" {
+				sawText = true
+			}
+		case loop.ProviderEventError:
+			t.Fatalf("turn 2 provider error (the bug if 'thought_signature'): %s", ev.Error)
+		}
+	}
+	if !sawText {
+		t.Fatal("turn 2 produced no text after the tool result")
+	}
+}
+
 // TestLiveSmoke exercises a real Gemini call when GEMINI_API_KEY is set.
 // CI never sets the variable, so this is a no-op there; it is the minimum
 // proof that the streaming path works end-to-end.
@@ -352,7 +564,9 @@ func TestLiveSmoke(t *testing.T) {
 
 	p := New(Options{})
 	events, err := p.Stream(context.Background(), loop.ProviderRequest{
-		Model: "gemini-2.5-flash",
+		// Use the provider default rather than a hardcoded id: gemini-2.5-flash
+		// was removed from the v1beta API, which 404'd this smoke test.
+		Model: DefaultModel,
 		Messages: []loop.Message{
 			{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "Reply with the single word: glue"}}},
 		},


### PR DESCRIPTION
## Summary

Gemini 3.x (incl. the default `gemini-3.1-pro-preview`) returns an opaque `thoughtSignature` on the parts it produces and **requires** it echoed back verbatim on replay. We dropped it, so the second turn of any tool-using conversation 400'd with `Function call is missing a thought_signature in functionCall parts` — the exact error reported.

This captures the signature from function-call and thought parts (base64-encoded onto the already-defined-but-unused `loop.ContentPart.Signature`) and restores it on the next request. Prior thinking now replays as real `thought` parts instead of plain text, and `includeThoughts` is enabled on Gemini 3.x so reasoning streams through. No `loop` type change needed.

`Closes #311`

## Verified live (gemini-3.1-pro-preview)

A standalone probe and the new gated test confirm the mechanism:

| Replay of a tool turn | Result |
|---|---|
| real signature round-tripped | ✅ 200 OK |
| signature stripped | ❌ 400 "Function call is missing a thought_signature" |

The function-call signature is returned regardless of `includeThoughts` (559–595 B in all modes), so the flag is complementary, not the fix.

## Verification

```
$ go build ./... && go vet ./...          # clean
$ go test ./...                            # all packages ok (full suite green)
$ GEMINI_API_KEY=… go test ./providers/gemini/ -run TestLive -count=1 -v
--- PASS: TestLiveToolLoopRoundTripsSignature (4.48s)
--- PASS: TestLiveSmoke (2.41s)
```

## Notes / follow-ups

- glue has **no** provider-level HTTP retry (the genai SDK owns transport), so the upstream "never retry 400" guidance is a no-op here — nothing to change.
- Drive-by: the gated live smoke test hardcoded `gemini-2.5-flash` (removed from v1beta, 404s); repointed at the provider default.
- Stacked follow-ups from the same investigation: #312 (synthetic-signature fallback), #313 (schema/Unicode sanitize), #314 (api-version env + cyclic-schema hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
