### PR TITLE
cmd/glue: goal worktree isolation — /goal -w (closes #326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Goal worktree isolation — `/goal -w` (goal loop Phase 3b).**
+  `/goal -w <objective>` (or `--worktree`) runs the goal's maker and checker
+  in a dedicated git worktree at `.glue/worktrees/<goal-id>` on branch
+  `goal/<id>`, leaving your checkout untouched; the finished goal names the
+  branch to review and merge (never auto-merged). The run's coding tool set
+  is rebuilt rooted at the worktree via the new `tui.Config.BuildTools`
+  factory (wired from `glue run --coding` with the same `--allow-binary` /
+  `--coding-allow-overwrite` / `--tools` / `--no-tools` flags), and the new
+  `GoalSpec.WorkDir` / `GoalRecord.WorkDir` (`glue/goal:workdir`) field makes
+  resume — in-process or across restarts — re-attach the same worktree and
+  branch. Without `--coding` or outside a git repository, `-w` refuses with a
+  clear message before any goal starts. Closes #326.
 - **Durable goal state + resume across restarts (goal loop Phase 3a).**
   When the agent has a `Store`, `Agent.PursueGoal` checkpoints a `GoalRecord`
   (objective, status, verified checklist, iterations, usage, summary) as

--- a/README.md
+++ b/README.md
@@ -376,8 +376,10 @@ checklist card in the transcript, a `◎ goal · iter 2/10 · 1/4 ✓` status-ba
 segment, and `/goal status` / `pause` / `resume` (continues from the verified
 checklist without re-planning — even in a new process, since progress is
 checkpointed to the session store) / `list` (recent goals with status and
-age) / `clear` subcommands — see
-[ADR-0016](docs/adr/0016-goal-loop.md)). Anywhere in a prompt,
+age) / `clear` subcommands; `/goal -w <objective>` isolates the run in its
+own git worktree at `.glue/worktrees/<goal-id>` on branch `goal/<id>`, so
+the loop never touches your checkout and the result is a reviewable
+branch — see [ADR-0016](docs/adr/0016-goal-loop.md)). Anywhere in a prompt,
 **`@<path>`** inlines that file's
 contents (`@"path with space"` for spaces, `@@literal` to escape — and
 the workspace blocklist refuses `.env` / `id_rsa` / etc.). Typing

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -474,6 +474,25 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 	})
 
 	if interactive {
+		// buildToolsAt re-roots the run's coding tool set for /goal -w
+		// worktree isolation, honoring the same flags as the main set.
+		// Only offered when --coding is on: an isolated goal without
+		// coding tools could not touch its worktree anyway.
+		var buildToolsAt func(dir string) ([]glue.Tool, error)
+		if *coding {
+			buildToolsAt = func(dir string) ([]glue.Tool, error) {
+				wtTools, _, err := buildCodingTools(codingFlagConfig{
+					Enabled:         true,
+					WorkDir:         dir,
+					AllowedBinaries: append([]string(nil), allowedBinaries...),
+					AllowOverwrite:  effectiveAllowOverwrite,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return filterTools(wtTools, *toolsAllow, *noTools)
+			}
+		}
 		return tui.Run(ctx, tui.Config{
 			Agent:        agent,
 			SessionID:    *id,
@@ -484,6 +503,7 @@ func runCommand(ctx context.Context, args []string, stdin io.Reader, stdout io.W
 			Store:        storeImpl,
 			ProviderImpl: providerImpl,
 			AlwaysAllow:  *yolo,
+			BuildTools:   buildToolsAt,
 		})
 	}
 	session, err := agent.Session(ctx, *id)

--- a/cmd/glue/tui/goal.go
+++ b/cmd/glue/tui/goal.go
@@ -36,6 +36,11 @@ type goalState struct {
 	usage         glue.Usage
 	summary       string // last checker verdict summary
 
+	// workDir and branch are set when the goal runs isolated in its own
+	// git worktree (/goal -w). Empty means it works the user's checkout.
+	workDir string
+	branch  string
+
 	// cardIdx is the transcript index of the live goal card, updated in
 	// place as events arrive. -1 means not created yet (or detached after
 	// a transcript reset — the next event re-appends it).
@@ -85,6 +90,7 @@ func (m *Model) handleSlashGoal(arg string) (tea.Model, tea.Cmd) {
 				seed:           m.goal.checklist,
 				id:             m.goal.id,
 				startIteration: m.goal.iteration + 1,
+				isolated:       m.goal.workDir != "",
 			})
 		}
 	case "list":
@@ -101,7 +107,18 @@ func (m *Model) handleSlashGoal(arg string) (tea.Model, tea.Cmd) {
 			m.appendSystem("goal cleared.")
 		}
 	default:
-		return m.startGoal(goalStart{objective: arg})
+		objective, isolated := arg, false
+		for _, flag := range []string{"-w", "--worktree"} {
+			if arg == flag || strings.HasPrefix(arg, flag+" ") {
+				objective, isolated = strings.TrimSpace(strings.TrimPrefix(arg, flag)), true
+				break
+			}
+		}
+		if objective == "" {
+			m.appendSystem("usage: /goal -w <objective> — run the goal in an isolated goal/<id> worktree")
+			break
+		}
+		return m.startGoal(goalStart{objective: objective, isolated: isolated})
 	}
 	m.rerender()
 	return m, nil
@@ -115,6 +132,7 @@ type goalStart struct {
 	seed           []glue.ChecklistItem
 	id             string // session prefix; empty starts a fresh goal-<id>
 	startIteration int    // 0 means 1
+	isolated       bool   // run in a dedicated goal/<id> git worktree
 }
 
 // startGoal launches Agent.PursueGoal in the background.
@@ -136,6 +154,31 @@ func (m *Model) startGoal(req goalStart) (tea.Model, tea.Cmd) {
 		req.startIteration = 1
 	}
 
+	// Isolated goals get their own worktree-rooted tool set; everything
+	// here is fail-fast so a setup error never leaves a half-started goal.
+	var isolatedTools []glue.Tool
+	workDir, branch := "", ""
+	if req.isolated {
+		if m.cfg.BuildTools == nil {
+			m.appendSystem("/goal -w: worktree isolation needs coding tools (run with --coding)")
+			m.rerender()
+			return m, nil
+		}
+		dir, err := ensureGoalWorktree(m.cfg.WorkDir, req.id)
+		if err != nil {
+			m.appendSystem("/goal -w: " + err.Error())
+			m.rerender()
+			return m, nil
+		}
+		tools, err := m.cfg.BuildTools(dir)
+		if err != nil {
+			m.appendSystem("/goal -w: build tools: " + err.Error())
+			m.rerender()
+			return m, nil
+		}
+		isolatedTools, workDir, branch = tools, dir, goalBranch(req.id)
+	}
+
 	ctx, cancel := context.WithCancel(m.ctx)
 	g := &goalState{
 		id:            req.id,
@@ -146,6 +189,8 @@ func (m *Model) startGoal(req goalStart) (tea.Model, tea.Cmd) {
 		maxIterations: req.startIteration + goalMaxIterations - 1,
 		checklist:     append([]glue.ChecklistItem(nil), req.seed...),
 		cardIdx:       -1,
+		workDir:       workDir,
+		branch:        branch,
 	}
 	m.goal = g
 
@@ -158,6 +203,9 @@ func (m *Model) startGoal(req goalStart) (tea.Model, tea.Cmd) {
 		MaxIterations:  goalMaxIterations,
 		Checklist:      req.seed,
 		StartIteration: req.startIteration,
+		Tools:          isolatedTools,
+		CheckerTools:   isolatedTools,
+		WorkDir:        workDir,
 		Permission:     m.perm,
 		Emit:           func(ev glue.GoalEvent) { send(goalEventMsg{Ev: ev}) },
 	}
@@ -194,6 +242,7 @@ func (m *Model) resumeStoredGoal() (tea.Model, tea.Cmd) {
 				seed:           rec.Checklist,
 				id:             rec.ID,
 				startIteration: rec.Iterations + 1,
+				isolated:       rec.WorkDir != "",
 			})
 		}
 	}
