### PR TITLE
glue: durable goal state + resume across restarts (closes #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Durable goal state + resume across restarts (goal loop Phase 3a).**
+  When the agent has a `Store`, `Agent.PursueGoal` checkpoints a `GoalRecord`
+  (objective, status, verified checklist, iterations, usage, summary) as
+  namespaced `glue/goal:*` metadata on the `SessionPrefix` session — after
+  planning, after every checker verdict, and at the terminal state. A context
+  cancellation persists as the new `GoalPaused` status (resumable); the new
+  `GoalRunning` status marks in-flight records. `Agent.LoadGoal` and
+  `Agent.ListGoals` (most recent first, via the optional `SessionLister`
+  capability) read records back, and `GoalRecord.Resumable()` says whether a
+  goal can continue from its checklist. `GoalSpec.StartIteration` lets a
+  resumed run continue iteration numbering (`iter-4`, `check-4`, …) so
+  maker/checker sessions stay fresh instead of appending to the previous
+  run's transcripts. In the TUI, `/goal resume` with no in-process goal now
+  continues the most recent unfinished record from the store — a goal
+  survives quitting `glue run` — and the new `/goal list` shows recent goals
+  with status, checklist fraction, and age. Checkpointing is best-effort and
+  storeless agents are unaffected. Closes #324.
+
 ## 1.11.0 — 2026-06-09
 
 - **TUI `/goal`: drive the goal loop from inside `glue run` (Phase 2).**

--- a/README.md
+++ b/README.md
@@ -374,7 +374,9 @@ session), **`/tree`** (visualize the session lineage with
 plan → maker → independent checker per iteration, with a live `[x]/[ ]`
 checklist card in the transcript, a `◎ goal · iter 2/10 · 1/4 ✓` status-bar
 segment, and `/goal status` / `pause` / `resume` (continues from the verified
-checklist without re-planning) / `clear` subcommands — see
+checklist without re-planning — even in a new process, since progress is
+checkpointed to the session store) / `list` (recent goals with status and
+age) / `clear` subcommands — see
 [ADR-0016](docs/adr/0016-goal-loop.md)). Anywhere in a prompt,
 **`@<path>`** inlines that file's
 contents (`@"path with space"` for spaces, `@@literal` to escape — and

--- a/cmd/glue/tui/commands.go
+++ b/cmd/glue/tui/commands.go
@@ -60,7 +60,7 @@ func slashSpecs() []slashSpec {
 		{Name: "clear", Aliases: []string{"new"}, Desc: "clear the transcript and start a fresh session id"},
 		{Name: "usage", Desc: "show this turn's token usage (when the provider reports it)"},
 		{Name: "tools", Desc: "list registered tools"},
-		{Name: "goal", Args: "<objective>", Desc: "pursue a goal autonomously (also: status · pause · resume · clear)"},
+		{Name: "goal", Args: "<objective>", Desc: "pursue a goal autonomously (also: status · pause · resume · list · clear)"},
 		{Name: "model", Args: "<id>", Desc: "switch model for subsequent turns"},
 		{Name: "session", Args: "[id]", Desc: "print current session id, or switch to <id>"},
 		{Name: "compact", Desc: "summarize older messages to free context window"},

--- a/cmd/glue/tui/goal.go
+++ b/cmd/glue/tui/goal.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -21,6 +22,7 @@ const goalMaxIterations = 10
 // struct only mirrors what the Emit events report, for the live card and
 // the status bar.
 type goalState struct {
+	id        string // GoalSpec.SessionPrefix, also the durable record id
 	objective string
 	cancel    context.CancelFunc
 
@@ -29,7 +31,7 @@ type goalState struct {
 	status  glue.GoalStatus // terminal status once finished; "" while running or paused
 
 	iteration     int
-	maxIterations int
+	maxIterations int // last iteration number of this run (startIteration + budget - 1)
 	checklist     []glue.ChecklistItem
 	usage         glue.Usage
 	summary       string // last checker verdict summary
@@ -48,7 +50,7 @@ func (m *Model) handleSlashGoal(arg string) (tea.Model, tea.Cmd) {
 		if m.goal != nil {
 			m.appendBlock("Goal", m.goal.cardBody())
 		} else {
-			m.appendSystem("usage: /goal <objective> — then /goal status · pause · resume · clear")
+			m.appendSystem("usage: /goal <objective> — then /goal status · pause · resume · list · clear")
 		}
 	case "status":
 		if m.goal == nil {
@@ -68,14 +70,25 @@ func (m *Model) handleSlashGoal(arg string) (tea.Model, tea.Cmd) {
 	case "resume":
 		switch {
 		case m.goal == nil:
-			m.appendSystem("/goal resume: no goal to resume — start one with /goal <objective>")
+			// No goal in this process — look for the most recent unfinished
+			// record in the store (resume across restarts).
+			return m.resumeStoredGoal()
 		case m.goal.running:
 			m.appendSystem("/goal resume: goal is already running")
+		case m.goal.status == glue.GoalAchieved:
+			m.appendSystem("/goal resume: goal already achieved — /goal clear, then start a new one")
 		case len(m.goal.checklist) == 0:
 			m.appendSystem("/goal resume: no checklist captured; start over with /goal <objective>")
 		default:
-			return m.startGoal(m.goal.objective, m.goal.checklist)
+			return m.startGoal(goalStart{
+				objective:      m.goal.objective,
+				seed:           m.goal.checklist,
+				id:             m.goal.id,
+				startIteration: m.goal.iteration + 1,
+			})
 		}
+	case "list":
+		return m.listStoredGoals()
 	case "clear", "stop":
 		if m.goal == nil {
 			m.appendSystem("/goal clear: no goal to clear")
@@ -88,16 +101,24 @@ func (m *Model) handleSlashGoal(arg string) (tea.Model, tea.Cmd) {
 			m.appendSystem("goal cleared.")
 		}
 	default:
-		return m.startGoal(arg, nil)
+		return m.startGoal(goalStart{objective: arg})
 	}
 	m.rerender()
 	return m, nil
 }
 
-// startGoal launches Agent.PursueGoal in the background. A non-empty seed
-// is the resume path: the loop skips planning and continues from the last
-// verified checklist.
-func (m *Model) startGoal(objective string, seed []glue.ChecklistItem) (tea.Model, tea.Cmd) {
+// goalStart parameterizes one PursueGoal launch. A non-empty seed is the
+// resume path (the loop skips planning); id and startIteration carry the
+// durable record identity and iteration numbering across pauses/restarts.
+type goalStart struct {
+	objective      string
+	seed           []glue.ChecklistItem
+	id             string // session prefix; empty starts a fresh goal-<id>
+	startIteration int    // 0 means 1
+}
+
+// startGoal launches Agent.PursueGoal in the background.
+func (m *Model) startGoal(req goalStart) (tea.Model, tea.Cmd) {
 	if m.goal != nil && m.goal.running {
 		m.appendSystem("/goal: a goal is already running — /goal status to inspect, /goal pause or /goal clear first.")
 		m.rerender()
@@ -108,14 +129,22 @@ func (m *Model) startGoal(objective string, seed []glue.ChecklistItem) (tea.Mode
 		m.rerender()
 		return m, nil
 	}
+	if req.id == "" {
+		req.id = "goal-" + shortID()
+	}
+	if req.startIteration <= 0 {
+		req.startIteration = 1
+	}
 
 	ctx, cancel := context.WithCancel(m.ctx)
 	g := &goalState{
-		objective:     objective,
+		id:            req.id,
+		objective:     req.objective,
 		cancel:        cancel,
 		running:       true,
-		maxIterations: goalMaxIterations,
-		checklist:     append([]glue.ChecklistItem(nil), seed...),
+		iteration:     req.startIteration - 1,
+		maxIterations: req.startIteration + goalMaxIterations - 1,
+		checklist:     append([]glue.ChecklistItem(nil), req.seed...),
 		cardIdx:       -1,
 	}
 	m.goal = g
@@ -123,13 +152,14 @@ func (m *Model) startGoal(objective string, seed []glue.ChecklistItem) (tea.Mode
 	send := m.send
 	agent := m.cfg.Agent
 	spec := glue.GoalSpec{
-		Objective:     objective,
-		SessionPrefix: "goal-" + shortID(),
-		Model:         m.cfg.Model,
-		MaxIterations: goalMaxIterations,
-		Checklist:     seed,
-		Permission:    m.perm,
-		Emit:          func(ev glue.GoalEvent) { send(goalEventMsg{Ev: ev}) },
+		Objective:      req.objective,
+		SessionPrefix:  req.id,
+		Model:          m.cfg.Model,
+		MaxIterations:  goalMaxIterations,
+		Checklist:      req.seed,
+		StartIteration: req.startIteration,
+		Permission:     m.perm,
+		Emit:           func(ev glue.GoalEvent) { send(goalEventMsg{Ev: ev}) },
 	}
 	go func() {
 		defer cancel()
@@ -138,12 +168,90 @@ func (m *Model) startGoal(objective string, seed []glue.ChecklistItem) (tea.Mode
 	}()
 
 	verb := "pursuing"
-	if len(seed) > 0 {
+	if len(req.seed) > 0 {
 		verb = "resuming"
 	}
-	m.appendSystem(fmt.Sprintf("%s goal: %s  (/goal status · pause · clear)", verb, objective))
+	m.appendSystem(fmt.Sprintf("%s goal: %s  (/goal status · pause · clear)", verb, req.objective))
 	m.rerender()
 	return m, m.spinner.Tick
+}
+
+// resumeStoredGoal continues the most recent unfinished goal record from
+// the session store — the across-restarts path. A stale "running" record is
+// fair game: nothing is running in this process (m.goal is nil), so its
+// owner is gone.
+func (m *Model) resumeStoredGoal() (tea.Model, tea.Cmd) {
+	recs, err := m.recentGoalRecords()
+	if err != nil {
+		m.appendSystem("/goal resume: " + err.Error())
+		m.rerender()
+		return m, nil
+	}
+	for _, rec := range recs {
+		if (rec.Resumable() || rec.Status == glue.GoalRunning) && len(rec.Checklist) > 0 {
+			return m.startGoal(goalStart{
+				objective:      rec.Objective,
+				seed:           rec.Checklist,
+				id:             rec.ID,
+				startIteration: rec.Iterations + 1,
+			})
+		}
+	}
+	m.appendSystem("/goal resume: no unfinished goal found — start one with /goal <objective> (see /goal list)")
+	m.rerender()
+	return m, nil
+}
+
+// listStoredGoals renders the recent goal records as a block.
+func (m *Model) listStoredGoals() (tea.Model, tea.Cmd) {
+	recs, err := m.recentGoalRecords()
+	if err != nil {
+		m.appendSystem("/goal list: " + err.Error())
+		m.rerender()
+		return m, nil
+	}
+	if len(recs) == 0 {
+		m.appendSystem("/goal list: no goals on the store yet")
+		m.rerender()
+		return m, nil
+	}
+	lines := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		status := goalStatusStyle(rec.Status).Render(fmt.Sprintf("%-14s", rec.Status))
+		lines = append(lines, fmt.Sprintf("  %s %5s ✓  %8s  %s",
+			status, doneFraction(rec.Checklist), relAge(rec.UpdatedAt),
+			truncateGoalText(rec.Objective, 60)))
+	}
+	m.appendBlock("Goals", strings.Join(lines, "\n"))
+	m.rerender()
+	return m, nil
+}
+
+// recentGoalRecords loads the latest goal records for resume/list, fresh
+// ones first. Errors from stores without listing support read as a
+// friendly capability message.
+func (m *Model) recentGoalRecords() ([]glue.GoalRecord, error) {
+	if m.cfg.Agent == nil {
+		return nil, fmt.Errorf("no agent wired")
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+	return m.cfg.Agent.ListGoals(ctx, glue.ListGoalsOptions{Prefix: "goal-", Limit: 10})
+}
+
+// relAge renders a coarse relative timestamp for the /goal list block.
+func relAge(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
 }
 
 // goalRunning reports whether a goal loop is in flight (keeps the spinner

--- a/cmd/glue/tui/goal_test.go
+++ b/cmd/glue/tui/goal_test.go
@@ -114,9 +114,11 @@ func TestSlashGoalSubcommandGating(t *testing.T) {
 	if !strings.Contains(lastSystem(), "no goal running") {
 		t.Errorf("/goal pause with no goal: %q", lastSystem())
 	}
+	// With no in-memory goal, resume consults the store — no agent wired
+	// here, so the lookup degrades with a message instead of panicking.
 	m.handleSlashGoal("resume")
-	if !strings.Contains(lastSystem(), "no goal to resume") {
-		t.Errorf("/goal resume with no goal: %q", lastSystem())
+	if !strings.Contains(lastSystem(), "no agent wired") {
+		t.Errorf("/goal resume with no goal/agent: %q", lastSystem())
 	}
 
 	m.goal = &goalState{objective: "x", running: true, maxIterations: 10, cardIdx: -1}
@@ -221,6 +223,138 @@ func scriptedTurn(text string) []glue.ProviderEvent {
 	}
 }
 
+// goalMemStore is a minimal in-memory glue.Store + SessionLister for
+// resume-across-restart tests.
+type goalMemStore struct {
+	mu     sync.Mutex
+	states map[string]glue.SessionState
+}
+
+func newGoalMemStore() *goalMemStore {
+	return &goalMemStore{states: map[string]glue.SessionState{}}
+}
+
+func (s *goalMemStore) Load(_ context.Context, id string) (glue.SessionState, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st, ok := s.states[id]
+	return st, ok, nil
+}
+
+func (s *goalMemStore) Save(_ context.Context, id string, state glue.SessionState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.states[id] = state
+	return nil
+}
+
+func (s *goalMemStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.states, id)
+	return nil
+}
+
+func (s *goalMemStore) ListSessions(_ context.Context, opts glue.ListSessionsOptions) ([]glue.SessionSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []glue.SessionSummary
+	for id, st := range s.states {
+		if opts.Prefix != "" && !strings.HasPrefix(id, opts.Prefix) {
+			continue
+		}
+		out = append(out, glue.SessionSummary{ID: id, CreatedAt: st.CreatedAt, UpdatedAt: st.UpdatedAt})
+	}
+	return out, nil
+}
+
+// pausedGoalRecordState crafts the durable glue/goal:* record a paused goal
+// leaves behind — written literally because the key strings are a stable
+// on-store format.
+func pausedGoalRecordState(id string) glue.SessionState {
+	return glue.SessionState{
+		Version: 1,
+		ID:      id,
+		Metadata: map[string]any{
+			"glue/goal:objective":  "finish B",
+			"glue/goal:status":     string(glue.GoalPaused),
+			"glue/goal:checklist":  `[{"title":"A","done":true,"evidence":"A.go"},{"title":"B"}]`,
+			"glue/goal:iterations": 2,
+		},
+		CreatedAt: time.Now().Add(-time.Hour),
+		UpdatedAt: time.Now().Add(-time.Minute),
+	}
+}
+
+func TestGoalResumeAcrossRestart(t *testing.T) {
+	t.Parallel()
+	store := newGoalMemStore()
+	store.states["goal-prev"] = pausedGoalRecordState("goal-prev")
+
+	// The resumed run must skip planning: only a maker turn and a checker
+	// verdict are scripted, and a planning call would consume the maker
+	// turn and fail the assertions below.
+	provider := &scriptedGoalProvider{turns: [][]glue.ProviderEvent{
+		scriptedTurn("finished B"),
+		scriptedTurn(`{"done":true,"items":[{"title":"A","done":true},{"title":"B","done":true}],"summary":"done"}`),
+	}}
+	agent := glue.NewAgent(glue.AgentOptions{Provider: provider, Model: "fake-1", Store: store})
+
+	m := makeTestModel(t)
+	m.cfg.Agent = agent
+	msgs := make(chan tea.Msg, 64)
+	m.send = func(msg tea.Msg) { msgs <- msg }
+
+	m.handleSlashGoal("resume")
+	if m.goal == nil || m.goal.id != "goal-prev" {
+		t.Fatalf("goal = %+v, want resumed under goal-prev", m.goal)
+	}
+
+	deadline := time.After(10 * time.Second)
+	for m.goalRunning() {
+		select {
+		case msg := <-msgs:
+			m.Update(msg)
+		case <-deadline:
+			t.Fatal("timed out waiting for resumed goal to finish")
+		}
+	}
+	if m.goal.status != glue.GoalAchieved {
+		t.Fatalf("status = %q, want achieved", m.goal.status)
+	}
+	if m.goal.iteration != 3 {
+		t.Fatalf("iteration = %d, want 3 (continues prior numbering)", m.goal.iteration)
+	}
+	if provider.calls != 2 {
+		t.Fatalf("provider calls = %d, want 2 (no planning call on resume)", provider.calls)
+	}
+	if _, ok := store.states["goal-prev:iter-3"]; !ok {
+		t.Error("missing goal-prev:iter-3 session — resumed run reused old iteration ids?")
+	}
+}
+
+func TestGoalListRendersStoredRecords(t *testing.T) {
+	t.Parallel()
+	store := newGoalMemStore()
+	store.states["goal-prev"] = pausedGoalRecordState("goal-prev")
+	agent := glue.NewAgent(glue.AgentOptions{Provider: &scriptedGoalProvider{}, Store: store})
+
+	m := makeTestModel(t)
+	m.cfg.Agent = agent
+	m.listStoredGoals()
+
+	last := m.transcript[len(m.transcript)-1]
+	if last.Kind != itemBlock || last.BlockTitle != "Goals" {
+		t.Fatalf("last item = %+v, want Goals block", last)
+	}
+	plain := stripANSI(last.render(renderCtx{width: 120}))
+	for _, want := range []string{"paused", "1/2", "finish B", "ago"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("goal list missing %q\n%s", want, plain)
+		}
+	}
+}
+
 func TestStartGoalRunsLoopToAchieved(t *testing.T) {
 	t.Parallel()
 	provider := &scriptedGoalProvider{turns: [][]glue.ProviderEvent{
@@ -235,7 +369,7 @@ func TestStartGoalRunsLoopToAchieved(t *testing.T) {
 	msgs := make(chan tea.Msg, 64)
 	m.send = func(msg tea.Msg) { msgs <- msg }
 
-	m.startGoal("ship A", nil)
+	m.startGoal(goalStart{objective: "ship A"})
 	if !m.goalRunning() {
 		t.Fatal("goal not running after startGoal")
 	}

--- a/docs/design.md
+++ b/docs/design.md
@@ -282,10 +282,16 @@ against real evidence via `Session.PromptJSON` and decides completion. Guardrail
 streams progress. The maker≠checker split keeps the writer from grading its own
 homework. See [ADR-0016](adr/0016-goal-loop.md). A non-empty `GoalSpec.Checklist`
 seeds the loop and skips planning — that is how a paused goal resumes from its
-last verified state. The TUI surfaces all of this as `/goal <objective>` with
-`status` / `pause` / `resume` / `clear` subcommands, a live checklist card in
-the transcript, and a `◎ goal` status-bar segment; durable resume across
-restarts is the Phase 3 follow-up.
+last verified state. When the agent has a `Store`, `PursueGoal` also
+checkpoints a durable [`GoalRecord`](../goal_store.go) (objective, status,
+checklist, iterations, usage) as namespaced `glue/goal:*` metadata on the
+`SessionPrefix` session — a context cancellation persists as `paused` — and
+`Agent.LoadGoal` / `Agent.ListGoals` read records back; `GoalSpec.StartIteration`
+lets a resumed run continue iteration numbering so maker/checker sessions stay
+fresh. The TUI surfaces all of this as `/goal <objective>` with `status` /
+`pause` / `resume` (continues the most recent unfinished record, even in a new
+process) / `list` / `clear` subcommands, a live checklist card in the
+transcript, and a `◎ goal` status-bar segment.
 
 ## Gemini Provider
 

--- a/goal.go
+++ b/goal.go
@@ -50,6 +50,13 @@ type GoalSpec struct {
 	// verified state without re-planning.
 	Checklist []ChecklistItem
 
+	// StartIteration numbers this run's first iteration (default 1). A
+	// resumed goal passes its prior Iterations+1 so maker/checker session
+	// ids stay fresh (iter-4, check-4, …) instead of appending to the
+	// previous run's transcripts. MaxIterations still counts iterations
+	// in this run.
+	StartIteration int
+
 	// Tools overrides the maker tool set. Empty uses the agent's tools.
 	Tools []Tool
 	// CheckerTools overrides the verifier tool set. Empty uses the agent's
@@ -75,6 +82,13 @@ type GoalSpec struct {
 type GoalStatus string
 
 const (
+	// GoalRunning is never returned by PursueGoal; it appears only on the
+	// durable [GoalRecord] while the loop is in flight.
+	GoalRunning GoalStatus = "running"
+	// GoalPaused is never returned by PursueGoal; it is the durable record
+	// of a context cancellation — the loop stopped cleanly mid-objective
+	// and can resume from its checklist.
+	GoalPaused GoalStatus = "paused"
 	// GoalAchieved means the checker confirmed every deliverable.
 	GoalAchieved GoalStatus = "achieved"
 	// GoalBlocked means the loop stopped because no progress was made for
@@ -162,9 +176,33 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		}
 	}
 
+	// checkpoint persists the durable GoalRecord when the agent has a
+	// store. Best-effort: the loop never depended on the store, so a failed
+	// save must not abort it. WithoutCancel because the terminal checkpoint
+	// (paused, errored) runs after ctx has already been cancelled.
+	var checklist []ChecklistItem
+	checkpoint := func(status GoalStatus) {
+		_ = a.saveGoalRecord(context.WithoutCancel(ctx), GoalRecord{
+			ID:         spec.SessionPrefix,
+			Objective:  spec.Objective,
+			Status:     status,
+			Checklist:  cloneChecklist(checklist),
+			Iterations: result.Iterations,
+			Usage:      result.Usage,
+			Summary:    result.Summary,
+		})
+	}
+	// pauseOrErrored maps a run failure to its durable status: a cancelled
+	// context is a clean pause (resumable), anything else an error.
+	pauseOrErrored := func() GoalStatus {
+		if ctx.Err() != nil {
+			return GoalPaused
+		}
+		return GoalErrored
+	}
+
 	// 1) Plan: decompose the objective into verifiable deliverables — unless
 	// the caller seeded a checklist (a resumed goal keeps its verified state).
-	var checklist []ChecklistItem
 	if len(spec.Checklist) > 0 {
 		checklist = cloneChecklist(spec.Checklist)
 	} else {
@@ -177,20 +215,24 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		}
 	}
 	emit(GoalEvent{Type: GoalEventPlan, Checklist: cloneChecklist(checklist), Usage: result.Usage})
+	checkpoint(GoalRunning)
 
 	var prevRemaining string
 	noProgress := 0
 
-	for i := 1; i <= spec.MaxIterations; i++ {
+	for n := 0; n < spec.MaxIterations; n++ {
+		i := spec.StartIteration + n
 		if err := ctx.Err(); err != nil {
 			result.Status = GoalErrored
 			result.Checklist = cloneChecklist(checklist)
+			checkpoint(GoalPaused)
 			return result, err
 		}
 		if spec.TokenBudget > 0 && result.Usage.TotalTokens >= spec.TokenBudget {
 			result.Status = GoalBudgetLimited
 			result.Checklist = cloneChecklist(checklist)
 			emit(GoalEvent{Type: GoalEventBudget, Iteration: result.Iterations, Checklist: cloneChecklist(checklist), Usage: result.Usage})
+			checkpoint(GoalBudgetLimited)
 			return result, nil
 		}
 		result.Iterations = i
@@ -202,6 +244,7 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		if err != nil {
 			result.Status = GoalErrored
 			result.Checklist = cloneChecklist(checklist)
+			checkpoint(pauseOrErrored())
 			return result, fmt.Errorf("glue: goal maker iteration %d: %w", i, err)
 		}
 		emit(GoalEvent{Type: GoalEventMakerDone, Iteration: i, Usage: result.Usage})
@@ -212,6 +255,7 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		if err != nil {
 			result.Status = GoalErrored
 			result.Checklist = cloneChecklist(checklist)
+			checkpoint(pauseOrErrored())
 			return result, fmt.Errorf("glue: goal checker iteration %d: %w", i, err)
 		}
 		if len(verdict.Items) > 0 {
@@ -220,11 +264,13 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		result.Summary = strings.TrimSpace(verdict.Summary)
 		result.Checklist = cloneChecklist(checklist)
 		emit(GoalEvent{Type: GoalEventVerdict, Iteration: i, Message: result.Summary, Checklist: cloneChecklist(checklist), Usage: result.Usage})
+		checkpoint(GoalRunning)
 
 		// 4) Decide.
 		if verdict.Done && allDone(checklist) {
 			result.Status = GoalAchieved
 			emit(GoalEvent{Type: GoalEventDone, Iteration: i, Message: result.Summary, Checklist: cloneChecklist(checklist), Usage: result.Usage})
+			checkpoint(GoalAchieved)
 			return result, nil
 		}
 		remaining := remainingKey(checklist)
@@ -237,6 +283,7 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 		if noProgress >= spec.NoProgressLimit {
 			result.Status = GoalBlocked
 			emit(GoalEvent{Type: GoalEventBlocked, Iteration: i, Checklist: cloneChecklist(checklist), Usage: result.Usage})
+			checkpoint(GoalBlocked)
 			return result, nil
 		}
 	}
@@ -244,6 +291,7 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 	result.Status = GoalMaxIterations
 	result.Checklist = cloneChecklist(checklist)
 	emit(GoalEvent{Type: GoalEventMaxIterations, Iteration: result.Iterations, Checklist: cloneChecklist(checklist), Usage: result.Usage})
+	checkpoint(GoalMaxIterations)
 	return result, nil
 }
 
@@ -257,6 +305,9 @@ func (s GoalSpec) withDefaults() GoalSpec {
 	}
 	if s.NoProgressLimit <= 0 {
 		s.NoProgressLimit = 2
+	}
+	if s.StartIteration <= 0 {
+		s.StartIteration = 1
 	}
 	if s.CheckerModel == "" {
 		s.CheckerModel = s.Model

--- a/goal_store.go
+++ b/goal_store.go
@@ -1,0 +1,182 @@
+package glue
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Namespaced metadata keys carrying the durable goal record on the session
+// stored at the goal's SessionPrefix id — the same convention as the
+// glue/tree:* lineage keys.
+const (
+	goalMetaObjective  = "glue/goal:objective"
+	goalMetaStatus     = "glue/goal:status"
+	goalMetaChecklist  = "glue/goal:checklist" // JSON-encoded []ChecklistItem
+	goalMetaIterations = "glue/goal:iterations"
+	goalMetaUsage      = "glue/goal:usage" // JSON-encoded Usage
+	goalMetaSummary    = "glue/goal:summary"
+)
+
+// GoalRecord is the durable snapshot of a goal loop, checkpointed by
+// [Agent.PursueGoal] as it runs (when the agent has a Store) and read back
+// by [Agent.LoadGoal] / [Agent.ListGoals]. ID is the GoalSpec.SessionPrefix
+// the goal ran under.
+type GoalRecord struct {
+	ID         string          `json:"id"`
+	Objective  string          `json:"objective"`
+	Status     GoalStatus      `json:"status"`
+	Checklist  []ChecklistItem `json:"checklist,omitempty"`
+	Iterations int             `json:"iterations"`
+	Usage      Usage           `json:"usage"`
+	Summary    string          `json:"summary,omitempty"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// Resumable reports whether the goal can be continued from its checklist:
+// any unmet, non-running state with verified items to seed from. A stale
+// "running" record left behind by a crashed process is excluded — a caller
+// that knows the owning process is gone may still choose to resume it.
+func (r GoalRecord) Resumable() bool {
+	switch r.Status {
+	case GoalPaused, GoalErrored, GoalBlocked, GoalMaxIterations, GoalBudgetLimited:
+		return len(r.Checklist) > 0
+	default:
+		return false
+	}
+}
+
+// saveGoalRecord checkpoints the record onto the session at rec.ID.
+// Best-effort by design: persistence failures must never abort the loop,
+// so the error is intentionally dropped by callers inside PursueGoal.
+func (a *Agent) saveGoalRecord(ctx context.Context, rec GoalRecord) error {
+	if a.store == nil {
+		return nil
+	}
+	state, ok, err := a.store.Load(ctx, rec.ID)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if !ok {
+		state = SessionState{Version: 1, ID: rec.ID, CreatedAt: now}
+	}
+	if state.Metadata == nil {
+		state.Metadata = map[string]any{}
+	}
+	checklist, err := json.Marshal(rec.Checklist)
+	if err != nil {
+		return err
+	}
+	usage, err := json.Marshal(rec.Usage)
+	if err != nil {
+		return err
+	}
+	state.Metadata[goalMetaObjective] = rec.Objective
+	state.Metadata[goalMetaStatus] = string(rec.Status)
+	state.Metadata[goalMetaChecklist] = string(checklist)
+	state.Metadata[goalMetaIterations] = rec.Iterations
+	state.Metadata[goalMetaUsage] = string(usage)
+	state.Metadata[goalMetaSummary] = rec.Summary
+	state.UpdatedAt = now
+	return a.store.Save(ctx, rec.ID, state)
+}
+
+// LoadGoal returns the durable record for the goal that ran under id (its
+// GoalSpec.SessionPrefix). ok is false when the session does not exist or
+// carries no goal metadata.
+func (a *Agent) LoadGoal(ctx context.Context, id string) (GoalRecord, bool, error) {
+	if a == nil || a.store == nil {
+		return GoalRecord{}, false, nil
+	}
+	state, ok, err := a.store.Load(ctx, id)
+	if err != nil || !ok {
+		return GoalRecord{}, false, err
+	}
+	rec, ok := goalRecordFromState(state)
+	return rec, ok, nil
+}
+
+// ListGoalsOptions filters and pages a goal record listing.
+type ListGoalsOptions struct {
+	// Prefix restricts results to goal ids beginning with Prefix
+	// (e.g. "goal-" for goals started by the TUI).
+	Prefix string
+
+	// Limit caps returned records. Non-positive values return all matches
+	// the underlying session listing yields.
+	Limit int
+}
+
+// ListGoals returns durable goal records, most recently updated first. It
+// requires the store to implement the optional [SessionLister] capability
+// and returns [ErrSessionListingNotSupported] otherwise.
+func (a *Agent) ListGoals(ctx context.Context, opts ListGoalsOptions) ([]GoalRecord, error) {
+	// Over-fetch sessions: most ids under the prefix are per-iteration
+	// maker/checker sessions, not goal records. The lister's own default
+	// page would miss records, so ask for a generous fixed window.
+	summaries, err := a.ListSessions(ctx, ListSessionsOptions{Prefix: opts.Prefix, Limit: 1000})
+	if err != nil {
+		return nil, err
+	}
+	var out []GoalRecord
+	for _, s := range summaries {
+		// Iteration sessions are named {prefix}:plan / :iter-N / :check-N;
+		// records live at the bare prefix. Skipping ids with ':' after the
+		// prefix avoids a store Load per non-record session.
+		if strings.Contains(strings.TrimPrefix(s.ID, opts.Prefix), ":") {
+			continue
+		}
+		state, ok, err := a.store.Load(ctx, s.ID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if rec, ok := goalRecordFromState(state); ok {
+			out = append(out, rec)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].UpdatedAt.After(out[j].UpdatedAt) })
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
+}
+
+// goalRecordFromState decodes the glue/goal:* metadata, tolerating missing
+// or malformed keys for forward compatibility. ok is false when the state
+// carries no goal objective at all.
+func goalRecordFromState(state SessionState) (GoalRecord, bool) {
+	objective, ok := state.Metadata[goalMetaObjective].(string)
+	if !ok || strings.TrimSpace(objective) == "" {
+		return GoalRecord{}, false
+	}
+	rec := GoalRecord{
+		ID:        state.ID,
+		Objective: objective,
+		UpdatedAt: state.UpdatedAt,
+	}
+	if s, ok := state.Metadata[goalMetaStatus].(string); ok {
+		rec.Status = GoalStatus(s)
+	}
+	if s, ok := state.Metadata[goalMetaChecklist].(string); ok {
+		_ = json.Unmarshal([]byte(s), &rec.Checklist)
+	}
+	switch n := state.Metadata[goalMetaIterations].(type) {
+	case int:
+		rec.Iterations = n
+	case float64: // JSON round-trip through the store decodes numbers as float64
+		rec.Iterations = int(n)
+	}
+	if s, ok := state.Metadata[goalMetaUsage].(string); ok {
+		_ = json.Unmarshal([]byte(s), &rec.Usage)
+	}
+	if s, ok := state.Metadata[goalMetaSummary].(string); ok {
+		rec.Summary = s
+	}
+	return rec, true
+}

--- a/goal_store_test.go
+++ b/goal_store_test.go
@@ -1,0 +1,208 @@
+package glue
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// listingMemStore adds the optional SessionLister capability to memStore so
+// goal-record tests can exercise ListGoals.
+type listingMemStore struct{ *memStore }
+
+func (s listingMemStore) ListSessions(_ context.Context, opts ListSessionsOptions) ([]SessionSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []SessionSummary
+	for id, st := range s.states {
+		if opts.Prefix != "" && !strings.HasPrefix(id, opts.Prefix) {
+			continue
+		}
+		out = append(out, SessionSummary{ID: id, CreatedAt: st.CreatedAt, UpdatedAt: st.UpdatedAt})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
+}
+
+func TestPursueGoalCheckpointsRecord(t *testing.T) {
+	t.Parallel()
+
+	store := listingMemStore{newMemStore()}
+	provider := &recordingProvider{turns: [][]ProviderEvent{
+		goalTurn(mustJSON(t, goalPlan{Items: []ChecklistItem{{Title: "A"}}}), 0),
+		goalTurn("worked on A", 0),
+		goalTurn(mustJSON(t, goalVerdict{Done: true, Items: []ChecklistItem{{Title: "A", Done: true, Evidence: "A.go"}}, Summary: "all done"}), 0),
+	}}
+	agent := NewAgent(AgentOptions{Provider: provider, Model: "fake-1", Store: store})
+
+	res, err := agent.PursueGoal(context.Background(), GoalSpec{Objective: "ship A", SessionPrefix: "goal-rec1"})
+	if err != nil {
+		t.Fatalf("PursueGoal: %v", err)
+	}
+	if res.Status != GoalAchieved {
+		t.Fatalf("status = %q, want achieved", res.Status)
+	}
+
+	rec, ok, err := agent.LoadGoal(context.Background(), "goal-rec1")
+	if err != nil || !ok {
+		t.Fatalf("LoadGoal: ok=%v err=%v", ok, err)
+	}
+	if rec.Objective != "ship A" || rec.Status != GoalAchieved || rec.Iterations != 1 {
+		t.Fatalf("record = %+v, want achieved after 1 iteration", rec)
+	}
+	if len(rec.Checklist) != 1 || !rec.Checklist[0].Done || rec.Checklist[0].Evidence != "A.go" {
+		t.Fatalf("record checklist = %+v, want verified item round-tripped", rec.Checklist)
+	}
+	if rec.Summary != "all done" {
+		t.Fatalf("record summary = %q", rec.Summary)
+	}
+	if rec.Resumable() {
+		t.Fatal("achieved goal must not be resumable")
+	}
+}
+
+func TestPursueGoalCancelPersistsPaused(t *testing.T) {
+	t.Parallel()
+
+	store := listingMemStore{newMemStore()}
+	agent := NewAgent(AgentOptions{Provider: &recordingProvider{}, Model: "fake-1", Store: store})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	seed := []ChecklistItem{{Title: "A", Done: true}, {Title: "B"}}
+	_, err := agent.PursueGoal(ctx, GoalSpec{
+		Objective:     "ship it",
+		SessionPrefix: "goal-rec2",
+		Checklist:     seed,
+		// Cancel as soon as the (seeded) plan event fires, before the
+		// first maker call — the loop's top-of-iteration check trips.
+		Emit: func(ev GoalEvent) {
+			if ev.Type == GoalEventPlan {
+				cancel()
+			}
+		},
+	})
+	if err == nil {
+		t.Fatal("want cancellation error")
+	}
+
+	rec, ok, err := agent.LoadGoal(context.Background(), "goal-rec2")
+	if err != nil || !ok {
+		t.Fatalf("LoadGoal: ok=%v err=%v", ok, err)
+	}
+	if rec.Status != GoalPaused {
+		t.Fatalf("status = %q, want paused", rec.Status)
+	}
+	if len(rec.Checklist) != 2 || !rec.Checklist[0].Done {
+		t.Fatalf("checklist = %+v, want seeded state preserved", rec.Checklist)
+	}
+	if !rec.Resumable() {
+		t.Fatal("paused goal with checklist must be resumable")
+	}
+}
+
+func TestPursueGoalStartIterationNumbersSessions(t *testing.T) {
+	t.Parallel()
+
+	store := listingMemStore{newMemStore()}
+	notDone := mustJSON(t, goalVerdict{Items: []ChecklistItem{{Title: "A"}}})
+	provider := &recordingProvider{turns: [][]ProviderEvent{
+		goalTurn("iter3 work", 0),
+		goalTurn(notDone, 0),
+	}}
+	agent := NewAgent(AgentOptions{Provider: provider, Model: "fake-1", Store: store})
+
+	res, err := agent.PursueGoal(context.Background(), GoalSpec{
+		Objective:      "x",
+		SessionPrefix:  "goal-rec3",
+		Checklist:      []ChecklistItem{{Title: "A"}},
+		StartIteration: 3,
+		MaxIterations:  1,
+	})
+	if err != nil {
+		t.Fatalf("PursueGoal: %v", err)
+	}
+	if res.Status != GoalMaxIterations {
+		t.Fatalf("status = %q, want max_iterations", res.Status)
+	}
+	if res.Iterations != 3 {
+		t.Fatalf("iterations = %d, want 3 (continues prior numbering)", res.Iterations)
+	}
+	for _, id := range []string{"goal-rec3:iter-3", "goal-rec3:check-3"} {
+		if _, ok := store.states[id]; !ok {
+			t.Errorf("missing session %q; stored: %v", id, storeIDs(store.memStore))
+		}
+	}
+}
+
+func TestLoadGoalMissing(t *testing.T) {
+	t.Parallel()
+
+	agent := NewAgent(AgentOptions{Provider: &recordingProvider{}, Store: listingMemStore{newMemStore()}})
+	if _, ok, err := agent.LoadGoal(context.Background(), "nope"); ok || err != nil {
+		t.Fatalf("ok=%v err=%v, want absent", ok, err)
+	}
+	storeless := NewAgent(AgentOptions{Provider: &recordingProvider{}})
+	if _, ok, err := storeless.LoadGoal(context.Background(), "nope"); ok || err != nil {
+		t.Fatalf("storeless: ok=%v err=%v, want absent", ok, err)
+	}
+}
+
+func TestListGoalsOrdersAndFilters(t *testing.T) {
+	t.Parallel()
+
+	store := listingMemStore{newMemStore()}
+	agent := NewAgent(AgentOptions{Provider: &recordingProvider{}, Store: store})
+
+	base := time.Now().Add(-time.Hour)
+	put := func(id string, meta map[string]any, updated time.Time) {
+		store.states[id] = SessionState{Version: 1, ID: id, Metadata: meta, CreatedAt: base, UpdatedAt: updated}
+	}
+	goalMeta := func(objective, status string) map[string]any {
+		return map[string]any{
+			goalMetaObjective:  objective,
+			goalMetaStatus:     status,
+			goalMetaChecklist:  `[{"title":"A","done":true}]`,
+			goalMetaIterations: float64(2), // as decoded from a JSON round-trip
+			goalMetaUsage:      `{"total_tokens":42}`,
+			goalMetaSummary:    "s",
+		}
+	}
+	put("goal-old", goalMeta("older goal", string(GoalPaused)), base.Add(1*time.Minute))
+	put("goal-new", goalMeta("newer goal", string(GoalAchieved)), base.Add(30*time.Minute))
+	put("goal-old:iter-1", nil, base)                // iteration session: skipped by shape
+	put("goal-junk", map[string]any{"x": "y"}, base) // no goal metadata: skipped
+	put("tui:chat", nil, base)                       // outside prefix
+
+	recs, err := agent.ListGoals(context.Background(), ListGoalsOptions{Prefix: "goal-"})
+	if err != nil {
+		t.Fatalf("ListGoals: %v", err)
+	}
+	if len(recs) != 2 || recs[0].ID != "goal-new" || recs[1].ID != "goal-old" {
+		t.Fatalf("records = %+v, want goal-new then goal-old", recs)
+	}
+	if recs[1].Iterations != 2 || recs[1].Status != GoalPaused || !recs[1].Resumable() {
+		t.Fatalf("goal-old record = %+v, want decoded paused/resumable with 2 iterations", recs[1])
+	}
+
+	limited, err := agent.ListGoals(context.Background(), ListGoalsOptions{Prefix: "goal-", Limit: 1})
+	if err != nil {
+		t.Fatalf("ListGoals limited: %v", err)
+	}
+	if len(limited) != 1 || limited[0].ID != "goal-new" {
+		t.Fatalf("limited = %+v, want only goal-new", limited)
+	}
+}
+
+func storeIDs(m *memStore) []string {
+	ids := make([]string, 0, len(m.states))
+	for id := range m.states {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}


### PR DESCRIPTION
Goal loop **Phase 3a** ([ADR-0016](https://github.com/erain/glue/blob/main/docs/adr/0016-goal-loop.md), tracker #110). Phase 2 (v1.11.0) made pause/resume work in-process; this makes a goal survive a TUI restart.

## What

- **`GoalRecord` checkpointing in `PursueGoal`** (store-backed agents only): a metadata-only session at `spec.SessionPrefix` carries `glue/goal:*` keys — objective, status, checklist JSON, iterations, usage JSON, summary — written after planning, after every checker verdict, and at the terminal state. Same namespacing convention as `glue/tree:*`. Best-effort: a failed save never aborts the loop; terminal saves use `context.WithoutCancel` since they run after the loop's ctx died.
- **`GoalRunning` / `GoalPaused`**: `running` appears only on the durable record while in flight; a context cancellation persists as `paused` (that *is* what pause means since Phase 2). Other run failures persist as `errored`; terminal statuses as-is. `GoalRecord.Resumable()` encodes which states can continue from the checklist.
- **`Agent.LoadGoal(ctx, id)`** / **`Agent.ListGoals(ctx, opts)`** read records back; listing scans by id prefix via the optional `SessionLister` capability (degrades to `ErrSessionListingNotSupported`), skips `:`-suffixed iteration sessions without loading them, and orders most-recently-updated first.
- **`GoalSpec.StartIteration`**: a resumed run continues iteration numbering (`iter-4`, `check-4`, …) instead of appending to the previous run's `iter-1` transcripts — preserving the Ralph fresh-context property across restarts. `MaxIterations` still counts iterations per run.
- **TUI**: `/goal resume` with no in-process goal loads the most recent unfinished record (paused/errored/blocked/max_iterations/budget_limited, plus stale `running` — nothing can be running in a fresh process) and continues it under the same record id; in-process resume now also reuses the record id and iteration numbering. New **`/goal list`** block: status, checklist fraction, age, objective.

## Tests

- Library (`goal_store_test.go`): checkpoint→`LoadGoal` round-trip on an achieved run; cancel persists `paused` with seeded state intact; `StartIteration` numbers sessions `iter-3`/`check-3` and reports cumulative iterations; missing/storeless `LoadGoal`; `ListGoals` ordering, filtering (iteration sessions, non-goal sessions, prefix), and limit.
- TUI (`cmd/glue/tui/goal_test.go`): resume-across-restart against a crafted on-store record through the real `PursueGoal` loop (no planning call, `iter-3` session created, achieved); `/goal list` rendering; updated subcommand gating.

## Verification

```
go build ./... && go vet ./...   # clean
go test ./...                    # all packages pass
```

Closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)