### PR TITLE
docs: reconcile version-line drift (0.x → 1.x) and refresh stale status (closes #332)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,11 @@ go.work.sum
 # Local agent harness state
 .claude/
 
-# Built example binaries (e.g. `go build ./examples/glue-review` lands here).
+# Built binaries (e.g. `go build ./cmd/glue` or
+# `go build ./agents/glue-review` lands here).
+/glue
 /glue-review
 /local-agent
+/peggy
 
 .gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-The library at `github.com/erain/glue` is **pre-1.0**; the `0.x`
-series may break API on minor bumps. See
+The library at `github.com/erain/glue` versions on a `1.x` line but
+has **not** locked its API: minor bumps may still break API, exactly
+as the pre-1.0 stance in
 [`docs/adr/0013-pre-1-0-stability-stance.md`](docs/adr/0013-pre-1-0-stability-stance.md)
-for the policy, and pin a tag in your `go.mod` if you need stability.
-Breaking changes always land with a `**Breaking:**` entry under a
-minor-bump section — never on a patch release.
+describes (its addendum records how the `1.x` line started). Pin a
+tag in your `go.mod` if you need stability. Breaking changes always
+land with a `**Breaking:**` entry under a minor-bump section — never
+on a patch release.
 
 This file tracks library-level changes. The reference agents version
 independently:

--- a/README.md
+++ b/README.md
@@ -474,16 +474,21 @@ GEMINI_API_KEY=... go test ./providers/gemini -run Live
 
 ## Project status & contributing
 
-The harness is feature-complete for the `0.x` series, tagged at
-**`v0.1.0`**, and in active use behind the
-[`agents/glue-review`](agents/glue-review) and
-[`agents/peggy`](agents/peggy) reference agents. The library remains
-pre-1.0: the public `Agent` / `Session` surface is stable in practice,
-but minor versions may still break API. The full stability stance is
-[ADR-0013](docs/adr/0013-pre-1-0-stability-stance.md); breaking
-changes always land with a `**Breaking:**` entry in
-[`CHANGELOG.md`](CHANGELOG.md), never on a patch release. Security
-reports go through [`SECURITY.md`](SECURITY.md).
+The project advances on three fronts: the **framework** (the library
+you `go get` — feature-complete and stable in practice), the **`glue`
+binary as a coding agent** (interactive TUI, coding tools, and the
+autonomous goal loop, [ADR-0016](docs/adr/0016-goal-loop.md)), and
+**Peggy**, the long-running personal assistant built on top
+([`agents/peggy`](agents/peggy)). Releases are tagged on a `1.x` line
+(currently well past `v1.10`), but the stability stance is still the
+pre-stability one recorded in
+[ADR-0013](docs/adr/0013-pre-1-0-stability-stance.md) (see its
+addendum for why the tags say `1.x`): the public `Agent` / `Session`
+surface is stable in practice, but **minor versions may still break
+API** until a deliberate surface-review pass. Breaking changes always
+land with a `**Breaking:**` entry in [`CHANGELOG.md`](CHANGELOG.md),
+never on a patch release. Security reports go through
+[`SECURITY.md`](SECURITY.md).
 
 Glue is built one GitHub issue at a time. The contributor workflow,
 branch/PR conventions, and the active tracker are documented in

--- a/docs/adr/0013-pre-1-0-stability-stance.md
+++ b/docs/adr/0013-pre-1-0-stability-stance.md
@@ -78,3 +78,29 @@ tagged release behind `go get github.com/erain/glue@v0.1.0`. Future
 breaking changes are cheap (one minor bump) but visible (one CHANGELOG
 entry per break). Locking to `v1.0.0` remains a future, deliberate
 choice rather than a launch-deadline accident.
+
+## Addendum (2026-06-09): the release line is `1.x`, the stance is unchanged
+
+This ADR chose to stay on `0.x` and cut `v0.1.0`. In practice the
+release line drifted: after `v0.5.0`, the next release was tagged
+**`v1.2.0`** (2026-06-08, the interactive-TUI release) — there was
+never a deliberate `v1.0.0` surface-review pass, and no `v1.0.0` or
+`v1.1.0` tag exists. Subsequent releases continued the `1.x` line
+(`v1.3.0` … `v1.12.0` and counting).
+
+Published module versions are immutable in the Go module proxy and
+`go get` resolves "latest" by SemVer, so the `1.x` line cannot be
+walked back without breaking consumers. We therefore accept the tags
+as they are and keep the *stance* of this ADR rather than its version
+numbers:
+
+- The surface-lock that `v1.0.0` normally implies **has not
+  happened**. Minor bumps on the `1.x` line may still break API,
+  flagged by `**Breaking:**` CHANGELOG entries, never on a patch
+  release — exactly the pre-1.0 discipline decided above.
+- The deliberate surface-review pass remains a future gate; when it
+  happens, the lock will be announced explicitly (likely as a `v2.0.0`
+  with a documented stability guarantee, since `v1.0.0` is no longer
+  available to carry that meaning).
+- README and CHANGELOG carry the caveat so consumers are not misled
+  by the `1.x` major version.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -153,9 +153,17 @@ milestone).
   `cmd/glue run|serve --provider <name> --coding` runs it on any
   registered provider (codex for a ChatGPT-subscription coding agent).
   Boundary recorded in
