### PR TITLE
cmd/glue/tui: /goal — drive Agent.PursueGoal from the TUI (closes #322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **TUI `/goal`: drive the goal loop from inside `glue run` (Phase 2).**
+  `/goal <objective>` runs `Agent.PursueGoal` in the background on its own
+  session ids while the chat stays usable: a live goal card in the transcript
+  updates in place per iteration (verified `[x]/[ ]` checklist with evidence,
+  iteration counter, token usage, last checker verdict), and the status bar
+  gains a `◎ goal · iter 2/10 · 1/4 ✓ · 12.3k tok` segment. Subcommands:
+  `/goal status`, `/goal pause` (cancels cleanly, keeps the verified
+  checklist), `/goal resume` (continues from that checklist without
+  re-planning), `/goal clear`. Goal tool calls flow through the same in-card
+  permission prompt as chat turns — pending permission requests are now a FIFO
+  queue, so a concurrent goal + chat request can no longer drop one (`--yolo`
+  makes goals fully autonomous). Closes #322.
+- **`GoalSpec.Checklist`: seed `Agent.PursueGoal` with an existing plan.**
+  When non-empty, the planning step is skipped and the loop continues from the
+  given items (done flags and evidence respected) — the primitive behind
+  `/goal resume`, and the hook Phase 3's durable resume will reuse.
+- **`GoalSpec.Permission` now applies to the planner and checker sessions too**
+  (previously maker-only). Without this, a checker under an agent with no
+  default permission policy — e.g. the interactive TUI — was denied every
+  side-effecting tool and could not run builds or tests to verify evidence.
+
 ## 1.10.0 — 2026-06-09
 
 - **Goal loop: `Agent.PursueGoal` — "loop engineering" / `/goal` (Phase 1).**

--- a/README.md
+++ b/README.md
@@ -367,9 +367,15 @@ past sessions; ↑/↓ navigate, Enter replays the chosen one into the
 transcript), **`/fork [N]`** (branch from message N — defaults to
 "just before my last user turn" — into a new session id, keeping the
 original intact), **`/clone`** (full duplicate of the current
-session), and **`/tree`** (visualize the session lineage with
-`├─ / └─` glyphs, current node marked `◉`; pick one to switch). See
-[ADR-0015](docs/adr/0015-session-tree.md). Anywhere in a prompt,
+session), **`/tree`** (visualize the session lineage with
+`├─ / └─` glyphs, current node marked `◉`; pick one to switch — see
+[ADR-0015](docs/adr/0015-session-tree.md)), and **`/goal <objective>`**
+(pursue a goal autonomously in the background via `Agent.PursueGoal` —
+plan → maker → independent checker per iteration, with a live `[x]/[ ]`
+checklist card in the transcript, a `◎ goal · iter 2/10 · 1/4 ✓` status-bar
+segment, and `/goal status` / `pause` / `resume` (continues from the verified
+checklist without re-planning) / `clear` subcommands — see
+[ADR-0016](docs/adr/0016-goal-loop.md)). Anywhere in a prompt,
 **`@<path>`** inlines that file's
 contents (`@"path with space"` for spaces, `@@literal` to escape — and
 the workspace blocklist refuses `.env` / `id_rsa` / etc.). Typing

