### PR TITLE
cmd/glue/tui: inline autocomplete for / slash commands (closes #318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **TUI: inline autocomplete for `/` slash commands (`cmd/glue/tui`).**
+  Typing `/` now opens a filtering command popup (mirroring the `@`-file
+  picker): `↑/↓` navigate, `Tab` completes, `Esc` closes (keeping what you
+  typed), and `Enter` runs a fully-typed or no-argument command while
+  completing an argument-taking one (e.g. `/model `). The command list is now
+  a single source of truth shared by the picker and `/help`, so they can't
+  drift. Closes #318.
+
 ## 1.8.0 — 2026-06-08
 
 - **Fix Gemini 3.x tool calls: round-trip `thoughtSignature` (`providers/gemini`).**

--- a/cmd/glue/tui/commands.go
+++ b/cmd/glue/tui/commands.go
@@ -28,30 +28,58 @@ func parseSlashCommand(s string) (slashCommand, bool) {
 	return slashCommand{Name: strings.ToLower(name), Arg: strings.TrimSpace(arg)}, true
 }
 
+// slashSpec describes one slash command for both /help and the inline
+// autocomplete picker, so the two never drift. Name is the primary form
+// (no leading slash); Aliases are equivalents that dispatch the same way.
+type slashSpec struct {
+	Name    string
+	Aliases []string
+	Args    string // e.g. "<id>", "[N]", or "" when the command takes none
+	Desc    string
+}
+
+// display renders the command for the /help table and the picker, e.g.
+// "/exit, /quit, /q" or "/model <id>".
+func (s slashSpec) display() string {
+	name := "/" + s.Name
+	for _, a := range s.Aliases {
+		name += ", /" + a
+	}
+	if s.Args != "" {
+		name += " " + s.Args
+	}
+	return name
+}
+
+// slashSpecs is the canonical command list. Keep it in sync with the
+// dispatch in (*Model).handleSlash.
+func slashSpecs() []slashSpec {
+	return []slashSpec{
+		{Name: "help", Desc: "show this list"},
+		{Name: "exit", Aliases: []string{"quit", "q"}, Desc: "leave the TUI"},
+		{Name: "clear", Aliases: []string{"new"}, Desc: "clear the transcript and start a fresh session id"},
+		{Name: "usage", Desc: "show this turn's token usage (when the provider reports it)"},
+		{Name: "tools", Desc: "list registered tools"},
+		{Name: "model", Args: "<id>", Desc: "switch model for subsequent turns"},
+		{Name: "session", Args: "[id]", Desc: "print current session id, or switch to <id>"},
+		{Name: "compact", Desc: "summarize older messages to free context window"},
+		{Name: "resume", Desc: "pick a past session and replay it into the transcript"},
+		{Name: "fork", Args: "[N]", Desc: "branch from message N (default: last user turn) into a new session"},
+		{Name: "clone", Desc: "duplicate the current session into a fresh id"},
+		{Name: "tree", Desc: "visualize and switch between branches in this session's lineage"},
+	}
+}
+
 // describeCommands renders the /help body.
 func describeCommands() string {
-	type row struct{ name, doc string }
-	rows := []row{
-		{"/help", "show this list"},
-		{"/exit, /quit, /q", "leave the TUI"},
-		{"/clear, /new", "clear the transcript and start a fresh session id"},
-		{"/usage", "show this turn's token usage (when the provider reports it)"},
-		{"/tools", "list registered tools"},
-		{"/model <id>", "switch model for subsequent turns"},
-		{"/session [id]", "print current session id, or switch to <id>"},
-		{"/compact", "summarize older messages to free context window"},
-		{"/resume", "pick a past session and replay it into the transcript"},
-		{"/fork [N]", "branch from message N (default: last user turn) into a new session"},
-		{"/clone", "duplicate the current session into a fresh id"},
-		{"/tree", "visualize and switch between branches in this session's lineage"},
-	}
-	sort.SliceStable(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
+	specs := slashSpecs()
+	sort.SliceStable(specs, func(i, j int) bool { return specs[i].display() < specs[j].display() })
 	var b strings.Builder
-	for i, r := range rows {
+	for i, s := range specs {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		b.WriteString(fmt.Sprintf("  %-22s  %s", r.name, r.doc))
+		b.WriteString(fmt.Sprintf("  %-22s  %s", s.display(), s.Desc))
 	}
 	return b.String()
 }

--- a/cmd/glue/tui/slashpicker.go
+++ b/cmd/glue/tui/slashpicker.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// slashPicker is the inline `/command` autocomplete popup. It opens when
+// the input is a bare slash token (starts with `/`, no whitespace yet) and
+// closes once the user types a space (entering args) or clears the slash.
+// It mirrors atPicker: a popup ABOVE the input box, not a modal.
+type slashPicker struct {
+	specs   []slashSpec // sorted alphabetically by Name
+	query   string      // text typed after the `/`
+	matches []int       // indices into specs of currently matching entries
+	cursor  int         // index into matches (NOT specs)
+}
+
+// newSlashPicker builds the picker from the canonical command list.
+func newSlashPicker() *slashPicker {
+	specs := slashSpecs()
+	sort.SliceStable(specs, func(i, j int) bool { return specs[i].Name < specs[j].Name })
+	p := &slashPicker{specs: specs}
+	p.refilter("")
+	return p
+}
+
+// detectSlashTrigger reports whether the input is a command being typed —
+// a leading `/` with no whitespace after it yet. The returned query is the
+// text after the `/` (possibly empty, i.e. a bare `/` shows every command).
+// Once the user types a space the picker should close, because they are now
+// entering an argument (e.g. `/model gpt-…`).
+func detectSlashTrigger(input string) (query string, ok bool) {
+	if !strings.HasPrefix(input, "/") {
+		return "", false
+	}
+	rest := input[1:]
+	if strings.ContainsAny(rest, " \t\n") {
+		return "", false
+	}
+	return rest, true
+}
+
+// refilter recomputes matches against a new query. Matching is a
+// case-insensitive prefix over the command name or any alias; an empty
+// query matches everything. Results stay in the picker's alphabetical
+// order, so the list never reshuffles under the cursor as you type.
+func (p *slashPicker) refilter(query string) {
+	p.query = query
+	lower := strings.ToLower(query)
+	p.matches = p.matches[:0]
+	for i, s := range p.specs {
+		if lower == "" || specMatches(s, lower) {
+			p.matches = append(p.matches, i)
+		}
+	}
+	if p.cursor >= len(p.matches) {
+		p.cursor = 0
+	}
+}
+
+// specMatches reports whether a command name or alias begins with q
+// (q already lower-cased).
+func specMatches(s slashSpec, q string) bool {
+	if strings.HasPrefix(s.Name, q) {
+		return true
+	}
+	for _, a := range s.Aliases {
+		if strings.HasPrefix(a, q) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *slashPicker) up() {
+	if p == nil || len(p.matches) == 0 {
+		return
+	}
+	if p.cursor > 0 {
+		p.cursor--
+	}
+}
+
+func (p *slashPicker) down() {
+	if p == nil || len(p.matches) == 0 {
+		return
+	}
+	if p.cursor < len(p.matches)-1 {
+		p.cursor++
+	}
+}
+
+// selected returns the currently-focused command spec, or ok=false when
+// there are no matches.
+func (p *slashPicker) selected() (slashSpec, bool) {
+	if p == nil || len(p.matches) == 0 {
+		return slashSpec{}, false
+	}
+	idx := p.matches[p.cursor]
+	if idx < 0 || idx >= len(p.specs) {
+		return slashSpec{}, false
+	}
+	return p.specs[idx], true
+}
+
+// exactMatch reports whether the typed query already equals the selected
+// command's name (case-insensitive) — i.e. the user has fully typed it, so
+// Enter should run it rather than re-complete.
+func (p *slashPicker) exactMatch() bool {
+	s, ok := p.selected()
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(p.query, s.Name)
+}
+
+// applySlashSelection returns the input rewritten to the chosen command
+// with a trailing space, ready for an argument (e.g. `/model `). The slash
+// command always occupies the whole input, so the previous text is
+// replaced entirely.
+func applySlashSelection(name string) string {
+	return "/" + name + " "
+}
+
+// ------ rendering ------
+
+// renderSlashPicker returns the popup string positioned above the input.
+// width is the full TUI width. It mirrors renderAtPicker's frame so the two
+// autocompletes look identical.
+func renderSlashPicker(p *slashPicker, width int) string {
+	if p == nil {
+		return ""
+	}
+	w := width - 4
+	if w > inputMaxBoxWidth {
+		w = inputMaxBoxWidth
+	}
+	if w < 30 {
+		w = 30
+	}
+
+	var b strings.Builder
+	head := "Commands"
+	if p.query != "" {
+		head = "Commands matching /" + p.query
+	}
+	b.WriteString(pickerTitle.Render(" " + head + " "))
+	b.WriteByte('\n')
+
+	if len(p.matches) == 0 {
+		b.WriteString(atRow.Render("  (no matching command)"))
+	} else {
+		start := 0
+		if p.cursor >= atPickerVisibleRows {
+			start = p.cursor - atPickerVisibleRows + 1
+		}
+		end := start + atPickerVisibleRows
+		if end > len(p.matches) {
+			end = len(p.matches)
+		}
+		for i := start; i < end; i++ {
+			s := p.specs[p.matches[i]]
+			row := truncate(s.display()+"  —  "+s.Desc, w-6)
+			if i == p.cursor {
+				b.WriteString(atSel.Render("› " + row))
+			} else {
+				b.WriteString(atRow.Render("  " + row))
+			}
+			if i < end-1 {
+				b.WriteByte('\n')
+			}
+		}
+	}
+	b.WriteByte('\n')
+	b.WriteString(keyHint.Render("  ↑/↓ navigate · Tab complete · Enter run · Esc cancel"))
+
+	rendered := atBox.Width(w).Render(b.String())
+	if w < width {
+		return lipgloss.PlaceHorizontal(width, lipgloss.Center, rendered)
+	}
+	return rendered
+}

--- a/cmd/glue/tui/slashpicker_test.go
+++ b/cmd/glue/tui/slashpicker_test.go
@@ -1,0 +1,247 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestDetectSlashTrigger(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		// Opens
+		{"/", "", true},
+		{"/h", "h", true},
+		{"/model", "model", true},
+
+		// Does NOT open
+		{"", "", false},
+		{"hello", "", false},
+		{"/model gpt-5", "", false}, // space → entering an argument
+		{" /help", "", false},       // leading space: not a bare slash token
+		{"a/b", "", false},
+		{"/multi\nline", "", false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.in, func(t *testing.T) {
+			got, ok := detectSlashTrigger(c.in)
+			if ok != c.wantOK || got != c.want {
+				t.Fatalf("detectSlashTrigger(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.wantOK)
+			}
+		})
+	}
+}
+
+func TestSlashRefilterEmptyMatchesAll(t *testing.T) {
+	t.Parallel()
+	p := newSlashPicker()
+	if len(p.matches) != len(p.specs) || len(p.specs) == 0 {
+		t.Fatalf("empty query matched %d of %d specs", len(p.matches), len(p.specs))
+	}
+}
+
+func TestSlashRefilterPrefixMatch(t *testing.T) {
+	t.Parallel()
+	p := newSlashPicker()
+
+	p.refilter("mo")
+	if got, ok := p.selected(); !ok || got.Name != "model" {
+		t.Fatalf("/mo selected %+v (ok=%v), want model", got, ok)
+	}
+	if len(p.matches) != 1 {
+		t.Fatalf("/mo matched %d, want 1", len(p.matches))
+	}
+
+	// Alias prefixes match too: "qui" → /exit (alias /quit).
+	p.refilter("qui")
+	if got, ok := p.selected(); !ok || got.Name != "exit" {
+		t.Fatalf("/qui selected %+v (ok=%v), want exit via alias", got, ok)
+	}
+
+	// No command starts with "zzz".
+	p.refilter("zzz")
+	if len(p.matches) != 0 {
+		t.Fatalf("/zzz matched %d, want 0", len(p.matches))
+	}
+	if _, ok := p.selected(); ok {
+		t.Fatal("selected() should be !ok with no matches")
+	}
+}
+
+func TestSlashMatchesStayAlphabetical(t *testing.T) {
+	t.Parallel()
+	p := newSlashPicker()
+	p.refilter("c") // clear, clone, compact
+	var names []string
+	for _, idx := range p.matches {
+		names = append(names, p.specs[idx].Name)
+	}
+	want := []string{"clear", "clone", "compact"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("/c matches = %v, want %v (alphabetical, stable)", names, want)
+	}
+}
+
+func TestSlashExactMatch(t *testing.T) {
+	t.Parallel()
+	p := newSlashPicker()
+	p.refilter("help")
+	if !p.exactMatch() {
+		t.Fatal("exactMatch() = false for fully-typed /help")
+	}
+	p.refilter("hel")
+	if p.exactMatch() {
+		t.Fatal("exactMatch() = true for partial /hel")
+	}
+}
+
+func TestApplySlashSelection(t *testing.T) {
+	t.Parallel()
+	if got := applySlashSelection("model"); got != "/model " {
+		t.Fatalf("got %q, want %q", got, "/model ")
+	}
+}
+
+func TestSlashPickerUpDownClamps(t *testing.T) {
+	t.Parallel()
+	p := newSlashPicker()
+	for i := 0; i < 50; i++ {
+		p.down()
+	}
+	if p.cursor != len(p.matches)-1 {
+		t.Fatalf("down past end: cursor = %d, want %d", p.cursor, len(p.matches)-1)
+	}
+	for i := 0; i < 50; i++ {
+		p.up()
+	}
+	if p.cursor != 0 {
+		t.Fatalf("up past start: cursor = %d", p.cursor)
+	}
+}
+
+func TestSlashPickerOpensAndTabCompletes(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+
+	m.input.SetValue("/mo")
+	m.refreshPickers()
+	if m.slashPicker == nil {
+		t.Fatal("slashPicker did not open for /mo")
+	}
+	if m.atPicker != nil {
+		t.Fatal("atPicker should be closed while slashPicker is open")
+	}
+
+	if _, _ = m.slashPickerAccept(); m.input.Value() != "/model " {
+		t.Fatalf("after accept, input = %q, want %q", m.input.Value(), "/model ")
+	}
+	if m.slashPicker != nil {
+		t.Fatal("slashPicker should close after accept")
+	}
+}
+
+func TestSlashPickerClosesOnSpace(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.input.SetValue("/model")
+	m.refreshPickers()
+	if m.slashPicker == nil {
+		t.Fatal("expected open picker for /model")
+	}
+	m.input.SetValue("/model ") // typed a space → now entering an argument
+	m.refreshPickers()
+	if m.slashPicker != nil {
+		t.Fatal("slashPicker should close once an argument is being typed")
+	}
+}
+
+func TestSlashPickerEnterRunsFullyTypedCommand(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.input.SetValue("/help")
+	m.refreshPickers()
+	if m.slashPicker == nil {
+		t.Fatal("expected open picker for /help")
+	}
+	// Enter on an exact match runs the command (does not re-complete).
+	_, _ = m.handleInputKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.input.Value() != "" {
+		t.Fatalf("input not cleared after running command: %q", m.input.Value())
+	}
+	if m.slashPicker != nil {
+		t.Fatal("slashPicker should be closed after running")
+	}
+	var sawCommands bool
+	for _, it := range m.transcript {
+		if it.Kind == itemBlock && strings.Contains(it.render(renderCtx{width: 80}), "Commands") {
+			sawCommands = true
+		}
+	}
+	if !sawCommands {
+		t.Fatal("/help did not append the Commands block")
+	}
+}
+
+func TestSlashPickerEnterRunsSelectedNoArgCommand(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	// "/cl" highlights /clear (a no-arg command) but isn't an exact match.
+	m.input.SetValue("/cl")
+	m.refreshPickers()
+	sel, ok := m.slashPicker.selected()
+	if !ok || sel.Name != "clear" || sel.Args != "" {
+		t.Fatalf("precondition: selected = %+v (ok=%v), want no-arg clear", sel, ok)
+	}
+	_, _ = m.handleInputKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.input.Value() != "" {
+		t.Fatalf("no-arg command should run on Enter; input = %q", m.input.Value())
+	}
+	if m.cfg.SessionID == "tui:test" {
+		t.Fatal("/clear did not run (session id unchanged)")
+	}
+}
+
+func TestSlashPickerEnterCompletesArgCommand(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	// "/mod" highlights /model, which takes an <id> argument.
+	m.input.SetValue("/mod")
+	m.refreshPickers()
+	_, _ = m.handleInputKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.input.Value() != "/model " {
+		t.Fatalf("arg command should complete (not run) on Enter; input = %q, want %q", m.input.Value(), "/model ")
+	}
+	if m.slashPicker != nil {
+		t.Fatal("picker should close after completing")
+	}
+}
+
+func TestSlashPickerEscClosesKeepingText(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.input.SetValue("/mo")
+	m.refreshPickers()
+	_, _ = m.handleInputKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.slashPicker != nil {
+		t.Fatal("Esc should close the slash picker")
+	}
+	if m.input.Value() != "/mo" {
+		t.Fatalf("Esc altered input: %q, want /mo preserved", m.input.Value())
+	}
+}
+
+func TestDescribeCommandsAndPickerShareSpecs(t *testing.T) {
+	t.Parallel()
+	body := describeCommands()
+	for _, s := range slashSpecs() {
+		if !strings.Contains(body, "/"+s.Name) {
+			t.Errorf("describeCommands missing /%s", s.Name)
+		}
+	}
+}

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -161,6 +161,11 @@ type Model struct {
 	// closed. Distinct from picker/tree because it's a popup ABOVE the
 	// input box, not a modal that replaces it.
 	atPicker *atPicker
+	// slashPicker is the inline `/command` autocomplete popup, opened when
+	// the input is a bare slash token. Like atPicker it sits above the
+	// input box; the two are mutually exclusive (slash needs a leading `/`
+	// with no space, @ needs a whitespace-bounded word).
+	slashPicker *slashPicker
 	// workspaceFiles is the cached file list for the @-autocomplete
 	// walker. Walked lazily on first @ trigger; never refreshed within
 	// a session (a follow-up could re-walk on /clear).
@@ -427,6 +432,19 @@ func (m *Model) layout() {
 		}
 		bottomH += rows + 4
 	}
+	// The /command popup occupies the same slot as the @-picker (they are
+	// never open together). Same height math: title(1) + matches + hint(1)
+	// + borders(2).
+	if m.slashPicker != nil {
+		rows := len(m.slashPicker.matches)
+		if rows > atPickerVisibleRows {
+			rows = atPickerVisibleRows
+		}
+		if rows == 0 {
+			rows = 1 // "(no matching command)" row
+		}
+		bottomH += rows + 4
+	}
 	bodyH := m.height - headerH - statusH - bottomH
 	if bodyH < 3 {
 		bodyH = 3
@@ -550,6 +568,11 @@ func (m *Model) bottomView() string {
 		pop := renderAtPicker(m.atPicker, m.width)
 		return lipgloss.JoinVertical(lipgloss.Left, pop, input)
 	}
+	if m.slashPicker != nil {
+		input := m.renderInputBox()
+		pop := renderSlashPicker(m.slashPicker, m.width)
+		return lipgloss.JoinVertical(lipgloss.Left, pop, input)
+	}
 	return m.renderInputBox()
 }
 
@@ -620,6 +643,14 @@ func (m *Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	//   - turn in flight: cancel it
 	//   - otherwise: no-op
 	if msg.Type == tea.KeyEsc {
+		if m.slashPicker != nil {
+			// Just close the popup; leave the typed text so the user can
+			// finish or edit the command by hand.
+			m.slashPicker = nil
+			m.layout()
+			m.rerender()
+			return m, nil
+		}
 		if m.atPicker != nil {
 			m.input.SetValue(removeAtToken(m.input.Value()))
 			m.input.CursorEnd()
@@ -655,6 +686,45 @@ func (m *Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.armedQuit = false
+
+	// /command autocomplete intercepts navigation/complete keys BEFORE
+	// history scroll and Enter-submit. Tab completes the highlighted
+	// command; Enter runs the input as typed (so a fully-typed command
+	// fires on the first Enter), except when the command is only partly
+	// typed — then Enter completes it, matching the @-picker's feel.
+	if m.slashPicker != nil {
+		switch msg.Type {
+		case tea.KeyTab:
+			return m.slashPickerAccept()
+		case tea.KeyUp:
+			m.slashPicker.up()
+			m.rerender()
+			return m, nil
+		case tea.KeyDown:
+			m.slashPicker.down()
+			m.rerender()
+			return m, nil
+		case tea.KeyEnter:
+			if sel, ok := m.slashPicker.selected(); ok && !m.slashPicker.exactMatch() {
+				// Complete to the highlighted command. If it takes no
+				// argument, run it straight away; otherwise fill `/name `
+				// and wait for the user to type the argument.
+				m.slashPicker = nil
+				if sel.Args == "" {
+					m.input.SetValue("/" + sel.Name)
+					return m.submit()
+				}
+				m.input.SetValue(applySlashSelection(sel.Name))
+				m.input.CursorEnd()
+				m.layout()
+				m.rerender()
+				return m, nil
+			}
+			// Exact match (or no matches): run the input as typed.
+			m.slashPicker = nil
+			return m.submit()
+		}
+	}
 
 	// @-autocomplete commands intercept their keys BEFORE history scroll
 	// and Enter-submit, so the navigation/select/cancel UX works.
@@ -707,12 +777,48 @@ func (m *Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	var c tea.Cmd
 	m.input, c = m.input.Update(msg)
-	// After the textarea has processed the keystroke, re-evaluate
-	// whether the input now ends in a fresh `@<query>` so we open,
-	// update, or close the autocomplete popup accordingly.
-	m.refreshAtPicker()
+	// After the textarea has processed the keystroke, re-evaluate which
+	// inline autocomplete (if any) should be open for the new input.
+	m.refreshPickers()
 	m.layout()
 	return m, c
+}
+
+// refreshPickers opens, updates, or closes the inline autocomplete popups
+// after a keystroke. A leading slash takes precedence (the input is a
+// command being typed); otherwise fall back to the @-file picker. The two
+// are mutually exclusive.
+func (m *Model) refreshPickers() {
+	if q, ok := detectSlashTrigger(m.input.Value()); ok {
+		m.atPicker = nil
+		if m.slashPicker == nil {
+			m.slashPicker = newSlashPicker()
+		}
+		m.slashPicker.refilter(q)
+		return
+	}
+	m.slashPicker = nil
+	m.refreshAtPicker()
+}
+
+// slashPickerAccept completes the input to the highlighted command
+// (`/name `, ready for an argument) and closes the popup.
+func (m *Model) slashPickerAccept() (tea.Model, tea.Cmd) {
+	if m.slashPicker == nil {
+		return m, nil
+	}
+	sel, ok := m.slashPicker.selected()
+	m.slashPicker = nil
+	if !ok {
+		m.layout()
+		m.rerender()
+		return m, nil
+	}
+	m.input.SetValue(applySlashSelection(sel.Name))
+	m.input.CursorEnd()
+	m.layout()
+	m.rerender()
+	return m, nil
 }
 
 // refreshAtPicker is called after every keystroke that flowed through


### PR DESCRIPTION
## Summary

Adds inline autocomplete for `/` slash commands in the coding-agent TUI, mirroring the existing `@`-file picker. Typing `/` opens a filtering command popup so commands are discoverable and completable without memorizing them — making good on the welcome card's "/ for commands" hint.

`Closes #318`

### UX
- `↑/↓` navigate, `Tab` completes the highlighted command.
- `Esc` closes the popup but keeps what you typed.
- `Enter` runs a fully-typed or no-argument command immediately, and completes an argument-taking command to `/<name> ` so you can type the argument.
- Opens only on a bare slash token (closes once you type a space / argument); mutually exclusive with the `@`-file picker.

### Internals
The command list is now a single source of truth (`slashSpecs`) shared by the picker and `/help`, so the two can't drift.

```
 ╭──────────────────────────────────────────────────────────╮
 │  Commands matching /c                                      │
 │ › /clear, /new  —  clear the transcript and start a fresh… │
 │   /clone  —  duplicate the current session into a fresh id │
 │   /compact  —  summarize older messages to free context…  │
 │   ↑/↓ navigate · Tab complete · Enter run · Esc cancel     │
 ╰──────────────────────────────────────────────────────────╯
```

## Verification

```
$ go build ./... && go vet ./cmd/glue/tui/   # clean
$ go test ./cmd/glue/tui/                     # ok
```

New tests cover trigger detection, prefix/alias matching, stable alphabetical ordering, Tab-complete, Esc-keeps-text, and the run-vs-complete Enter behavior for no-arg vs arg commands.

## Follow-up (out of scope)
Argument autocomplete — model ids after `/model`, session ids after `/session`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