@@ -218,9 +267,12 @@ func (m *Model) listStoredGoals() (tea.Model, tea.Cmd) {
 	lines := make([]string, 0, len(recs))
 	for _, rec := range recs {
 		status := goalStatusStyle(rec.Status).Render(fmt.Sprintf("%-14s", rec.Status))
+		objective := truncateGoalText(rec.Objective, 60)
+		if rec.WorkDir != "" {
+			objective = "⎇ " + objective
+		}
 		lines = append(lines, fmt.Sprintf("  %s %5s ✓  %8s  %s",
-			status, doneFraction(rec.Checklist), relAge(rec.UpdatedAt),
-			truncateGoalText(rec.Objective, 60)))
+			status, doneFraction(rec.Checklist), relAge(rec.UpdatedAt), objective))
 	}
 	m.appendBlock("Goals", strings.Join(lines, "\n"))
 	m.rerender()
@@ -310,6 +362,9 @@ func (m *Model) handleGoalDone(msg goalDoneMsg) {
 		if g.summary != "" {
 			note += " — " + g.summary
 		}
+		if g.branch != "" {
+			note += fmt.Sprintf("  ·  changes on branch %s (%s) — review and merge", g.branch, g.workDir)
+		}
 		m.appendSystem(note)
 	}
 	m.updateGoalCard()