--- a/cmd/glue/tui/commands.go
+++ b/cmd/glue/tui/commands.go
@@ -60,6 +60,7 @@ func slashSpecs() []slashSpec {
 		{Name: "clear", Aliases: []string{"new"}, Desc: "clear the transcript and start a fresh session id"},
 		{Name: "usage", Desc: "show this turn's token usage (when the provider reports it)"},
 		{Name: "tools", Desc: "list registered tools"},
+		{Name: "goal", Args: "<objective>", Desc: "pursue a goal autonomously (also: status · pause · resume · clear)"},
 		{Name: "model", Args: "<id>", Desc: "switch model for subsequent turns"},
 		{Name: "session", Args: "[id]", Desc: "print current session id, or switch to <id>"},
 		{Name: "compact", Desc: "summarize older messages to free context window"},

--- a/cmd/glue/tui/goal.go
+++ b/cmd/glue/tui/goal.go
@@ -1,0 +1,341 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/erain/glue"
+)
+
+// goalMaxIterations mirrors the library default for GoalSpec.MaxIterations.
+// The TUI sets it explicitly on the spec so the status bar can render an
+// honest "iter 2/10" denominator without reaching into glue internals.
+const goalMaxIterations = 10
+
+// goalState tracks the single in-TUI goal pursuit. The loop itself runs in
+// a background goroutine (Agent.PursueGoal on its own session ids); this
+// struct only mirrors what the Emit events report, for the live card and
+// the status bar.
+type goalState struct {
+	objective string
+	cancel    context.CancelFunc
+
+	running bool
+	paused  bool            // user ran /goal pause; cancel maps to "paused", not an error
+	status  glue.GoalStatus // terminal status once finished; "" while running or paused
+
+	iteration     int
+	maxIterations int
+	checklist     []glue.ChecklistItem
+	usage         glue.Usage
+	summary       string // last checker verdict summary
+
+	// cardIdx is the transcript index of the live goal card, updated in
+	// place as events arrive. -1 means not created yet (or detached after
+	// a transcript reset — the next event re-appends it).
+	cardIdx int
+}
+
+// handleSlashGoal dispatches the /goal command family. A bare single-word
+// subcommand manages the current goal; anything else is a new objective.
+func (m *Model) handleSlashGoal(arg string) (tea.Model, tea.Cmd) {
+	switch strings.ToLower(arg) {
+	case "":
+		if m.goal != nil {
+			m.appendBlock("Goal", m.goal.cardBody())
+		} else {
+			m.appendSystem("usage: /goal <objective> — then /goal status · pause · resume · clear")
+		}
+	case "status":
+		if m.goal == nil {
+			m.appendSystem("/goal status: no goal yet — start one with /goal <objective>")
+		} else {
+			m.appendBlock("Goal", m.goal.cardBody())
+		}
+	case "pause":
+		switch {
+		case m.goal == nil || !m.goal.running:
+			m.appendSystem("/goal pause: no goal running")
+		default:
+			m.goal.paused = true
+			m.goal.cancel()
+			m.appendSystem("pausing goal after the in-flight call returns…")
+		}
+	case "resume":
+		switch {
+		case m.goal == nil:
+			m.appendSystem("/goal resume: no goal to resume — start one with /goal <objective>")
+		case m.goal.running:
+			m.appendSystem("/goal resume: goal is already running")
+		case len(m.goal.checklist) == 0:
+			m.appendSystem("/goal resume: no checklist captured; start over with /goal <objective>")
+		default:
+			return m.startGoal(m.goal.objective, m.goal.checklist)
+		}
+	case "clear", "stop":
+		if m.goal == nil {
+			m.appendSystem("/goal clear: no goal to clear")
+		} else {
+			if m.goal.running {
+				m.goal.paused = true // suppress the "goal error" line from the cancel
+				m.goal.cancel()
+			}
+			m.goal = nil
+			m.appendSystem("goal cleared.")
+		}
+	default:
+		return m.startGoal(arg, nil)
+	}
+	m.rerender()
+	return m, nil
+}
+
+// startGoal launches Agent.PursueGoal in the background. A non-empty seed
+// is the resume path: the loop skips planning and continues from the last
+// verified checklist.
+func (m *Model) startGoal(objective string, seed []glue.ChecklistItem) (tea.Model, tea.Cmd) {
+	if m.goal != nil && m.goal.running {
+		m.appendSystem("/goal: a goal is already running — /goal status to inspect, /goal pause or /goal clear first.")
+		m.rerender()
+		return m, nil
+	}
+	if m.send == nil {
+		m.appendSystem("tui: program send not initialised")
+		m.rerender()
+		return m, nil
+	}
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	g := &goalState{
+		objective:     objective,
+		cancel:        cancel,
+		running:       true,
+		maxIterations: goalMaxIterations,
+		checklist:     append([]glue.ChecklistItem(nil), seed...),
+		cardIdx:       -1,
+	}
+	m.goal = g
+
+	send := m.send
+	agent := m.cfg.Agent
+	spec := glue.GoalSpec{
+		Objective:     objective,
+		SessionPrefix: "goal-" + shortID(),
+		Model:         m.cfg.Model,
+		MaxIterations: goalMaxIterations,
+		Checklist:     seed,
+		Permission:    m.perm,
+		Emit:          func(ev glue.GoalEvent) { send(goalEventMsg{Ev: ev}) },
+	}
+	go func() {
+		defer cancel()
+		res, err := agent.PursueGoal(ctx, spec)
+		send(goalDoneMsg{Res: res, Err: err})
+	}()
+
+	verb := "pursuing"
+	if len(seed) > 0 {
+		verb = "resuming"
+	}
+	m.appendSystem(fmt.Sprintf("%s goal: %s  (/goal status · pause · clear)", verb, objective))
+	m.rerender()
+	return m, m.spinner.Tick
+}
+
+// goalRunning reports whether a goal loop is in flight (keeps the spinner
+// ticking even when no chat turn is active).
+func (m *Model) goalRunning() bool {
+	return m.goal != nil && m.goal.running
+}
+
+// handleGoalEvent mirrors one Emit event into the goal state and refreshes
+// the live card.
+func (m *Model) handleGoalEvent(ev glue.GoalEvent) {
+	g := m.goal
+	if g == nil {
+		return
+	}
+	switch ev.Type {
+	case glue.GoalEventPlan:
+		g.checklist = ev.Checklist
+	case glue.GoalEventIterationStart:
+		g.iteration = ev.Iteration
+	case glue.GoalEventVerdict:
+		g.checklist = ev.Checklist
+		g.summary = ev.Message
+	}
+	g.usage = ev.Usage
+	m.updateGoalCard()
+}
+
+// handleGoalDone records the terminal result. A pause shows as "paused"
+// rather than surfacing the underlying context cancellation as an error.
+func (m *Model) handleGoalDone(msg goalDoneMsg) {
+	g := m.goal
+	if g == nil {
+		return // cleared while the final message was in flight
+	}
+	g.running = false
+	if len(msg.Res.Checklist) > 0 {
+		g.checklist = msg.Res.Checklist
+	}
+	if msg.Res.Summary != "" {
+		g.summary = msg.Res.Summary
+	}
+	g.usage = msg.Res.Usage
+	if msg.Res.Iterations > g.iteration {
+		g.iteration = msg.Res.Iterations
+	}
+	switch {
+	case g.paused && errors.Is(msg.Err, context.Canceled):
+		m.appendSystem("goal paused — /goal resume continues from the verified checklist.")
+	case msg.Err != nil:
+		g.status = glue.GoalErrored
+		m.appendSystem("goal error: " + msg.Err.Error())
+	default:
+		g.status = msg.Res.Status
+		note := fmt.Sprintf("goal %s after %d iteration(s): %s", g.status, g.iteration, doneFraction(g.checklist))
+		if g.summary != "" {
+			note += " — " + g.summary
+		}
+		m.appendSystem(note)
+	}
+	m.updateGoalCard()
+}
+
+// updateGoalCard rewrites the live goal card in place, or (re)appends it
+// when missing — e.g. before the first event, or after /clear or a session
+// switch reset the transcript under it.
+func (m *Model) updateGoalCard() {
+	g := m.goal
+	if g == nil {
+		return
+	}
+	body := g.cardBody()
+	if g.cardIdx >= 0 && g.cardIdx < len(m.transcript) &&
+		m.transcript[g.cardIdx].Kind == itemBlock && m.transcript[g.cardIdx].BlockTitle == "Goal" {
+		m.transcript[g.cardIdx].BlockBody = body
+		return
+	}
+	m.transcript = append(m.transcript, transcriptItem{Kind: itemBlock, BlockTitle: "Goal", BlockBody: body})
+	g.cardIdx = len(m.transcript) - 1
+}
+
+// detachGoalCard forgets the card's transcript index after a transcript
+// reset; the next event re-appends the card instead of clobbering whatever
+// now lives at the stale index.
+func (m *Model) detachGoalCard() {
+	if m.goal != nil {
+		m.goal.cardIdx = -1
+	}
+}
+
+// cardBody renders the goal card / /goal status block.
+func (g *goalState) cardBody() string {
+	var b strings.Builder
+	b.WriteString("  " + g.objective + "\n\n")
+	b.WriteString(renderGoalChecklist(g.checklist))
+	b.WriteString("\n\n  " + g.stateLine())
+	if g.summary != "" {
+		b.WriteString("\n  " + keyHint.Render("verdict: "+truncateGoalText(g.summary, 80)))
+	}
+	return b.String()
+}
+
+// stateLine is the one-line progress summary shared by the card footer.
+func (g *goalState) stateLine() string {
+	switch {
+	case g.running && g.iteration == 0:
+		return toolWarning.Render("planning…")
+	case g.running:
+		return toolWarning.Render(fmt.Sprintf("iter %d/%d", g.iteration, g.maxIterations)) +
+			keyHint.Render(fmt.Sprintf(" · %s ✓ · %s tok", doneFraction(g.checklist), formatTokens(g.usage.TotalTokens)))
+	case g.paused:
+		return toolWarning.Render("paused") +
+			keyHint.Render(fmt.Sprintf(" · %s ✓ · /goal resume to continue", doneFraction(g.checklist)))
+	default:
+		return goalStatusStyle(g.status).Render(string(g.status)) +
+			keyHint.Render(fmt.Sprintf(" · iter %d · %s ✓ · %s tok", g.iteration, doneFraction(g.checklist), formatTokens(g.usage.TotalTokens)))
+	}
+}
+
+// statusSegment is the compact status-bar chip, e.g.
+// "◎ goal · iter 2/10 · 1/4 ✓ · 12.3k tok".
+func (g *goalState) statusSegment() string {
+	switch {
+	case g.running && g.iteration == 0:
+		return toolWarning.Render("◎ goal · planning")
+	case g.running:
+		return toolWarning.Render(fmt.Sprintf("◎ goal · iter %d/%d · %s ✓ · %s tok",
+			g.iteration, g.maxIterations, doneFraction(g.checklist), formatTokens(g.usage.TotalTokens)))
+	case g.paused:
+		return toolWarning.Render(fmt.Sprintf("◎ goal paused · %s ✓", doneFraction(g.checklist)))
+	default:
+		return goalStatusStyle(g.status).Render("◎ goal " + string(g.status))
+	}
+}
+
+func goalStatusStyle(s glue.GoalStatus) lipgloss.Style {
+	switch s {
+	case glue.GoalAchieved:
+		return toolOk
+	case glue.GoalErrored, glue.GoalBlocked:
+		return toolErrSty
+	default:
+		return toolWarning
+	}
+}
+
+func renderGoalChecklist(items []glue.ChecklistItem) string {
+	if len(items) == 0 {
+		return keyHint.Render("  (no checklist yet)")
+	}
+	lines := make([]string, 0, len(items))
+	for _, it := range items {
+		box := keyHint.Render("[ ]")
+		if it.Done {
+			box = toolOk.Render("[x]")
+		}
+		line := "  " + box + " " + it.Title
+		if it.Evidence != "" {
+			line += " " + keyHint.Render("— "+truncateGoalText(it.Evidence, 60))
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// doneFraction renders "2/5" for the checklist completion count.
+func doneFraction(items []glue.ChecklistItem) string {
+	done := 0
+	for _, it := range items {
+		if it.Done {
+			done++
+		}
+	}
+	return fmt.Sprintf("%d/%d", done, len(items))
+}
+
+// formatTokens compacts a token count for chrome: 987, 12.3k, 1.2M.
+func formatTokens(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fk", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
+func truncateGoalText(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/cmd/glue/tui/goal_test.go
+++ b/cmd/glue/tui/goal_test.go
@@ -1,0 +1,265 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/erain/glue"
+)
+
+func testChecklist() []glue.ChecklistItem {
+	return []glue.ChecklistItem{{Title: "A", Done: true, Evidence: "A.go"}, {Title: "B"}}
+}
+
+func TestGoalEventLifecycleUpdatesCardInPlace(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.goal = &goalState{objective: "ship it", running: true, maxIterations: 10, cardIdx: -1}
+
+	m.handleGoalEvent(glue.GoalEvent{Type: glue.GoalEventPlan, Checklist: testChecklist()})
+	if m.goal.cardIdx != len(m.transcript)-1 {
+		t.Fatalf("cardIdx = %d, want last transcript index %d", m.goal.cardIdx, len(m.transcript)-1)
+	}
+	cardCount := len(m.transcript)
+
+	m.handleGoalEvent(glue.GoalEvent{Type: glue.GoalEventIterationStart, Iteration: 2, Usage: glue.Usage{TotalTokens: 12345}})
+	m.handleGoalEvent(glue.GoalEvent{
+		Type:      glue.GoalEventVerdict,
+		Iteration: 2,
+		Message:   "B remains",
+		Checklist: testChecklist(),
+		Usage:     glue.Usage{TotalTokens: 23456},
+	})
+	if len(m.transcript) != cardCount {
+		t.Fatalf("transcript grew to %d items, want card updated in place", len(m.transcript))
+	}
+
+	plain := stripANSI(m.transcript[m.goal.cardIdx].render(renderCtx{width: 100}))
+	for _, want := range []string{"ship it", "[x] A", "— A.go", "[ ] B", "iter 2/10", "1/2", "23.5k tok", "verdict: B remains"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("card missing %q\n%s", want, plain)
+		}
+	}
+	seg := stripANSI(m.goal.statusSegment())
+	if !strings.Contains(seg, "iter 2/10") || !strings.Contains(seg, "1/2") {
+		t.Errorf("status segment = %q, want iter and fraction", seg)
+	}
+}
+
+func TestGoalCardReattachesAfterTranscriptReset(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.goal = &goalState{objective: "x", running: true, maxIterations: 10, cardIdx: -1}
+	m.handleGoalEvent(glue.GoalEvent{Type: glue.GoalEventPlan, Checklist: testChecklist()})
+
+	// Simulate /clear: transcript nuked, card index detached.
+	m.transcript = nil
+	m.detachGoalCard()
+
+	m.handleGoalEvent(glue.GoalEvent{Type: glue.GoalEventIterationStart, Iteration: 1})
+	if len(m.transcript) != 1 || m.transcript[0].Kind != itemBlock || m.transcript[0].BlockTitle != "Goal" {
+		t.Fatalf("transcript = %#v, want single re-appended goal card", m.transcript)
+	}
+}
+
+func TestGoalDoneMapsCancelToPaused(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.goal = &goalState{objective: "x", running: true, paused: true, maxIterations: 10, cardIdx: -1, checklist: testChecklist()}
+
+	m.handleGoalDone(goalDoneMsg{
+		Res: glue.GoalResult{Status: glue.GoalErrored, Checklist: testChecklist(), Iterations: 1},
+		Err: context.Canceled,
+	})
+	if m.goal.running {
+		t.Fatal("goal still running after done")
+	}
+	if m.goal.status != "" {
+		t.Fatalf("status = %q, want empty (paused, not terminal)", m.goal.status)
+	}
+	seg := stripANSI(m.goal.statusSegment())
+	if !strings.Contains(seg, "paused") {
+		t.Errorf("status segment = %q, want paused", seg)
+	}
+	// No "goal error:" line — pause is not an error.
+	for _, it := range m.transcript {
+		if it.Kind == itemSystem && strings.Contains(it.Text, "goal error") {
+			t.Errorf("unexpected error line: %q", it.Text)
+		}
+	}
+}
+
+func TestSlashGoalSubcommandGating(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+
+	lastSystem := func() string {
+		for i := len(m.transcript) - 1; i >= 0; i-- {
+			if m.transcript[i].Kind == itemSystem {
+				return m.transcript[i].Text
+			}
+		}
+		return ""
+	}
+
+	m.handleSlashGoal("")
+	if !strings.Contains(lastSystem(), "usage: /goal") {
+		t.Errorf("bare /goal with no goal: %q", lastSystem())
+	}
+	m.handleSlashGoal("pause")
+	if !strings.Contains(lastSystem(), "no goal running") {
+		t.Errorf("/goal pause with no goal: %q", lastSystem())
+	}
+	m.handleSlashGoal("resume")
+	if !strings.Contains(lastSystem(), "no goal to resume") {
+		t.Errorf("/goal resume with no goal: %q", lastSystem())
+	}
+
+	m.goal = &goalState{objective: "x", running: true, maxIterations: 10, cardIdx: -1}
+	m.handleSlashGoal("resume")
+	if !strings.Contains(lastSystem(), "already running") {
+		t.Errorf("/goal resume while running: %q", lastSystem())
+	}
+
+	m.goal = &goalState{objective: "x", running: false, maxIterations: 10, cardIdx: -1}
+	m.handleSlashGoal("resume")
+	if !strings.Contains(lastSystem(), "no checklist captured") {
+		t.Errorf("/goal resume without checklist: %q", lastSystem())
+	}
+
+	m.handleSlashGoal("clear")
+	if m.goal != nil || !strings.Contains(lastSystem(), "goal cleared") {
+		t.Errorf("/goal clear: goal=%v msg=%q", m.goal, lastSystem())
+	}
+}
+
+func TestPermissionQueuePromotesNextRequest(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+	m.width, m.height = 100, 40
+	m.ready = true
+
+	first := make(chan glue.PermissionDecision, 1)
+	second := make(chan glue.PermissionDecision, 1)
+	m.Update(permRequestMsg{Req: glue.PermissionRequest{Tool: "write_file", Target: "a.go"}, Respond: first})
+	m.Update(permRequestMsg{Req: glue.PermissionRequest{Tool: "run_command", Target: "go test"}, Respond: second})
+
+	if m.pending == nil || m.pending.req.Tool != "write_file" {
+		t.Fatalf("pending = %+v, want write_file first", m.pending)
+	}
+	if len(m.permQueue) != 1 {
+		t.Fatalf("queue len = %d, want 1", len(m.permQueue))
+	}
+
+	m.handlePermissionKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	if d := <-first; !d.Allow {
+		t.Fatal("first request not allowed")
+	}
+	if m.pending == nil || m.pending.req.Tool != "run_command" {
+		t.Fatalf("pending after promote = %+v, want run_command", m.pending)
+	}
+	if len(m.permQueue) != 0 {
+		t.Fatalf("queue len = %d, want 0 after promote", len(m.permQueue))
+	}
+
+	m.handlePermissionKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if d := <-second; d.Allow {
+		t.Fatal("second request unexpectedly allowed")
+	}
+	if m.pending != nil {
+		t.Fatalf("pending = %+v, want nil after queue drained", m.pending)
+	}
+}
+
+func TestFormatTokens(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   int64
+		want string
+	}{{0, "0"}, {987, "987"}, {1500, "1.5k"}, {23456, "23.5k"}, {1_200_000, "1.2M"}}
+	for _, c := range cases {
+		if got := formatTokens(c.in); got != c.want {
+			t.Errorf("formatTokens(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// scriptedGoalProvider replays one fixed event stream per Stream call, in
+// order — mirrors the glue package's recordingProvider for goal loops.
+type scriptedGoalProvider struct {
+	mu    sync.Mutex
+	calls int
+	turns [][]glue.ProviderEvent
+}
+
+func (p *scriptedGoalProvider) Stream(_ context.Context, _ glue.ProviderRequest) (<-chan glue.ProviderEvent, error) {
+	p.mu.Lock()
+	turn := p.turns[p.calls%len(p.turns)]
+	p.calls++
+	p.mu.Unlock()
+	ch := make(chan glue.ProviderEvent, len(turn))
+	for _, e := range turn {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func scriptedTurn(text string) []glue.ProviderEvent {
+	msg := glue.Message{
+		Role:    glue.MessageRoleAssistant,
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
+	}
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: text},
+		{Type: glue.ProviderEventDone, Message: &msg},
+	}
+}
+
+func TestStartGoalRunsLoopToAchieved(t *testing.T) {
+	t.Parallel()
+	provider := &scriptedGoalProvider{turns: [][]glue.ProviderEvent{
+		scriptedTurn(`{"items":[{"title":"A"}]}`),
+		scriptedTurn("worked on A"),
+		scriptedTurn(`{"done":true,"items":[{"title":"A","done":true,"evidence":"verified"}],"summary":"all done"}`),
+	}}
+	agent := glue.NewAgent(glue.AgentOptions{Provider: provider, Model: "fake-1"})
+
+	m := makeTestModel(t)
+	m.cfg.Agent = agent
+	msgs := make(chan tea.Msg, 64)
+	m.send = func(msg tea.Msg) { msgs <- msg }
+
+	m.startGoal("ship A", nil)
+	if !m.goalRunning() {
+		t.Fatal("goal not running after startGoal")
+	}
+
+	deadline := time.After(10 * time.Second)
+	for m.goalRunning() {
+		select {
+		case msg := <-msgs:
+			m.Update(msg)
+		case <-deadline:
+			t.Fatal("timed out waiting for goalDoneMsg")
+		}
+	}
+	if m.goal.status != glue.GoalAchieved {
+		t.Fatalf("status = %q, want achieved", m.goal.status)
+	}
+	seg := stripANSI(m.goal.statusSegment())
+	if !strings.Contains(seg, "achieved") {
+		t.Errorf("status segment = %q, want achieved", seg)
+	}
+	plain := stripANSI(m.transcript[m.goal.cardIdx].render(renderCtx{width: 100}))
+	for _, want := range []string{"[x] A", "— verified", "achieved", "1/1"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("final card missing %q\n%s", want, plain)
+		}
+	}
+}

--- a/cmd/glue/tui/messages.go
+++ b/cmd/glue/tui/messages.go
@@ -51,5 +51,15 @@ type sessionSwitchedMsg struct {
 	Messages []glue.Message
 }
 
+// goalEventMsg wraps one GoalSpec.Emit event from the background
+// Agent.PursueGoal goroutine started by /goal.
+type goalEventMsg struct{ Ev glue.GoalEvent }
+
+// goalDoneMsg fires when PursueGoal returns with its terminal result.
+type goalDoneMsg struct {
+	Res glue.GoalResult
+	Err error
+}
+
 // fatalErrMsg marks a setup error that should end the session.
 type fatalErrMsg struct{ Err error }

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -142,7 +142,15 @@ type Model struct {
 	turn     *turnState
 	turnNum  int
 	pending  *permPending
+	// permQueue holds permission requests that arrived while another was
+	// already on screen — a background /goal loop and a chat turn can ask
+	// concurrently, and a single slot would silently drop one (deadlocking
+	// its goroutine until cancel). FIFO: answered in arrival order.
+	permQueue []permPending
 	lastUsage *glue.Usage
+
+	// goal is the single in-TUI goal pursuit (/goal). Nil means none.
+	goal *goalState
 
 	// Input history (in-process; not persisted)
 	history    []string
@@ -304,9 +312,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, c
 
 	case spinner.TickMsg:
-		// Spinner only animates during an in-flight turn; once the turn
-		// ends, stop ticking instead of consuming Update cycles forever.
-		if m.turn == nil {
+		// Spinner only animates during an in-flight turn or goal loop; once
+		// both end, stop ticking instead of consuming Update cycles forever.
+		if m.turn == nil && !m.goalRunning() {
 			return m, nil
 		}
 		var c tea.Cmd
@@ -332,6 +340,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case permRequestMsg:
+		if m.pending != nil {
+			m.permQueue = append(m.permQueue, permPending{req: msg.Req, respond: msg.Respond})
+			return m, nil
+		}
 		m.pending = &permPending{req: msg.Req, respond: msg.Respond}
 		m.markPendingTool(msg.Req)
 		m.rerender()
@@ -339,6 +351,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case turnDoneMsg:
 		m.handleTurnDone(msg)
+		m.rerender()
+		return m, nil
+
+	case goalEventMsg:
+		m.handleGoalEvent(msg.Ev)
+		m.rerender()
+		return m, nil
+
+	case goalDoneMsg:
+		m.handleGoalDone(msg)
 		m.rerender()
 		return m, nil
 
@@ -350,6 +372,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionSwitchedMsg:
 		m.cfg.SessionID = msg.ID
 		m.transcript = nil
+		m.detachGoalCard()
 		m.appendSystem(msg.Note + ": " + msg.ID)
 		m.transcript = append(m.transcript, transcriptFromMessages(msg.Messages)...)
 		m.turnNum = 0
@@ -614,6 +637,9 @@ func (m *Model) statusView() string {
 			}
 		}
 		parts = append(parts, m.spinner.View()+" "+toolWarning.Render(state))
+	}
+	if m.goal != nil {
+		parts = append(parts, m.goal.statusSegment())
 	}
 	if m.pending != nil {
 		parts = append(parts, toolWarning.Render("permission needed"))
@@ -938,6 +964,7 @@ func (m *Model) handleSlash(cmd slashCommand) (tea.Model, tea.Cmd) {
 		// behavior (only switching session id) confused users who saw
 		// last turn's content under a fresh session.
 		m.transcript = nil
+		m.detachGoalCard()
 		m.cfg.SessionID = "tui:" + shortID()
 		m.appendWelcome()
 		m.appendSystem("transcript cleared. new session: " + m.cfg.SessionID)
@@ -985,6 +1012,8 @@ func (m *Model) handleSlash(cmd slashCommand) (tea.Model, tea.Cmd) {
 		}
 		m.rerender()
 		return m, nil
+	case "goal":
+		return m.handleSlashGoal(cmd.Arg)
 	case "compact":
 		return m.runSlashCompact()
 	case "resume":
@@ -1052,6 +1081,14 @@ func (m *Model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	p.respond <- *decision
 	close(p.respond)
+	// Promote the next queued request, if any (e.g. a /goal tool call that
+	// arrived while this prompt was on screen).
+	if len(m.permQueue) > 0 {
+		next := m.permQueue[0]
+		m.permQueue = m.permQueue[1:]
+		m.pending = &next
+		m.markPendingTool(next.req)
+	}
 	m.rerender()
 	return m, nil
 }
@@ -1599,6 +1636,7 @@ func (m *Model) handlePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.cfg.SessionID = s.ID
 		m.transcript = nil
+		m.detachGoalCard()
 		m.appendSystem("resumed: " + s.ID)
 		m.transcript = append(m.transcript, transcriptFromMessages(sess.Messages())...)
 		m.turnNum = 0

--- a/docs/design.md
+++ b/docs/design.md
@@ -280,8 +280,12 @@ growing transcript) followed by a separate **checker** session that audits
 against real evidence via `Session.PromptJSON` and decides completion. Guardrails
 (max iterations, no-progress detection, token budget) bound it, and `GoalSpec.Emit`
 streams progress. The maker≠checker split keeps the writer from grading its own
-homework. See [ADR-0016](adr/0016-goal-loop.md). Phase 1 is the headless
-primitive; the TUI `/goal` command and durable resume are follow-ups.
+homework. See [ADR-0016](adr/0016-goal-loop.md). A non-empty `GoalSpec.Checklist`
+seeds the loop and skips planning — that is how a paused goal resumes from its
+last verified state. The TUI surfaces all of this as `/goal <objective>` with
+`status` / `pause` / `resume` / `clear` subcommands, a live checklist card in
+the transcript, and a `◎ goal` status-bar segment; durable resume across
+restarts is the Phase 3 follow-up.
 
 ## Gemini Provider
 

--- a/goal.go
+++ b/goal.go
@@ -44,6 +44,12 @@ type GoalSpec struct {
 	// Defaults to 2.
 	NoProgressLimit int
 
+	// Checklist seeds the loop with an existing plan instead of asking the
+	// model to decompose the objective; done flags and evidence are kept as
+	// given. This is how a paused or restarted goal resumes from its last
+	// verified state without re-planning.
+	Checklist []ChecklistItem
+
 	// Tools overrides the maker tool set. Empty uses the agent's tools.
 	Tools []Tool
 	// CheckerTools overrides the verifier tool set. Empty uses the agent's
@@ -56,8 +62,9 @@ type GoalSpec struct {
 	// built-in audit prompt.
 	CheckerSystemPrompt string
 
-	// Permission overrides the permission policy for the maker's
-	// side-effecting tools. Nil uses the agent's policy.
+	// Permission overrides the permission policy for side-effecting tools
+	// in the planner, maker, and checker sessions. Nil uses the agent's
+	// policy.
 	Permission Permission
 
 	// Emit, when set, receives progress events as the loop runs.
@@ -155,12 +162,19 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		}
 	}
 
-	// 1) Plan: decompose the objective into verifiable deliverables.
-	checklist, planUsage, err := a.planGoal(ctx, spec)
-	addUsage(&result.Usage, planUsage)
-	if err != nil || len(checklist) == 0 {
-		// A failed plan is recoverable: treat the whole objective as one item.
-		checklist = []ChecklistItem{{Title: spec.Objective}}
+	// 1) Plan: decompose the objective into verifiable deliverables — unless
+	// the caller seeded a checklist (a resumed goal keeps its verified state).
+	var checklist []ChecklistItem
+	if len(spec.Checklist) > 0 {
+		checklist = cloneChecklist(spec.Checklist)
+	} else {
+		planned, planUsage, err := a.planGoal(ctx, spec)
+		addUsage(&result.Usage, planUsage)
+		checklist = planned
+		if err != nil || len(checklist) == 0 {
+			// A failed plan is recoverable: treat the whole objective as one item.
+			checklist = []ChecklistItem{{Title: spec.Objective}}
+		}
 	}
 	emit(GoalEvent{Type: GoalEventPlan, Checklist: cloneChecklist(checklist), Usage: result.Usage})
 
@@ -275,6 +289,9 @@ func (a *Agent) planGoal(ctx context.Context, spec GoalSpec) ([]ChecklistItem, U
 	if spec.MaxTurns > 0 {
 		opts = append(opts, WithMaxTurns(spec.MaxTurns))
 	}
+	if spec.Permission != nil {
+		opts = append(opts, WithPermission(spec.Permission))
+	}
 	var plan goalPlan
 	res, err := sess.PromptJSON(ctx, planPrompt(spec.Objective), &plan, opts...)
 	var usage Usage
@@ -337,6 +354,9 @@ func (a *Agent) runGoalChecker(ctx context.Context, spec GoalSpec, iter int, che
 	}
 	if spec.MaxTurns > 0 {
 		opts = append(opts, WithMaxTurns(spec.MaxTurns))
+	}
+	if spec.Permission != nil {
+		opts = append(opts, WithPermission(spec.Permission))
 	}
 	var verdict goalVerdict
 	res, err := sess.PromptJSON(ctx, checkerPrompt(spec.Objective, checklist), &verdict, opts...)

--- a/goal_test.go
+++ b/goal_test.go
@@ -164,6 +164,41 @@ func TestPursueGoalPlanFallbackToObjective(t *testing.T) {
 	}
 }
 
+func TestPursueGoalSeededChecklistSkipsPlanning(t *testing.T) {
+	t.Parallel()
+
+	// A seeded checklist (the resume path) must go straight to the maker —
+	// the scripted turns contain no plan response, so a planning call would
+	// desynchronize the provider script and fail the assertions below.
+	provider := &recordingProvider{turns: [][]ProviderEvent{
+		goalTurn("finished B", 0),
+		goalTurn(mustJSON(t, goalVerdict{Done: true, Items: []ChecklistItem{{Title: "A", Done: true, Evidence: "A.go"}, {Title: "B", Done: true}}, Summary: "done"}), 0),
+	}}
+
+	var planned []ChecklistItem
+	res, err := newGoalAgent(provider).PursueGoal(context.Background(), GoalSpec{
+		Objective: "ship A and B",
+		Checklist: []ChecklistItem{{Title: "A", Done: true, Evidence: "A.go"}, {Title: "B"}},
+		Emit: func(ev GoalEvent) {
+			if ev.Type == GoalEventPlan {
+				planned = ev.Checklist
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("PursueGoal: %v", err)
+	}
+	if res.Status != GoalAchieved {
+		t.Fatalf("status = %q, want achieved", res.Status)
+	}
+	if provider.calls != 2 {
+		t.Fatalf("provider calls = %d, want 2 (no planning call)", provider.calls)
+	}
+	if len(planned) != 2 || !planned[0].Done || planned[0].Evidence != "A.go" || planned[1].Done {
+		t.Fatalf("plan event checklist = %+v, want seeded state preserved", planned)
+	}
+}
+
 func TestPursueGoalValidation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Goal loop **Phase 2** ([ADR-0016](https://github.com/erain/glue/blob/main/docs/adr/0016-goal-loop.md), tracker #110). Phase 1 shipped the headless `Agent.PursueGoal` primitive in v1.10.0; this PR puts it in the driver's seat of `glue run`.

## What

- **`/goal <objective>`** starts a background pursuit on its own `goal-<id>` session prefix — chat stays fully usable while it runs. One goal at a time.
- **Live goal card**: one transcript block created on the plan event, updated in place per iteration — verified `[x]/[ ]` checklist with evidence, iteration counter, token usage, last checker verdict. Survives `/clear` and session switches (the card detaches and re-appends on the next event).
- **Status bar**: `◎ goal · iter 2/10 · 1/4 ✓ · 12.3k tok` while running; `paused` / terminal status (`achieved` green, `blocked`/`errored` red) until cleared.
- **`/goal status | pause | resume | clear`** — pause cancels the in-flight call but keeps the verified checklist; resume continues from it **without re-planning**; clear stops and forgets. Pause maps the underlying `context.Canceled` to a "paused" display state, not an error.
- **`GoalSpec.Checklist`** (library): when non-empty, `PursueGoal` skips planning and seeds the loop with the given items, done flags and evidence respected. This is the `/goal resume` mechanism and the hook Phase 3 durable resume will reuse.
- **`GoalSpec.Permission` now reaches planner + checker sessions** (was maker-only). Phase 1 gap: in the TUI the agent-level permission is nil (deny-by-default), so the checker could never run builds/tests to verify evidence.
- **Permission FIFO queue**: a goal tool call and a chat tool call can request permission concurrently; the single `m.pending` slot would have silently dropped one (deadlocking its goroutine until cancel). Requests now queue and are answered in arrival order.
- `/goal` is in `slashSpecs()`, so `/help` and the v1.9.0 autocomplete pick it up automatically.

## Tests

- `goal_test.go`: `TestPursueGoalSeededChecklistSkipsPlanning` — seeded run makes no planning call (the scripted provider would desync otherwise), seeded state preserved in the plan event.
- `cmd/glue/tui/goal_test.go`: card lifecycle (create on plan, update in place, re-attach after transcript reset), pause↔cancel mapping, subcommand gating, permission-queue promotion, token formatting, and an end-to-end `startGoal` run against a scripted provider through the real `PursueGoal` loop to `achieved`.

## Verification

```
go build ./... && go vet ./...   # clean
go test ./...                    # all packages pass
```

Closes #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)