### PR TITLE
providers/gemini: GOOGLE_GENAI_API_VERSION env knob (closes #314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
   with a two-turn tool loop. (Also points the gated live smoke test at the
   provider default; it hardcoded the now-removed `gemini-2.5-flash`.)
 
+- **Gemini: `GOOGLE_GENAI_API_VERSION` env knob (`providers/gemini`).** Pins
+  the API version the client targets (e.g. `v1alpha`/`v1beta`) so users can
+  reach version-gated preview features without a code change, matching
+  gemini-cli. Unset leaves the SDK default in place.
+
 - **Fix Gemini default id: `gemini-3.1-pro-preview`, not `gemini-3.1-pro`.**
   v1.4.0 set the default to `gemini-3.1-pro`, which 404s — the public
   id on `generativelanguage.googleapis.com` v1beta carries the

--- a/providers/gemini/doc.go
+++ b/providers/gemini/doc.go
@@ -5,7 +5,9 @@
 // function declarations, and maps function calls and results across the
 // normalized loop types. The model comes from AgentOptions.Model, a
 // per-call WithModel, or the provider default. The API key is taken from
-// Options.APIKey or the GEMINI_API_KEY environment variable.
+// Options.APIKey or the GEMINI_API_KEY environment variable. Setting
+// GOOGLE_GENAI_API_VERSION pins the API version (e.g. "v1alpha") to reach
+// version-gated preview features.
 //
 // Gemini 3.x returns an opaque thought signature on the parts it produces and
 // requires it echoed back on replay; the provider captures it (base64-encoded

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -19,6 +19,12 @@ import (
 // probe key availability without hard-coding the name.
 const EnvKey = "GEMINI_API_KEY"
 
+// APIVersionEnvKey, when set, pins the Gemini API version (e.g. "v1alpha" or
+// "v1beta") the client targets. It lets users reach version-gated preview
+// features without a code change, matching gemini-cli's GOOGLE_GENAI_API_VERSION
+// knob. Unset leaves the SDK default in place.
+const APIVersionEnvKey = "GOOGLE_GENAI_API_VERSION"
+
 // DefaultModel is the registry-level default model for this provider.
 //
 // gemini-3.1-pro-preview is the daily-driver default per maintainer
@@ -120,14 +126,25 @@ func (p *Provider) clientFor(ctx context.Context) (*genai.Client, error) {
 	if apiKey == "" {
 		apiKey = os.Getenv(EnvKey)
 	}
-	client, err := genai.NewClient(ctx, &genai.ClientConfig{
-		APIKey:  apiKey,
-		Backend: genai.BackendGeminiAPI,
-	})
+	client, err := genai.NewClient(ctx, newClientConfig(apiKey))
 	if err != nil {
 		return nil, fmt.Errorf("gemini: create client: %w", err)
 	}
 	return client, nil
+}
+
+// newClientConfig assembles the genai client config, honoring the optional
+// GOOGLE_GENAI_API_VERSION pin. Split out from clientFor so the env wiring is
+// unit-testable without constructing a live client.
+func newClientConfig(apiKey string) *genai.ClientConfig {
+	config := &genai.ClientConfig{
+		APIKey:  apiKey,
+		Backend: genai.BackendGeminiAPI,
+	}
+	if version := os.Getenv(APIVersionEnvKey); version != "" {
+		config.HTTPOptions.APIVersion = version
+	}
+	return config
 }
 
 func (p *Provider) stream(

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -671,6 +671,23 @@ func TestLiveSyntheticSignatureFallback(t *testing.T) {
 	}
 }
 
+func TestNewClientConfigAPIVersion(t *testing.T) {
+	// Not parallel: mutates a process env var.
+	t.Setenv(APIVersionEnvKey, "v1alpha")
+	cfg := newClientConfig("k")
+	if cfg.HTTPOptions.APIVersion != "v1alpha" {
+		t.Fatalf("APIVersion = %q, want v1alpha", cfg.HTTPOptions.APIVersion)
+	}
+	if cfg.APIKey != "k" || cfg.Backend != genai.BackendGeminiAPI {
+		t.Fatalf("config = %#v, want APIKey=k Backend=GeminiAPI", cfg)
+	}
+
+	t.Setenv(APIVersionEnvKey, "")
+	if got := newClientConfig("k").HTTPOptions.APIVersion; got != "" {
+		t.Fatalf("APIVersion = %q, want empty when env unset", got)
+	}
+}
+
 // TestLiveSmoke exercises a real Gemini call when GEMINI_API_KEY is set.
 // CI never sets the variable, so this is a no-op there; it is the minimum
 // proof that the streaming path works end-to-end.


### PR DESCRIPTION
## Summary

Adds a `GOOGLE_GENAI_API_VERSION` environment knob: when set, it's threaded into the genai client's `HTTPOptions.APIVersion` so users can pin the API version (e.g. `v1alpha`/`v1beta`) and reach version-gated preview features without a code change — matching gemini-cli. Unset leaves the SDK default in place. Config assembly is factored into a testable `newClientConfig` helper.

`Closes #314`

> Independent of #315/#316 — branched from `main`, touches only `clientFor`.

## Scope note

The cyclic-schema 400 hint originally bundled in #314 was **dropped**: I verified live that `gemini-3.1-pro-preview` accepts recursive `$ref`/`$defs` schemas through `parametersJsonSchema`, so there's no reproducible depth/invalid-argument error to annotate. Same investigation closed #313 (array-typed `type` and invalid UTF-8 are also accepted/auto-sanitized).

## Verification

```
$ go build ./... && go vet ./...          # clean
$ go test ./providers/gemini/...           # ok
--- PASS: TestNewClientConfigAPIVersion (0.00s)
```

Full `go test ./...` is green except `agents/glue-review`, which timed out on a **live NVIDIA API call** (`context deadline exceeded`) — an unrelated network flake; this PR touches only the gemini client config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