-  [ADR 0012](adr/0012-sdk-coding-agent-peggy-boundary.md). The binary's
-  coding surface is functional; interactive multi-turn session UX and a
-  sandboxed `Executor` backend remain.
+  [ADR 0012](adr/0012-sdk-coding-agent-peggy-boundary.md). Since then
+  the binary became a full interactive coding agent: the bubbletea TUI
+  with streaming, tool cards, inline permission prompts, and slash
+  commands ([ADR 0014](adr/0014-coding-agent-tui.md)); session
+  fork/clone/tree ([ADR 0015](adr/0015-session-tree.md)); and the
+  autonomous goal loop — `Agent.PursueGoal`, TUI `/goal` (durable,
+  resumable, optionally worktree-isolated), and the headless
+  `glue goal` subcommand for cron/CI
+  ([ADR 0016](adr/0016-goal-loop.md), `v1.10.0`–`v1.12.0`). Remaining:
+  daemon goal endpoints, a sandboxed `Executor` backend (container/VM),
+  and TUI-on-`glue connect`.
 - **Track B — Peggy.** Peggy v0.1–v0.5 plus dogfood hardening (M1–M6)
   shipped: single-prompt CLI, Telegram channel, durable sqlite+FTS5
   memory with curated recall, opt-in coding tools, MCP servers, the


### PR DESCRIPTION
Closes #332.

Docs-only PR (plus two `.gitignore` lines). Reconciles documentation with the repo's actual state:

- **ADR-0013 addendum** — records the accidental `v0.5.0 → v1.2.0` jump (no `v1.0.0`/`v1.1.0` ever existed), accepts the immutable `1.x` tags, and carries the pre-1.0 stability stance over: minor bumps may still break API until a deliberate surface-review pass; that future lock would land as `v2.0.0`.
- **README "Project status"** — was "feature-complete for the 0.x series, tagged at **v0.1.0**" (repo is at `v1.12.0`); now states the three-track status (framework / coding-agent binary / Peggy) with the 1.x-line caveat.
- **CHANGELOG header** — same reconciliation.
- **project-plan Track A** — TUI (ADR-0014), session tree (ADR-0015), and the goal loop (ADR-0016, `v1.10.0`–`v1.12.0`) are shipped, not "remaining"; remaining items listed explicitly.
- **.gitignore** — `/glue` and `/peggy` build artifacts were not ignored.

Verified: no doc claims 0.x/v0.1.0 as current state (historical CHANGELOG sections untouched); `go build ./cmd/glue` leaves a clean `git status`; `docs/design.md` checked and already current (goal loop included), so untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)