@@ -345,7 +400,11 @@ func (m *Model) detachGoalCard() {
 // cardBody renders the goal card / /goal status block.
 func (g *goalState) cardBody() string {
 	var b strings.Builder
-	b.WriteString("  " + g.objective + "\n\n")
+	b.WriteString("  " + g.objective + "\n")
+	if g.branch != "" {
+		b.WriteString("  " + keyHint.Render("⎇ "+g.branch+" · "+g.workDir) + "\n")
+	}
+	b.WriteString("\n")
 	b.WriteString(renderGoalChecklist(g.checklist))
 	b.WriteString("\n\n  " + g.stateLine())
 	if g.summary != "" {

--- a/cmd/glue/tui/goalworktree.go
+++ b/cmd/glue/tui/goalworktree.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// goalBranch derives the branch name for an isolated goal from its record
+// id: "goal-ab12cd" → "goal/ab12cd".
+func goalBranch(goalID string) string {
+	return "goal/" + strings.TrimPrefix(goalID, "goal-")
+}
+
+// ensureGoalWorktree creates (or re-attaches, on resume) the dedicated git
+// worktree for a goal: <repo root>/.glue/worktrees/<goalID> on branch
+// goal/<suffix>. It returns the worktree directory. Git plumbing lives here
+// in cmd/glue per ADR-0012 — the library stays git-free.
+func ensureGoalWorktree(workDir, goalID string) (string, error) {
+	root, err := gitOutput(workDir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("worktree isolation needs a git repository at %s", workDir)
+	}
+	dir := filepath.Join(root, ".glue", "worktrees", goalID)
+	branch := goalBranch(goalID)
+
+	// Resume case: the worktree directory already exists — verify it is a
+	// usable checkout rather than silently working in a stale directory.
+	if _, statErr := os.Stat(dir); statErr == nil {
+		if _, err := gitOutput(dir, "rev-parse", "--is-inside-work-tree"); err != nil {
+			return "", fmt.Errorf("%s exists but is not a git worktree; remove it and retry", dir)
+		}
+		return dir, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return "", err
+	}
+	// New branch first; if the branch survived a deleted worktree (or a
+	// previous run), attach to it instead.
+	if _, err := gitOutput(root, "worktree", "add", dir, "-b", branch); err != nil {
+		if _, err2 := gitOutput(root, "worktree", "add", dir, branch); err2 != nil {
+			return "", fmt.Errorf("git worktree add: %w", err)
+		}
+	}
+	return dir, nil
+}
+
+// gitOutput runs git with the given args in dir and returns trimmed stdout.
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/cmd/glue/tui/goalworktree_test.go
+++ b/cmd/glue/tui/goalworktree_test.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/erain/glue"
+)
+
+// scratchRepo initializes a git repository with one commit so worktrees can
+// branch off it.
+func scratchRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"commit", "--allow-empty", "-q", "-m", "init"},
+	} {
+		if _, err := gitOutput(dir, args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+	return dir
+}
+
+func TestEnsureGoalWorktreeCreatesAndReuses(t *testing.T) {
+	t.Parallel()
+	repo := scratchRepo(t)
+
+	dir, err := ensureGoalWorktree(repo, "goal-abc123")
+	if err != nil {
+		t.Fatalf("ensureGoalWorktree: %v", err)
+	}
+	want := filepath.Join(repo, ".glue", "worktrees", "goal-abc123")
+	if dir != want {
+		t.Fatalf("dir = %q, want %q", dir, want)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("worktree dir missing: %v", err)
+	}
+	branch, err := gitOutput(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil || branch != "goal/abc123" {
+		t.Fatalf("branch = %q err=%v, want goal/abc123", branch, err)
+	}
+
+	// Second call (resume) reuses the existing worktree.
+	again, err := ensureGoalWorktree(repo, "goal-abc123")
+	if err != nil || again != dir {
+		t.Fatalf("reuse: dir=%q err=%v", again, err)
+	}
+
+	// Deleted worktree but surviving branch: re-attach instead of failing
+	// on the duplicate branch name.
+	if _, err := gitOutput(repo, "worktree", "remove", "--force", dir); err != nil {
+		t.Fatalf("worktree remove: %v", err)
+	}
+	reattached, err := ensureGoalWorktree(repo, "goal-abc123")
+	if err != nil || reattached != dir {
+		t.Fatalf("re-attach: dir=%q err=%v", reattached, err)
+	}
+}
+
+func TestEnsureGoalWorktreeOutsideRepo(t *testing.T) {
+	t.Parallel()
+	if _, err := ensureGoalWorktree(t.TempDir(), "goal-x"); err == nil || !strings.Contains(err.Error(), "git repository") {
+		t.Fatalf("err = %v, want needs-a-git-repository", err)
+	}
+}
+
+func TestSlashGoalWorktreeFlagGating(t *testing.T) {
+	t.Parallel()
+	m := makeTestModel(t)
+
+	lastSystem := func() string {
+		for i := len(m.transcript) - 1; i >= 0; i-- {
+			if m.transcript[i].Kind == itemSystem {
+				return m.transcript[i].Text
+			}
+		}
+		return ""
+	}
+
+	m.handleSlashGoal("-w")
+	if !strings.Contains(lastSystem(), "usage: /goal -w") {
+		t.Errorf("bare -w: %q", lastSystem())
+	}
+
+	// BuildTools is nil on the test model: isolation must refuse before
+	// any goal state is created.
+	m.send = func(tea.Msg) {}
+	m.handleSlashGoal("-w fix the bug")
+	if !strings.Contains(lastSystem(), "needs coding tools") || m.goal != nil {
+		t.Fatalf("isolated start without BuildTools: goal=%v msg=%q", m.goal, lastSystem())
+	}
+}
+
+func TestIsolatedGoalRunsInWorktreeAndPersistsWorkDir(t *testing.T) {
+	t.Parallel()
+	repo := scratchRepo(t)
+	store := newGoalMemStore()
+	provider := &scriptedGoalProvider{turns: [][]glue.ProviderEvent{
+		scriptedTurn(`{"items":[{"title":"A"}]}`),
+		scriptedTurn("did A"),
+		scriptedTurn(`{"done":true,"items":[{"title":"A","done":true}],"summary":"done"}`),
+	}}
+	agent := glue.NewAgent(glue.AgentOptions{Provider: provider, Model: "fake-1", Store: store})
+
+	m := makeTestModel(t)
+	m.cfg.Agent = agent
+	m.cfg.WorkDir = repo
+	var builtAt string
+	m.cfg.BuildTools = func(dir string) ([]glue.Tool, error) {
+		builtAt = dir
+		return []glue.Tool{{ToolSpec: glue.ToolSpec{Name: "stub"}}}, nil
+	}
+	msgs := make(chan tea.Msg, 64)
+	m.send = func(msg tea.Msg) { msgs <- msg }
+
+	m.handleSlashGoal("-w ship A")
+	if m.goal == nil || m.goal.workDir == "" || m.goal.branch != goalBranch(m.goal.id) {
+		t.Fatalf("goal = %+v, want isolated with branch", m.goal)
+	}
+	if builtAt != m.goal.workDir {
+		t.Fatalf("tools built at %q, want worktree %q", builtAt, m.goal.workDir)
+	}
+
+	deadline := time.After(10 * time.Second)
+	for m.goalRunning() {
+		select {
+		case msg := <-msgs:
+			m.Update(msg)
+		case <-deadline:
+			t.Fatal("timed out waiting for isolated goal")
+		}
+	}
+	if m.goal.status != glue.GoalAchieved {
+		t.Fatalf("status = %q, want achieved", m.goal.status)
+	}
+
+	rec, ok, err := agent.LoadGoal(context.Background(), m.goal.id)
+	if err != nil || !ok {
+		t.Fatalf("LoadGoal: ok=%v err=%v", ok, err)
+	}
+	if rec.WorkDir != m.goal.workDir {
+		t.Fatalf("record workdir = %q, want %q", rec.WorkDir, m.goal.workDir)
+	}
+}

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -50,6 +50,12 @@ type Config struct {
 	// permission bridge auto-approves every request without surfacing
 	// it. Wired by cmd/glue's --yolo flag.
 	AlwaysAllow bool
+
+	// BuildTools rebuilds the run's tool set rooted at a different
+	// directory — how /goal -w gives an isolated worktree its own coding
+	// tools while honoring the run's tool flags. Nil disables worktree
+	// isolation with a friendly message.
+	BuildTools func(workDir string) ([]glue.Tool, error)
 }
 
 // Run launches the TUI and blocks until the user quits. It returns

--- a/docs/design.md
+++ b/docs/design.md
@@ -291,7 +291,11 @@ lets a resumed run continue iteration numbering so maker/checker sessions stay
 fresh. The TUI surfaces all of this as `/goal <objective>` with `status` /
 `pause` / `resume` (continues the most recent unfinished record, even in a new
 process) / `list` / `clear` subcommands, a live checklist card in the
-transcript, and a `◎ goal` status-bar segment.
+transcript, and a `◎ goal` status-bar segment. `/goal -w` adds worktree
+isolation: cmd/glue (which owns the git plumbing per ADR-0012) creates
+`.glue/worktrees/<goal-id>` on branch `goal/<id>`, rebuilds the coding tool
+set rooted there via `tui.Config.BuildTools`, and records the root in
+`GoalSpec.WorkDir` so resume re-attaches the same worktree.
 
 ## Gemini Provider
 

--- a/goal.go
+++ b/goal.go
@@ -57,6 +57,12 @@ type GoalSpec struct {
 	// in this run.
 	StartIteration int
 
+	// WorkDir records where this goal's tools are rooted (e.g. an isolated
+	// git worktree). The loop itself never reads it — tools already carry
+	// their root — but it is persisted on the GoalRecord so a host can
+	// rebuild the right tool set when resuming.
+	WorkDir string
+
 	// Tools overrides the maker tool set. Empty uses the agent's tools.
 	Tools []Tool
 	// CheckerTools overrides the verifier tool set. Empty uses the agent's
@@ -190,6 +196,7 @@ func (a *Agent) PursueGoal(ctx context.Context, spec GoalSpec) (GoalResult, erro
 			Iterations: result.Iterations,
 			Usage:      result.Usage,
 			Summary:    result.Summary,
+			WorkDir:    spec.WorkDir,
 		})
 	}
 	// pauseOrErrored maps a run failure to its durable status: a cancelled

--- a/goal_store.go
+++ b/goal_store.go
@@ -18,6 +18,7 @@ const (
 	goalMetaIterations = "glue/goal:iterations"
 	goalMetaUsage      = "glue/goal:usage" // JSON-encoded Usage
 	goalMetaSummary    = "glue/goal:summary"
+	goalMetaWorkDir    = "glue/goal:workdir"
 )
 
 // GoalRecord is the durable snapshot of a goal loop, checkpointed by
@@ -32,6 +33,7 @@ type GoalRecord struct {
 	Iterations int             `json:"iterations"`
 	Usage      Usage           `json:"usage"`
 	Summary    string          `json:"summary,omitempty"`
+	WorkDir    string          `json:"work_dir,omitempty"` // tool root, e.g. an isolated worktree
 	UpdatedAt  time.Time       `json:"updated_at"`
 }
 
@@ -80,6 +82,7 @@ func (a *Agent) saveGoalRecord(ctx context.Context, rec GoalRecord) error {
 	state.Metadata[goalMetaIterations] = rec.Iterations
 	state.Metadata[goalMetaUsage] = string(usage)
 	state.Metadata[goalMetaSummary] = rec.Summary
+	state.Metadata[goalMetaWorkDir] = rec.WorkDir
 	state.UpdatedAt = now
 	return a.store.Save(ctx, rec.ID, state)
 }
@@ -177,6 +180,9 @@ func goalRecordFromState(state SessionState) (GoalRecord, bool) {
 	}
 	if s, ok := state.Metadata[goalMetaSummary].(string); ok {
 		rec.Summary = s
+	}
+	if s, ok := state.Metadata[goalMetaWorkDir].(string); ok {
+		rec.WorkDir = s
 	}
 	return rec, true
 }

