### PR TITLE
cmd/glue: headless glue goal subcommand (closes #328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Headless `glue goal` subcommand — scheduled/CI goal runs (goal loop
+  Phase 3c).** `glue goal "<objective>"` runs a full plan→make→verify loop
+  without a TUI, streaming checklist-level progress to stdout and exiting
+  with a status-mapped code (0 achieved · 2 blocked · 3 max-iterations ·
+  4 budget-limited · 1 errored) so cron, CI, or a peggy schedule can branch
+  on the outcome. Shares `glue run`'s infrastructure flags plus
+  `--max-iterations`, `--budget`, and `--worktree` (same `.glue/worktrees/`
+  + `goal/<id>` isolation as the TUI's `/goal -w`); `--yolo` for unattended
+  runs. `glue goal --list` prints stored records and `glue goal --resume
+  [id]` continues from the verified checklist — the store is shared with the
+  TUI, so a goal started in `glue run` can be resumed headlessly and vice
+  versa. The worktree helper moved to a shared `cmd/glue/worktree` package.
+  Closes #328.
 - **Goal worktree isolation — `/goal -w` (goal loop Phase 3b).**
   `/goal -w <objective>` (or `--worktree`) runs the goal's maker and checker
   in a dedicated git worktree at `.glue/worktrees/<goal-id>` on branch

--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ echo "summarize main.go" | go run ./cmd/glue run --provider codex --coding
 go run ./cmd/glue serve --store .glue/sessions
 go run ./cmd/glue connect --inspect
 go run ./cmd/glue connect --prompt "Say hi" --id demo
+
+# Headless goal loop (schedulable from cron/CI; exit code reflects the
+# outcome: 0 achieved · 2 blocked · 3 max-iterations · 4 budget · 1 error):
+go run ./cmd/glue goal --coding --yolo --worktree "Make the linter pass on ./..."
+go run ./cmd/glue goal --list
+go run ./cmd/glue goal --resume
 ```
 
 **Interactive mode** (designed in [ADR-0014](docs/adr/0014-coding-agent-tui.md)).

--- a/cmd/glue/goalcmd.go
+++ b/cmd/glue/goalcmd.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/erain/glue"
+	"github.com/erain/glue/cmd/glue/worktree"
+	filestore "github.com/erain/glue/stores/file"
+)
+
+// Exit codes for `glue goal`, so cron/CI schedulers can branch on the
+// outcome (retry a budget stop, alert on blocked, …).
+const (
+	goalExitAchieved      = 0
+	goalExitErrored       = 1
+	goalExitBlocked       = 2
+	goalExitMaxIterations = 3
+	goalExitBudgetLimited = 4
+)
+
+// goalCommand implements `glue goal`: the headless goal runner —
+// the unit cron, CI, or a peggy schedule invokes for unattended goals.
+func goalCommand(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer, newProvider providerFactory) (int, error) {
+	flags := flag.NewFlagSet("glue goal", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	providerName := flags.String("provider", defaultProvider, "provider name: codex, gemini, nvidia, or openrouter")
+	model := flags.String("model", "", "model id (default: the provider's default model); gemini/<model> accepted")
+	storeDir := flags.String("store", ".glue/sessions", "session store directory (shared with glue run, so the TUI sees the same goals)")
+	workDir := flags.String("work", ".", "working directory for AGENTS.md and coding tools")
+	coding := flags.Bool("coding", false, "enable local coding tools for the goal")
+	codingAllowOverwrite := flags.Bool("coding-allow-overwrite", false, "allow write_file to replace existing files after model and permission approval")
+	yolo := flags.Bool("yolo", false, "auto-allow all side-effecting tool calls; required for unattended runs. always use on a feature branch or with --worktree.")
+	maxIterations := flags.Int("max-iterations", 10, "outer-loop iteration cap for this run")
+	budget := flags.Int64("budget", 0, "total token budget across planning, makers, and checkers (0 = unlimited)")
+	useWorktree := flags.Bool("worktree", false, "isolate the goal in .glue/worktrees/<goal-id> on branch goal/<id> (needs --coding and a git repository)")
+	list := flags.Bool("list", false, "list stored goal records and exit")
+	resume := flags.Bool("resume", false, "resume the most recent unfinished goal, or the record id given as the argument")
+	var envs envFiles
+	flags.Var(&envs, "env", "env file path; repeatable")
+	var allowedBinaries repeatedStrings
+	flags.Var(&allowedBinaries, "allow-binary", "allowed shell_exec binary basename for --coding; repeatable")
+
+	if err := flags.Parse(args); err != nil {
+		return goalExitErrored, nil // flag package already printed the error
+	}
+	if err := loadEnvFiles(envs); err != nil {
+		return goalExitErrored, err
+	}
+
+	store := filestore.New(*storeDir)
+
+	if *list {
+		agent := glue.NewAgent(glue.AgentOptions{Store: store})
+		recs, err := agent.ListGoals(ctx, glue.ListGoalsOptions{Prefix: "goal-", Limit: 20})
+		if err != nil {
+			return goalExitErrored, err
+		}
+		if len(recs) == 0 {
+			fmt.Fprintln(stdout, "no goals on the store yet")
+			return goalExitAchieved, nil
+		}
+		for _, rec := range recs {
+			marker := " "
+			if rec.WorkDir != "" {
+				marker = "⎇"
+			}
+			fmt.Fprintf(stdout, "%-14s %5s ✓ %s %-18s %s\n",
+				rec.Status, plainFraction(rec.Checklist), marker, rec.ID, rec.Objective)
+		}
+		return goalExitAchieved, nil
+	}
+
+	resolvedProvider, effectiveModel, err := resolveProvider(*providerName, *model)
+	if err != nil {
+		return goalExitErrored, err
+	}
+	providerImpl, err := newProvider(resolvedProvider)
+	if err != nil {
+		return goalExitErrored, err
+	}
+	effectiveAllowOverwrite := *codingAllowOverwrite || *yolo
+	buildToolsAt := func(dir string) ([]glue.Tool, error) {
+		t, _, err := buildCodingTools(codingFlagConfig{
+			Enabled:         *coding,
+			WorkDir:         dir,
+			AllowedBinaries: append([]string(nil), allowedBinaries...),
+			AllowOverwrite:  effectiveAllowOverwrite,
+		})
+		return t, err
+	}
+	tools, err := buildToolsAt(*workDir)
+	if err != nil {
+		return goalExitErrored, err
+	}
+	var permission glue.Permission
+	switch {
+	case *yolo:
+		permission = yoloPermission{}
+		fmt.Fprintln(stderr, "glue goal: --yolo enabled; permission prompts are off (use on a feature branch or with --worktree).")
+	case *coding:
+		permission = newLocalPromptPermission(stdin, stderr)
+	}
+	agent := glue.NewAgent(glue.AgentOptions{
+		Provider:   providerImpl,
+		Model:      normalizeModel(effectiveModel),
+		Tools:      tools,
+		Store:      store,
+		WorkDir:    *workDir,
+		Permission: permission,
+	})
+
+	spec := glue.GoalSpec{
+		MaxIterations: *maxIterations,
+		TokenBudget:   *budget,
+		Permission:    permission,
+	}
+
+	switch {
+	case *resume:
+		rec, err := pickResumeRecord(ctx, agent, flags.Arg(0))
+		if err != nil {
+			return goalExitErrored, err
+		}
+		spec.Objective = rec.Objective
+		spec.SessionPrefix = rec.ID
+		spec.Checklist = rec.Checklist
+		spec.StartIteration = rec.Iterations + 1
+		if rec.WorkDir != "" {
+			if !*coding {
+				return goalExitErrored, fmt.Errorf("goal %s ran isolated in a worktree; resuming it needs --coding", rec.ID)
+			}
+			dir, err := worktree.Ensure(*workDir, rec.ID)
+			if err != nil {
+				return goalExitErrored, err
+			}
+			wtTools, err := buildToolsAt(dir)
+			if err != nil {
+				return goalExitErrored, err
+			}
+			spec.Tools, spec.CheckerTools, spec.WorkDir = wtTools, wtTools, dir
+		}
+		fmt.Fprintf(stdout, "resuming %s (iteration %d): %s\n", rec.ID, spec.StartIteration, rec.Objective)
+	default:
+		objective := strings.TrimSpace(strings.Join(flags.Args(), " "))
+		if objective == "" {
+			return goalExitErrored, fmt.Errorf(`usage: glue goal "<objective>" [flags], glue goal --resume [id], or glue goal --list`)
+		}
+		spec.Objective = objective
+		spec.SessionPrefix = "goal-" + newGoalID()
+		if *useWorktree {
+			if !*coding {
+				return goalExitErrored, fmt.Errorf("--worktree needs --coding (the isolated goal would have no tools)")
+			}
+			dir, err := worktree.Ensure(*workDir, spec.SessionPrefix)
+			if err != nil {
+				return goalExitErrored, err
+			}
+			wtTools, err := buildToolsAt(dir)
+			if err != nil {
+				return goalExitErrored, err
+			}
+			spec.Tools, spec.CheckerTools, spec.WorkDir = wtTools, wtTools, dir
+			fmt.Fprintf(stdout, "isolated on branch %s (%s)\n", worktree.Branch(spec.SessionPrefix), dir)
+		}
+	}
+
+	spec.Emit = func(ev glue.GoalEvent) {
+		switch ev.Type {
+		case glue.GoalEventPlan:
+			fmt.Fprintf(stdout, "goal %s: %s\nplan (%d items):\n%s\n", spec.SessionPrefix, spec.Objective, len(ev.Checklist), plainChecklist(ev.Checklist))
+		case glue.GoalEventIterationStart:
+			fmt.Fprintf(stdout, "— iteration %d (%d tokens so far)\n", ev.Iteration, ev.Usage.TotalTokens)
+		case glue.GoalEventVerdict:
+			fmt.Fprintf(stdout, "  verdict: %s ✓ — %s\n", plainFraction(ev.Checklist), ev.Message)
+		}
+	}
+
+	res, runErr := agent.PursueGoal(ctx, spec)
+	fmt.Fprintf(stdout, "\n%s\n", plainChecklist(res.Checklist))
+	fmt.Fprintf(stdout, "goal %s after %d iteration(s), %d tokens", res.Status, res.Iterations, res.Usage.TotalTokens)
+	if res.Summary != "" {
+		fmt.Fprintf(stdout, " — %s", res.Summary)
+	}
+	fmt.Fprintln(stdout)
+	if spec.WorkDir != "" {
+		fmt.Fprintf(stdout, "changes on branch %s (%s) — review and merge\n", worktree.Branch(spec.SessionPrefix), spec.WorkDir)
+	}
+	if runErr != nil {
+		return goalExitErrored, runErr
+	}
+	switch res.Status {
+	case glue.GoalAchieved:
+		return goalExitAchieved, nil
+	case glue.GoalBlocked:
+		return goalExitBlocked, nil
+	case glue.GoalMaxIterations:
+		return goalExitMaxIterations, nil
+	case glue.GoalBudgetLimited:
+		return goalExitBudgetLimited, nil
+	default:
+		return goalExitErrored, nil
+	}
+}
+
+// pickResumeRecord finds the record to continue: the given id, or the most
+// recent unfinished one. A stale "running" record is resumable here — this
+// is a fresh process, so its owner is gone.
+func pickResumeRecord(ctx context.Context, agent *glue.Agent, id string) (glue.GoalRecord, error) {
+	if id != "" {
+		rec, ok, err := agent.LoadGoal(ctx, id)
+		if err != nil {
+			return glue.GoalRecord{}, err
+		}
+		if !ok {
+			return glue.GoalRecord{}, fmt.Errorf("no goal record %q (try glue goal --list)", id)
+		}
+		if len(rec.Checklist) == 0 {
+			return glue.GoalRecord{}, fmt.Errorf("goal %q has no checklist to resume from", id)
+		}
+		return rec, nil
+	}
+	recs, err := agent.ListGoals(ctx, glue.ListGoalsOptions{Prefix: "goal-", Limit: 50})
+	if err != nil {
+		return glue.GoalRecord{}, err
+	}
+	for _, rec := range recs {
+		if (rec.Resumable() || rec.Status == glue.GoalRunning) && len(rec.Checklist) > 0 {
+			return rec, nil
+		}
+	}
+	return glue.GoalRecord{}, fmt.Errorf("no unfinished goal to resume (try glue goal --list)")
+}
+
+func plainChecklist(items []glue.ChecklistItem) string {
+	if len(items) == 0 {
+		return "  (no checklist)"
+	}
+	lines := make([]string, 0, len(items))
+	for _, it := range items {
+		box := "[ ]"
+		if it.Done {
+			box = "[x]"
+		}
+		line := "  " + box + " " + it.Title
+		if it.Evidence != "" {
+			line += " — " + it.Evidence
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func plainFraction(items []glue.ChecklistItem) string {
+	done := 0
+	for _, it := range items {
+		if it.Done {
+			done++
+		}
+	}
+	return fmt.Sprintf("%d/%d", done, len(items))
+}
+
+// newGoalID returns a 12-char hex id, matching the TUI's goal id shape.
+func newGoalID() string {
+	var b [6]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}

--- a/cmd/glue/goalcmd_test.go
+++ b/cmd/glue/goalcmd_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/erain/glue"
+)
+
+// goalCLITurn scripts one assistant turn whose final message carries text,
+// as the goal loop's PromptJSON parsing expects.
+func goalCLITurn(text string) []glue.ProviderEvent {
+	msg := glue.Message{
+		Role:    glue.MessageRoleAssistant,
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
+	}
+	return []glue.ProviderEvent{
+		{Type: glue.ProviderEventStart},
+		{Type: glue.ProviderEventTextDelta, Delta: text},
+		{Type: glue.ProviderEventDone, Message: &msg},
+	}
+}
+
+func TestGoalCommandAchieved(t *testing.T) {
+	t.Parallel()
+	store := t.TempDir()
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		goalCLITurn(`{"items":[{"title":"A"}]}`),
+		goalCLITurn("did A"),
+		goalCLITurn(`{"done":true,"items":[{"title":"A","done":true,"evidence":"A.go"}],"summary":"all done"}`),
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{"goal", "--store", store, "ship", "A"}, &stdout, &stderr, fakeFactory(provider))
+	if code != goalExitAchieved {
+		t.Fatalf("exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"goal goal-", "ship A", "plan (1 items):", "— iteration 1", "verdict: 1/1", "[x] A — A.go", "goal achieved after 1 iteration(s)", "all done"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\n%s", want, out)
+		}
+	}
+	// No --model flag: the provider's default model must be resolved, not
+	// left empty (live providers reject empty-model requests).
+	if len(provider.requests) == 0 || provider.requests[0].Model == "" {
+		t.Fatalf("requests carry no model: %+v", provider.requests)
+	}
+}
+
+func TestGoalCommandExitCodesAndResume(t *testing.T) {
+	t.Parallel()
+	store := t.TempDir()
+
+	// Round 1: one iteration, checker leaves B undone → max_iterations (3).
+	provider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		goalCLITurn(`{"items":[{"title":"A"},{"title":"B"}]}`),
+		goalCLITurn("did A"),
+		goalCLITurn(`{"done":false,"items":[{"title":"A","done":true},{"title":"B"}],"summary":"B remains"}`),
+	}}
+	var stdout bytes.Buffer
+	code := runCLI(context.Background(), []string{"goal", "--store", store, "--max-iterations", "1", "ship A and B"}, &stdout, io.Discard, fakeFactory(provider))
+	if code != goalExitMaxIterations {
+		t.Fatalf("exit = %d, want %d\n%s", code, goalExitMaxIterations, stdout.String())
+	}
+
+	// --list sees the stored record.
+	stdout.Reset()
+	code = runCLI(context.Background(), []string{"goal", "--store", store, "--list"}, &stdout, io.Discard, fakeFactory(nil))
+	if code != 0 || !strings.Contains(stdout.String(), "max_iterations") || !strings.Contains(stdout.String(), "ship A and B") {
+		t.Fatalf("--list: exit=%d out=%q", code, stdout.String())
+	}
+
+	// --resume continues from the verified checklist: no planning call, the
+	// scripted turns are maker + verdict only, and iteration numbering
+	// continues at 2.
+	resumeProvider := &scriptedProvider{turns: [][]glue.ProviderEvent{
+		goalCLITurn("did B"),
+		goalCLITurn(`{"done":true,"items":[{"title":"A","done":true},{"title":"B","done":true}],"summary":"done"}`),
+	}}
+	stdout.Reset()
+	code = runCLI(context.Background(), []string{"goal", "--store", store, "--resume"}, &stdout, io.Discard, fakeFactory(resumeProvider))
+	if code != goalExitAchieved {
+		t.Fatalf("--resume exit = %d, want 0\n%s", code, stdout.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"resuming goal-", "(iteration 2)", "— iteration 2", "goal achieved"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("resume stdout missing %q\n%s", want, out)
+		}
+	}
+	if len(resumeProvider.requests) != 2 {
+		t.Fatalf("provider calls = %d, want 2 (no planning call on resume)", len(resumeProvider.requests))
+	}
+}
+
+func TestGoalCommandUsageErrors(t *testing.T) {
+	t.Parallel()
+	var stderr bytes.Buffer
+	code := runCLI(context.Background(), []string{"goal", "--store", t.TempDir()}, io.Discard, &stderr, fakeFactory(&scriptedProvider{}))
+	if code != goalExitErrored || !strings.Contains(stderr.String(), "usage: glue goal") {
+		t.Fatalf("exit=%d stderr=%q", code, stderr.String())
+	}
+
+	stderr.Reset()
+	code = runCLI(context.Background(), []string{"goal", "--store", t.TempDir(), "--worktree", "x"}, io.Discard, &stderr, fakeFactory(&scriptedProvider{}))
+	if code != goalExitErrored || !strings.Contains(stderr.String(), "--worktree needs --coding") {
+		t.Fatalf("worktree gating: exit=%d stderr=%q", code, stderr.String())
+	}
+
+	stderr.Reset()
+	code = runCLI(context.Background(), []string{"goal", "--store", t.TempDir(), "--resume"}, io.Discard, &stderr, fakeFactory(&scriptedProvider{}))
+	if code != goalExitErrored || !strings.Contains(stderr.String(), "no unfinished goal") {
+		t.Fatalf("resume with empty store: exit=%d stderr=%q", code, stderr.String())
+	}
+}

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -307,6 +307,12 @@ func runCLIWithDeps(ctx context.Context, args []string, stdin io.Reader, stdout 
 			return 1
 		}
 		return 0
+	case "goal":
+		code, err := goalCommand(ctx, args[1:], stdin, stdout, stderr, newProvider)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+		}
+		return code
 	default:
 		fmt.Fprintf(stderr, "unknown command %q\n\n", args[0])
 		printUsage(stderr)
@@ -2829,6 +2835,8 @@ func printVersion(w io.Writer) {
 func printUsage(w io.Writer) {
 	fmt.Fprint(w, `Usage:
   glue run --prompt <text> [--provider <name>] [--id <id>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
+  glue goal "<objective>" [--provider <name>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--yolo] [--worktree] [--max-iterations <n>] [--budget <tokens>] [--env <path>]
+  glue goal --resume [<id>] | --list [--store <dir>]
   glue serve [--provider <name>] [--listen 127.0.0.1:0] [--metadata <path>] [--model <model>] [--store <dir>] [--work <dir>] [--coding] [--env <path>]
   glue connect --prompt <text> [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
   glue connect --skill <name> [--arg key=value] [--id <id>] [--metadata <path>] [--base-url <url>] [--token <token>]
@@ -2850,6 +2858,7 @@ func printUsage(w io.Writer) {
 
 Commands:
   run      Run a local agent on any registered provider, optionally with coding tools.
+  goal     Run an autonomous goal loop headlessly (plan → make → verify until done or a guardrail trips); exit code reflects the outcome.
   serve    Start a local HTTP+SSE daemon for Glue sessions, optionally with coding tools.
   connect  Start a daemon prompt/skill run, or inspect daemon status/tools/skills/roles/MCP/recall surfaces.
   version  Print the binary's version, git revision, and Go toolchain (also: --version, -v).

--- a/cmd/glue/tui/goal.go
+++ b/cmd/glue/tui/goal.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/erain/glue"
+	"github.com/erain/glue/cmd/glue/worktree"
 )
 
 // goalMaxIterations mirrors the library default for GoalSpec.MaxIterations.
@@ -164,7 +165,7 @@ func (m *Model) startGoal(req goalStart) (tea.Model, tea.Cmd) {
 			m.rerender()
 			return m, nil
 		}
-		dir, err := ensureGoalWorktree(m.cfg.WorkDir, req.id)
+		dir, err := worktree.Ensure(m.cfg.WorkDir, req.id)
 		if err != nil {
 			m.appendSystem("/goal -w: " + err.Error())
 			m.rerender()
@@ -176,7 +177,7 @@ func (m *Model) startGoal(req goalStart) (tea.Model, tea.Cmd) {
 			m.rerender()
 			return m, nil
 		}
-		isolatedTools, workDir, branch = tools, dir, goalBranch(req.id)
+		isolatedTools, workDir, branch = tools, dir, worktree.Branch(req.id)
 	}
 
 	ctx, cancel := context.WithCancel(m.ctx)

--- a/cmd/glue/tui/goalworktree_test.go
+++ b/cmd/glue/tui/goalworktree_test.go
@@ -2,18 +2,18 @@ package tui
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/erain/glue"
+	"github.com/erain/glue/cmd/glue/worktree"
 )
 
 // scratchRepo initializes a git repository with one commit so worktrees can
-// branch off it.
+// branch off it. The worktree mechanics themselves are tested in the
+// cmd/glue/worktree package; here we test the /goal -w flow around them.
 func scratchRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -23,55 +23,11 @@ func scratchRepo(t *testing.T) string {
 		{"config", "user.name", "test"},
 		{"commit", "--allow-empty", "-q", "-m", "init"},
 	} {
-		if _, err := gitOutput(dir, args...); err != nil {
+		if _, err := worktree.Git(dir, args...); err != nil {
 			t.Fatalf("git %v: %v", args, err)
 		}
 	}
 	return dir
-}
-
-func TestEnsureGoalWorktreeCreatesAndReuses(t *testing.T) {
-	t.Parallel()
-	repo := scratchRepo(t)
-
-	dir, err := ensureGoalWorktree(repo, "goal-abc123")
-	if err != nil {
-		t.Fatalf("ensureGoalWorktree: %v", err)
-	}
-	want := filepath.Join(repo, ".glue", "worktrees", "goal-abc123")
-	if dir != want {
-		t.Fatalf("dir = %q, want %q", dir, want)
-	}
-	if _, err := os.Stat(dir); err != nil {
-		t.Fatalf("worktree dir missing: %v", err)
-	}
-	branch, err := gitOutput(dir, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil || branch != "goal/abc123" {
-		t.Fatalf("branch = %q err=%v, want goal/abc123", branch, err)
-	}
-
-	// Second call (resume) reuses the existing worktree.
-	again, err := ensureGoalWorktree(repo, "goal-abc123")
-	if err != nil || again != dir {
-		t.Fatalf("reuse: dir=%q err=%v", again, err)
-	}
-
-	// Deleted worktree but surviving branch: re-attach instead of failing
-	// on the duplicate branch name.
-	if _, err := gitOutput(repo, "worktree", "remove", "--force", dir); err != nil {
-		t.Fatalf("worktree remove: %v", err)
-	}
-	reattached, err := ensureGoalWorktree(repo, "goal-abc123")
-	if err != nil || reattached != dir {
-		t.Fatalf("re-attach: dir=%q err=%v", reattached, err)
-	}
-}
-
-func TestEnsureGoalWorktreeOutsideRepo(t *testing.T) {
-	t.Parallel()
-	if _, err := ensureGoalWorktree(t.TempDir(), "goal-x"); err == nil || !strings.Contains(err.Error(), "git repository") {
-		t.Fatalf("err = %v, want needs-a-git-repository", err)
-	}
 }
 
 func TestSlashGoalWorktreeFlagGating(t *testing.T) {
@@ -124,7 +80,7 @@ func TestIsolatedGoalRunsInWorktreeAndPersistsWorkDir(t *testing.T) {
 	m.send = func(msg tea.Msg) { msgs <- msg }
 
 	m.handleSlashGoal("-w ship A")
-	if m.goal == nil || m.goal.workDir == "" || m.goal.branch != goalBranch(m.goal.id) {
+	if m.goal == nil || m.goal.workDir == "" || m.goal.branch != worktree.Branch(m.goal.id) {
 		t.Fatalf("goal = %+v, want isolated with branch", m.goal)
 	}
 	if builtAt != m.goal.workDir {

--- a/cmd/glue/worktree/worktree.go
+++ b/cmd/glue/worktree/worktree.go
@@ -1,4 +1,9 @@
-package tui
+// Package worktree creates the dedicated git worktrees isolated goals run
+// in: <repo root>/.glue/worktrees/<goal-id> on branch goal/<id-suffix>.
+// Shared by the TUI's /goal -w and the headless `glue goal --worktree`.
+// Git plumbing lives here in cmd/glue per ADR-0012 — the library stays
+// git-free.
+package worktree
 
 import (
 	"fmt"
@@ -8,28 +13,26 @@ import (
 	"strings"
 )
 
-// goalBranch derives the branch name for an isolated goal from its record
-// id: "goal-ab12cd" → "goal/ab12cd".
-func goalBranch(goalID string) string {
+// Branch derives the branch name for an isolated goal from its record id:
+// "goal-ab12cd" → "goal/ab12cd".
+func Branch(goalID string) string {
 	return "goal/" + strings.TrimPrefix(goalID, "goal-")
 }
 
-// ensureGoalWorktree creates (or re-attaches, on resume) the dedicated git
-// worktree for a goal: <repo root>/.glue/worktrees/<goalID> on branch
-// goal/<suffix>. It returns the worktree directory. Git plumbing lives here
-// in cmd/glue per ADR-0012 — the library stays git-free.
-func ensureGoalWorktree(workDir, goalID string) (string, error) {
-	root, err := gitOutput(workDir, "rev-parse", "--show-toplevel")
+// Ensure creates (or re-attaches, on resume) the dedicated git worktree for
+// a goal and returns its directory.
+func Ensure(workDir, goalID string) (string, error) {
+	root, err := Git(workDir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", fmt.Errorf("worktree isolation needs a git repository at %s", workDir)
 	}
 	dir := filepath.Join(root, ".glue", "worktrees", goalID)
-	branch := goalBranch(goalID)
+	branch := Branch(goalID)
 
 	// Resume case: the worktree directory already exists — verify it is a
 	// usable checkout rather than silently working in a stale directory.
 	if _, statErr := os.Stat(dir); statErr == nil {
-		if _, err := gitOutput(dir, "rev-parse", "--is-inside-work-tree"); err != nil {
+		if _, err := Git(dir, "rev-parse", "--is-inside-work-tree"); err != nil {
 			return "", fmt.Errorf("%s exists but is not a git worktree; remove it and retry", dir)
 		}
 		return dir, nil
@@ -39,16 +42,16 @@ func ensureGoalWorktree(workDir, goalID string) (string, error) {
 	}
 	// New branch first; if the branch survived a deleted worktree (or a
 	// previous run), attach to it instead.
-	if _, err := gitOutput(root, "worktree", "add", dir, "-b", branch); err != nil {
-		if _, err2 := gitOutput(root, "worktree", "add", dir, branch); err2 != nil {
+	if _, err := Git(root, "worktree", "add", dir, "-b", branch); err != nil {
+		if _, err2 := Git(root, "worktree", "add", dir, branch); err2 != nil {
 			return "", fmt.Errorf("git worktree add: %w", err)
 		}
 	}
 	return dir, nil
 }
 
-// gitOutput runs git with the given args in dir and returns trimmed stdout.
-func gitOutput(dir string, args ...string) (string, error) {
+// Git runs git with the given args in dir and returns trimmed stdout.
+func Git(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/glue/worktree/worktree_test.go
+++ b/cmd/glue/worktree/worktree_test.go
@@ -1,0 +1,70 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scratchRepo initializes a git repository with one commit so worktrees can
+// branch off it.
+func scratchRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"commit", "--allow-empty", "-q", "-m", "init"},
+	} {
+		if _, err := Git(dir, args...); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+	return dir
+}
+
+func TestEnsureCreatesAndReuses(t *testing.T) {
+	t.Parallel()
+	repo := scratchRepo(t)
+
+	dir, err := Ensure(repo, "goal-abc123")
+	if err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	want := filepath.Join(repo, ".glue", "worktrees", "goal-abc123")
+	if dir != want {
+		t.Fatalf("dir = %q, want %q", dir, want)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("worktree dir missing: %v", err)
+	}
+	branch, err := Git(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil || branch != "goal/abc123" {
+		t.Fatalf("branch = %q err=%v, want goal/abc123", branch, err)
+	}
+
+	// Second call (resume) reuses the existing worktree.
+	again, err := Ensure(repo, "goal-abc123")
+	if err != nil || again != dir {
+		t.Fatalf("reuse: dir=%q err=%v", again, err)
+	}
+
+	// Deleted worktree but surviving branch: re-attach instead of failing
+	// on the duplicate branch name.
+	if _, err := Git(repo, "worktree", "remove", "--force", dir); err != nil {
+		t.Fatalf("worktree remove: %v", err)
+	}
+	reattached, err := Ensure(repo, "goal-abc123")
+	if err != nil || reattached != dir {
+		t.Fatalf("re-attach: dir=%q err=%v", reattached, err)
+	}
+}
+
+func TestEnsureOutsideRepo(t *testing.T) {
+	t.Parallel()
+	if _, err := Ensure(t.TempDir(), "goal-x"); err == nil || !strings.Contains(err.Error(), "git repository") {
+		t.Fatalf("err = %v, want needs-a-git-repository", err)
+	}
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -295,7 +295,11 @@ transcript, and a `◎ goal` status-bar segment. `/goal -w` adds worktree
 isolation: cmd/glue (which owns the git plumbing per ADR-0012) creates
 `.glue/worktrees/<goal-id>` on branch `goal/<id>`, rebuilds the coding tool
 set rooted there via `tui.Config.BuildTools`, and records the root in
-`GoalSpec.WorkDir` so resume re-attaches the same worktree.
+`GoalSpec.WorkDir` so resume re-attaches the same worktree. The headless
+`glue goal "<objective>"` subcommand runs the same loop without a TUI —
+`--list` / `--resume` / `--worktree` / `--max-iterations` / `--budget`, with
+the terminal status mapped to the exit code — which is what cron, CI, or a
+peggy schedule invokes for unattended goals.
 
 ## Gemini Provider
 


### PR DESCRIPTION
Goal loop **Phase 3c** ([ADR-0016](https://github.com/erain/glue/blob/main/docs/adr/0016-goal-loop.md), tracker #110) — the final slice. 3a made goal state durable, 3b isolated goals on branches; this makes goals runnable without a TUI, which is the "scheduled goals" story: cron, CI, or a peggy schedule invokes `glue goal` as the unit of work.

## What

- **`glue goal "<objective>"`** (`cmd/glue/goalcmd.go`): runs plan→make→verify headlessly. Shares `glue run`'s infrastructure flags (`--provider`, `--model`, `--store`, `--work`, `--coding`, `--allow-binary`, `--coding-allow-overwrite`, `--env`, `--yolo`) plus `--max-iterations`, `--budget`, `--worktree`. Progress streams to stdout: plan checklist, per-iteration line with running token count, per-verdict fraction + summary, final evidence-annotated checklist.
- **Exit codes**: 0 achieved · 2 blocked · 3 max-iterations · 4 budget-limited · 1 errored/usage — schedulers can retry a budget stop or alert on blocked.
- **`--list` / `--resume [id]`**: same records the TUI reads (shared store) — a goal started in `glue run` can be finished headlessly and vice versa. Resume seeds the checklist, continues iteration numbering, and re-attaches the worktree when the record carries one.
- **Permissions**: `--yolo` for unattended runs (with the feature-branch warning); otherwise the same local stdin prompt as non-interactive `glue run --coding`.
- **Shared `cmd/glue/worktree` package**: `Ensure`/`Branch`/`Git` moved out of the TUI; both `/goal -w` and `glue goal --worktree` use it.
- **Bug found by the live smoke and fixed**: the subcommand now resolves the provider's default model via `resolveProvider` — without it, every run with no `--model` failed with `gemini: model is required` (and the failed planning call silently degraded to a one-item plan). Regression-tested by asserting provider requests carry a model.

## Live verification (gemini)

```
$ glue goal --coding --yolo --worktree "Create a file HAIKU.md …"
isolated on branch goal/ea8a086b18a5 (.glue/worktrees/goal-ea8a086b18a5)
plan (4 items): …
— iteration 1 (2345 tokens so far)
  verdict: 4/4 ✓ — All tasks are complete.
goal achieved after 1 iteration(s), 20223 tokens — All tasks are complete.   # exit 0
```
User checkout untouched; haiku exists only in the worktree; `glue goal --list` shows the achieved record with the `⎇` marker.

## Tests

`goalcmd_test.go`: achieved run end-to-end through `runCLI` (output format, exit 0, default-model regression); exit-code mapping + `--list` + `--resume` continuing iteration numbering with no planning call; usage errors (`--worktree` without `--coding`, empty objective, resume on empty store). `worktree_test.go`: create/reuse/re-attach/outside-repo moved with the package.

```
go build ./... && go vet ./...   # clean
go test ./...                    # all packages pass
```

Closes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)