### PR TITLE
providers/gemini: synthetic thoughtSignature fallback for active-loop turns (closes #312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Gemini: synthetic `thoughtSignature` fallback for unsigned replays
+  (`providers/gemini`).** When an active-loop model turn reaches Gemini 3.x
+  without a real signature on its first function call — compacted history, a
+  transcript written before signature round-tripping landed, or a turn that
+  genuinely arrived unsigned — the provider now injects the sentinel
+  `skip_thought_signature_validator` (the same value Google's gemini-cli uses)
+  so the request still validates. Scoped to the active loop (everything after
+  the most recent genuine user turn) and to Gemini 3.x ids; real signatures are
+  never overwritten. Verified live.
+
 - **Fix Gemini 3.x tool calls: round-trip `thoughtSignature` (`providers/gemini`).**
   Gemini 3.x (incl. the default `gemini-3.1-pro-preview`) returns an opaque
   `thoughtSignature` on the parts it produces and **requires** it echoed back

--- a/providers/gemini/convert.go
+++ b/providers/gemini/convert.go
@@ -166,6 +166,70 @@ func ConvertTools(tools []loop.ToolSpec) ([]*genai.Tool, error) {
 	return []*genai.Tool{{FunctionDeclarations: declarations}}, nil
 }
 
+// syntheticThoughtSignature is the sentinel Gemini's backend recognizes as
+// "skip thought-signature validation for this turn" — the same literal
+// Google's gemini-cli uses. We fall back to it only when a real signature is
+// absent (compacted history, transcripts written before signature
+// round-tripping landed, or a turn that genuinely arrived unsigned), so a
+// replayed Gemini 3.x function call does not 400 with "Function call is
+// missing a thought_signature". The SDK base64-encodes these bytes on the
+// wire and the backend recognizes the decoded value; verified accepted live.
+var syntheticThoughtSignature = []byte("skip_thought_signature_validator")
+
+// ensureActiveLoopSignatures guarantees that, for Gemini 3.x, every model turn
+// in the active loop has a thought signature on its first function call — the
+// invariant the API enforces. The active loop begins at the most recent
+// genuine user turn (one carrying text or images, not just function
+// responses); everything after it is the current tool-calling loop, and turns
+// before it are exempt. Real signatures (restored by convertMessage) are left
+// untouched; only a missing one gets the synthetic sentinel. Older models
+// neither emit nor require signatures, so they are skipped entirely.
+func ensureActiveLoopSignatures(contents []*genai.Content, model string) {
+	if !isModernGeminiModel(model) {
+		return
+	}
+	start := -1
+	for i := len(contents) - 1; i >= 0; i-- {
+		if isGenuineUserTurn(contents[i]) {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		return
+	}
+	for i := start; i < len(contents); i++ {
+		content := contents[i]
+		if content.Role != string(genai.RoleModel) {
+			continue
+		}
+		for _, part := range content.Parts {
+			if part == nil || part.FunctionCall == nil {
+				continue
+			}
+			if len(part.ThoughtSignature) == 0 {
+				part.ThoughtSignature = syntheticThoughtSignature
+			}
+			break // only the first function call in a turn needs a signature
+		}
+	}
+}
+
+// isGenuineUserTurn reports whether a content is a real user message (text or
+// image input) rather than a grouped batch of function responses, which also
+// carry the user role. It marks the active-loop boundary.
+func isGenuineUserTurn(content *genai.Content) bool {
+	if content == nil || content.Role != string(genai.RoleUser) {
+		return false
+	}
+	for _, part := range content.Parts {
+		if part != nil && part.FunctionResponse == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // encodeSignature base64-encodes an opaque thought signature for storage on a
 // loop.ContentPart. Empty signatures stay empty so transcripts don't carry
 // noise.

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -94,6 +94,10 @@ func (p *Provider) Stream(ctx context.Context, req loop.ProviderRequest) (<-chan
 	if err != nil {
 		return nil, err
 	}
+	// Backstop the round-tripped signatures: if any active-loop model turn
+	// reaches Gemini 3.x without one on its first function call (compacted or
+	// pre-fix history), inject the sentinel so the request validates.
+	ensureActiveLoopSignatures(contents, model)
 	config, err := buildGenerateConfig(req, model)
 	if err != nil {
 		return nil, err

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -554,6 +554,123 @@ func TestLiveToolLoopRoundTripsSignature(t *testing.T) {
 	}
 }
 
+func modelTurnWithCall(sig []byte) *genai.Content {
+	call := &genai.Part{FunctionCall: &genai.FunctionCall{Name: "weather", Args: map[string]any{"city": "T"}}}
+	if len(sig) > 0 {
+		call.ThoughtSignature = sig
+	}
+	return genai.NewContentFromParts([]*genai.Part{call}, genai.RoleModel)
+}
+
+func firstCallSignature(content *genai.Content) []byte {
+	for _, part := range content.Parts {
+		if part.FunctionCall != nil {
+			return part.ThoughtSignature
+		}
+	}
+	return nil
+}
+
+func TestEnsureActiveLoopSignaturesInjectsSynthetic(t *testing.T) {
+	t.Parallel()
+
+	contents := []*genai.Content{
+		genai.NewContentFromText("weather in Toronto?", genai.RoleUser),
+		modelTurnWithCall(nil), // unsigned: should get synthetic
+		genai.NewContentFromParts([]*genai.Part{{FunctionResponse: &genai.FunctionResponse{Name: "weather", Response: map[string]any{"output": "sunny"}}}}, genai.RoleUser),
+		modelTurnWithCall(nil), // unsigned: should get synthetic
+	}
+	ensureActiveLoopSignatures(contents, "gemini-3.1-pro-preview")
+
+	if string(firstCallSignature(contents[1])) != string(syntheticThoughtSignature) {
+		t.Fatalf("turn 1 signature = %q, want synthetic", firstCallSignature(contents[1]))
+	}
+	if string(firstCallSignature(contents[3])) != string(syntheticThoughtSignature) {
+		t.Fatalf("turn 3 signature = %q, want synthetic", firstCallSignature(contents[3]))
+	}
+}
+
+func TestEnsureActiveLoopSignaturesPreservesReal(t *testing.T) {
+	t.Parallel()
+
+	real := []byte("a-real-signature")
+	contents := []*genai.Content{
+		genai.NewContentFromText("weather?", genai.RoleUser),
+		modelTurnWithCall(real),
+	}
+	ensureActiveLoopSignatures(contents, "gemini-3.1-pro-preview")
+	if string(firstCallSignature(contents[1])) != string(real) {
+		t.Fatalf("real signature was overwritten: %q", firstCallSignature(contents[1]))
+	}
+}
+
+func TestEnsureActiveLoopSignaturesSkipsBeforeActiveLoop(t *testing.T) {
+	t.Parallel()
+
+	contents := []*genai.Content{
+		genai.NewContentFromText("first question", genai.RoleUser),
+		modelTurnWithCall(nil), // BEFORE the active loop: must stay unsigned
+		genai.NewContentFromText("second question", genai.RoleUser),
+		modelTurnWithCall(nil), // active loop: gets synthetic
+	}
+	ensureActiveLoopSignatures(contents, "gemini-3.1-pro-preview")
+
+	if firstCallSignature(contents[1]) != nil {
+		t.Fatalf("pre-active-loop turn was signed: %q", firstCallSignature(contents[1]))
+	}
+	if string(firstCallSignature(contents[3])) != string(syntheticThoughtSignature) {
+		t.Fatalf("active-loop turn signature = %q, want synthetic", firstCallSignature(contents[3]))
+	}
+}
+
+func TestEnsureActiveLoopSignaturesGatedByModel(t *testing.T) {
+	t.Parallel()
+
+	contents := []*genai.Content{
+		genai.NewContentFromText("weather?", genai.RoleUser),
+		modelTurnWithCall(nil),
+	}
+	ensureActiveLoopSignatures(contents, "gemini-2.5-flash") // non-modern: no-op
+	if firstCallSignature(contents[1]) != nil {
+		t.Fatalf("legacy model got a synthetic signature: %q", firstCallSignature(contents[1]))
+	}
+}
+
+// TestLiveSyntheticSignatureFallback proves the fallback path: an assistant
+// turn whose function call carries no signature (as in compacted or pre-fix
+// history) still completes on Gemini 3.x because the synthetic sentinel is
+// injected. Gated on GEMINI_API_KEY.
+func TestLiveSyntheticSignatureFallback(t *testing.T) {
+	if os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("GEMINI_API_KEY not set; skipping live synthetic-fallback test")
+	}
+
+	p := New(Options{})
+	tools := []loop.ToolSpec{{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`),
+	}}
+	events, err := p.Stream(context.Background(), loop.ProviderRequest{
+		Model: "gemini-3.1-pro-preview",
+		Tools: tools,
+		Messages: []loop.Message{
+			{Role: loop.MessageRoleUser, Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "What's the weather in Toronto? Use get_weather."}}},
+			// Assistant tool call with NO signature — what a pre-fix transcript looks like.
+			{Role: loop.MessageRoleAssistant, Content: []loop.ContentPart{{Type: loop.ContentTypeToolCall, ToolCall: &loop.ToolCall{ID: "c1", Name: "get_weather", Arguments: json.RawMessage(`{"city":"Toronto"}`)}}}},
+			{Role: loop.MessageRoleTool, ToolCallID: "c1", ToolName: "get_weather", Content: []loop.ContentPart{{Type: loop.ContentTypeText, Text: "sunny, 22C"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for ev := range events {
+		if ev.Type == loop.ProviderEventError {
+			t.Fatalf("provider error (synthetic fallback failed): %s", ev.Error)
+		}
+	}
+}
+
 // TestLiveSmoke exercises a real Gemini call when GEMINI_API_KEY is set.
 // CI never sets the variable, so this is a no-op there; it is the minimum
 // proof that the streaming path works end-to-end.


### PR DESCRIPTION
## Summary

Backstops the real-signature round-trip from #311. When an active-loop model turn reaches Gemini 3.x **without** a signature on its first function call — compacted history, a transcript written before #311, or a turn that genuinely arrived unsigned — the provider injects the sentinel `skip_thought_signature_validator` (the same literal Google's gemini-cli uses) so the request validates instead of 400ing with `Function call is missing a thought_signature`.

- Active loop = everything after the most recent **genuine** user turn (text/image, not a function-response batch); earlier turns are exempt.
- Only the **first** function call per model turn is signed; real signatures are never overwritten.
- Gated on Gemini 3.x ids — older models neither emit nor require signatures.

`Closes #312`

> Stacked on #315 (issue #311). Review/merge after #315; it will retarget to `main` cleanly.

## Verified live (gemini-3.1-pro-preview)

`[]byte("skip_thought_signature_validator")` is accepted by the backend through the Go SDK (it std-base64-encodes the bytes; the backend recognizes the decoded value). An assistant tool call constructed with **no** signature replays successfully.

## Verification

```
$ go build ./... && go vet ./...          # clean
$ go test ./providers/gemini/...           # ok
$ GEMINI_API_KEY=… go test ./providers/gemini/ -run TestLiveSyntheticSignatureFallback -count=1 -v
--- PASS: TestLiveSyntheticSignatureFallback (1.47s)
```

Unit tests cover: synthetic injection on active-loop turns, real-signature preservation, exemption of turns before the active-loop boundary, and the non-modern-model gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