--- a/goal_store_test.go
+++ b/goal_store_test.go
@@ -40,7 +40,7 @@ func TestPursueGoalCheckpointsRecord(t *testing.T) {
 	}}
 	agent := NewAgent(AgentOptions{Provider: provider, Model: "fake-1", Store: store})
 
-	res, err := agent.PursueGoal(context.Background(), GoalSpec{Objective: "ship A", SessionPrefix: "goal-rec1"})
+	res, err := agent.PursueGoal(context.Background(), GoalSpec{Objective: "ship A", SessionPrefix: "goal-rec1", WorkDir: "/tmp/wt"})
 	if err != nil {
 		t.Fatalf("PursueGoal: %v", err)
 	}
@@ -60,6 +60,9 @@ func TestPursueGoalCheckpointsRecord(t *testing.T) {
 	}
 	if rec.Summary != "all done" {
 		t.Fatalf("record summary = %q", rec.Summary)
+	}
+	if rec.WorkDir != "/tmp/wt" {
+		t.Fatalf("record workdir = %q, want /tmp/wt round-tripped", rec.WorkDir)
 	}
 	if rec.Resumable() {
 		t.Fatal("achieved goal must not be resumable")


### PR DESCRIPTION
Goal loop **Phase 3b** ([ADR-0016](https://github.com/erain/glue/blob/main/docs/adr/0016-goal-loop.md), tracker #110). An autonomous loop editing the checkout you're sitting in is nerve-wracking — give it its own branch and directory.

## What

- **`/goal -w <objective>`** (also `--worktree`) creates `.glue/worktrees/<goal-id>` on branch `goal/<id-suffix>` and runs both maker and checker there. The finished goal names the branch and path ("review and merge") — never auto-merged. The goal card and `/goal list` mark isolated goals with `⎇`.
- **`ensureGoalWorktree`** (`cmd/glue/tui/goalworktree.go`): finds the repo root via `git rev-parse --show-toplevel` (clear error outside a repo), `git worktree add -b`, falls back to attaching an existing branch (deleted-worktree resume), reuses an existing worktree directory after verifying it is one. Git plumbing stays in cmd/glue per ADR-0012 — the library remains git-free.
- **`tui.Config.BuildTools func(workDir string) ([]glue.Tool, error)`**: wired from `glue run` only when `--coding` is on, replicating `--allow-binary` / `--coding-allow-overwrite` / `--tools` / `--no-tools` with just the root swapped. Nil → `-w` refuses with "needs coding tools" before any goal state is created.
- **`GoalSpec.WorkDir` + `GoalRecord.WorkDir`** (persisted as `glue/goal:workdir`): the loop never reads it — tools already carry their root — but resume (in-process and across restarts) uses it to re-attach the same worktree and rebuild the tool set.

## Tests

- `goalworktree_test.go`: create → correct dir + branch; reuse on second call; re-attach after `git worktree remove` (branch survives); friendly error outside a repo; `-w` flag gating (bare `-w` usage hint, BuildTools-nil refusal); full isolated run through the real `PursueGoal` loop asserting tools are built at the worktree and the record round-trips the workdir.
- `goal_store_test.go`: record WorkDir round-trip added to the checkpoint test.

## Verification

```
go build ./... && go vet ./...   # clean
go test ./...                    # all packages pass
```

Closes #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)