### PR TITLE
repo: fix gofmt drift in 23 files and enforce gofmt in CI (closes #334)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: gofmt
+        run: |
+          out=$(gofmt -l .)
+          if [ -n "$out" ]; then
+            echo "gofmt drift in:"
+            echo "$out"
+            exit 1
+          fi
+
       - name: Vet
         run: go vet ./...
 

--- a/agent_tree_test.go
+++ b/agent_tree_test.go
@@ -227,13 +227,13 @@ func TestSessionParentMissingMetadata(t *testing.T) {
 		t.Fatal("empty metadata should not look like a fork")
 	}
 	if _, _, ok := glue.SessionParent(glue.SessionState{Metadata: map[string]any{
-		glue.MetadataKeyParentSessionID: "", // empty string is not a valid parent
+		glue.MetadataKeyParentSessionID:    "", // empty string is not a valid parent
 		glue.MetadataKeyParentMessageIndex: 0,
 	}}); ok {
 		t.Fatal("empty parent id should not look like a fork")
 	}
 	if _, _, ok := glue.SessionParent(glue.SessionState{Metadata: map[string]any{
-		glue.MetadataKeyParentSessionID: "x",
+		glue.MetadataKeyParentSessionID:    "x",
 		glue.MetadataKeyParentMessageIndex: "not-a-number",
 	}}); ok {
 		t.Fatal("non-numeric index should not look like a fork")

--- a/agents/glue-review/blocklist_test.go
+++ b/agents/glue-review/blocklist_test.go
@@ -35,20 +35,20 @@ func TestPathBlockedDefaults(t *testing.T) {
 		{".netrc", true},
 		{".pgpass", true},
 		{"config/api_secret.txt", true},
-		{"deploy/secrets.yaml", true},      // basename matches `secrets`
-		{"deploy/secrets/foo.yaml", true},  // path component matches `secrets`
-		{"infra/.aws/credentials", true},   // .aws component
+		{"deploy/secrets.yaml", true},     // basename matches `secrets`
+		{"deploy/secrets/foo.yaml", true}, // path component matches `secrets`
+		{"infra/.aws/credentials", true},  // .aws component
 		{"server.kubeconfig", true},
-		{"FOO_SECRET.env", true},           // case-insensitive basename
-		{".ENV", true},                     // case-insensitive
+		{"FOO_SECRET.env", true}, // case-insensitive basename
+		{".ENV", true},           // case-insensitive
 
 		// Should NOT block (legitimate code).
 		{"main.go", false},
 		{"docs/README.md", false},
 		{"src/handler.ts", false},
-		{"environment.go", false},          // contains "env" but not the pattern
-		{"keychain.go", false},             // contains "key" but not `*.key`
-		{"private/notes.md", false},        // word "private" alone is not blocked
+		{"environment.go", false},   // contains "env" but not the pattern
+		{"keychain.go", false},      // contains "key" but not `*.key`
+		{"private/notes.md", false}, // word "private" alone is not blocked
 	}
 	for _, c := range cases {
 		got, pat := pathBlocked(c.path, defaults)
@@ -103,12 +103,12 @@ func TestMergeBlocklistDedups(t *testing.T) {
 func TestSplitCommaList(t *testing.T) {
 	t.Parallel()
 	cases := map[string][]string{
-		"":                     nil,
-		"  ":                   nil,
-		"a":                    {"a"},
-		"a,b,c":                {"a", "b", "c"},
-		" a , b , c ":          {"a", "b", "c"},
-		"a,,b":                 {"a", "b"},
+		"":            nil,
+		"  ":          nil,
+		"a":           {"a"},
+		"a,b,c":       {"a", "b", "c"},
+		" a , b , c ": {"a", "b", "c"},
+		"a,,b":        {"a", "b"},
 	}
 	for in, want := range cases {
 		got := splitCommaList(in)

--- a/agents/glue-review/main_test.go
+++ b/agents/glue-review/main_test.go
@@ -280,4 +280,3 @@ func TestLiveReviewSmoke(t *testing.T) {
 	}
 	t.Logf("review output (%d bytes):\n%s", out.Len(), out.String())
 }
-

--- a/agents/glue-review/tools.go
+++ b/agents/glue-review/tools.go
@@ -262,4 +262,3 @@ func truncate(s string, max int) string {
 	}
 	return s[:max-len(note)] + note
 }
-

--- a/agents/peggy/channel_test.go
+++ b/agents/peggy/channel_test.go
@@ -12,9 +12,9 @@ func TestChannelSessionID(t *testing.T) {
 		want    string
 	}{
 		{"telegram", "12345", "telegram:12345"},
-		{"TELEGRAM", "abc", "telegram:abc"},      // lower-cased
-		{"  telegram  ", "9", "telegram:9"},     // trimmed
-		{"", "7", "7"},                           // no-op for empty channel
+		{"TELEGRAM", "abc", "telegram:abc"}, // lower-cased
+		{"  telegram  ", "9", "telegram:9"}, // trimmed
+		{"", "7", "7"},                      // no-op for empty channel
 		{"slack", "U123", "slack:U123"},
 	}
 	for _, tc := range cases {

--- a/cmd/glue/tui/atpicker_test.go
+++ b/cmd/glue/tui/atpicker_test.go
@@ -27,8 +27,8 @@ func TestDetectAtTriggerOpensOnAtWord(t *testing.T) {
 		{"", "", false},
 		{"hello", "", false},
 		{"alice@example.com", "", false}, // no preceding whitespace
-		{"@@param", "", false},            // escaped literal @
-		{"@ut hello", "", false},          // word ended already
+		{"@@param", "", false},           // escaped literal @
+		{"@ut hello", "", false},         // word ended already
 		{"@a\tb", "", false},
 	}
 	for _, c := range cases {
@@ -85,7 +85,7 @@ func makePickerFixture(t *testing.T) *atPicker {
 	mk("cmd/util/helper.go", "")
 	mk("vendor/x/util.go", "")
 	mk("README.md", "")
-	mk(".git/config", "")     // should be skipped
+	mk(".git/config", "")  // should be skipped
 	mk(".env", "SECRET=1") // should be blocklisted
 	return newAtPicker(dir)
 }

--- a/cmd/glue/tui/commands_test.go
+++ b/cmd/glue/tui/commands_test.go
@@ -15,8 +15,8 @@ func TestParseSlashCommand(t *testing.T) {
 	}{
 		{"", false, "", ""},
 		{"hello world", false, "", ""},
-		{"/", false, "", ""},     // bare slash is not a command
-		{"  /", false, "", ""},   // whitespace tolerated, still nothing
+		{"/", false, "", ""},   // bare slash is not a command
+		{"  /", false, "", ""}, // whitespace tolerated, still nothing
 		{"/help", true, "help", ""},
 		{"  /help  ", true, "help", ""},
 		{"/HELP", true, "help", ""}, // case-insensitive name

--- a/cmd/glue/tui/layout_test.go
+++ b/cmd/glue/tui/layout_test.go
@@ -14,9 +14,9 @@ import (
 func TestLayoutCapsViewportAtBodyMaxWidth(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name     string
-		termW    int
-		wantVPW  int
+		name    string
+		termW   int
+		wantVPW int
 	}{
 		{"narrow stays uncapped", 60, 60},
 		{"at exactly cap", bodyMaxWidth, bodyMaxWidth},

--- a/cmd/glue/tui/sessions_test.go
+++ b/cmd/glue/tui/sessions_test.go
@@ -90,7 +90,7 @@ func TestHumanAge(t *testing.T) {
 	// Just sanity: cover the buckets so we don't regress them.
 	cases := []string{"just now", "m ago", "h ago", "d ago"}
 	got := []string{
-		humanAge(30_000_000_000),       // 30s
+		humanAge(30_000_000_000),          // 30s
 		humanAge(30 * 60 * 1_000_000_000), // 30 min
 		humanAge(3 * 3600 * 1_000_000_000),
 		humanAge(48 * 3600 * 1_000_000_000),

--- a/cmd/glue/tui/styles.go
+++ b/cmd/glue/tui/styles.go
@@ -16,12 +16,13 @@ import "github.com/charmbracelet/lipgloss"
 // rest of the palette in a terminal.
 //
 // Reference flavor hexes for grep-ability:
-//   Mocha base #1e1e2e · text #cdd6f4 · mauve #cba6f7 · green #a6e3a1
-//          red #f38ba8 · peach #fab387 · subtext0 #a6adc8 · overlay1 #7f849c
-//          surface1 #45475a · lavender #b4befe
-//   Latte base #eff1f5 · text #4c4f69 · mauve #8839ef · green #40a02b
-//          red #d20f39 · peach #fe640b · subtext0 #6c6f85 · overlay1 #8c8fa1
-//          surface1 #bcc0cc · lavender #7287fd
+//
+//	Mocha base #1e1e2e · text #cdd6f4 · mauve #cba6f7 · green #a6e3a1
+//	       red #f38ba8 · peach #fab387 · subtext0 #a6adc8 · overlay1 #7f849c
+//	       surface1 #45475a · lavender #b4befe
+//	Latte base #eff1f5 · text #4c4f69 · mauve #8839ef · green #40a02b
+//	       red #d20f39 · peach #fe640b · subtext0 #6c6f85 · overlay1 #8c8fa1
+//	       surface1 #bcc0cc · lavender #7287fd
 var (
 	// accent — mauve. Brand color: user prefix, headers, focused chrome.
 	accent = lipgloss.AdaptiveColor{Light: "#8839ef", Dark: "#cba6f7"}

--- a/cmd/glue/tui/tui.go
+++ b/cmd/glue/tui/tui.go
@@ -105,8 +105,8 @@ func shortID() string {
 type turnState struct {
 	cancel context.CancelFunc
 	// indexes of currently-streaming items so deltas append cheaply
-	asstIndex int                  // -1 if no current assistant item
-	toolIndex map[string]int       // ToolCallID -> transcript index
+	asstIndex int            // -1 if no current assistant item
+	toolIndex map[string]int // ToolCallID -> transcript index
 }
 
 func newTurnState() *turnState {
@@ -145,9 +145,9 @@ type Model struct {
 	transcript []transcriptItem
 
 	// Current turn
-	turn     *turnState
-	turnNum  int
-	pending  *permPending
+	turn    *turnState
+	turnNum int
+	pending *permPending
 	// permQueue holds permission requests that arrived while another was
 	// already on screen — a background /goal loop and a chat turn can ask
 	// concurrently, and a single slot would silently drop one (deadlocking
@@ -514,7 +514,6 @@ func (m *Model) inputHeight() int {
 	return h
 }
 
-
 func (m *Model) rerender() {
 	// Sticky scroll: only auto-scroll if the user is already at the
 	// bottom. If they scrolled up to read older context, preserve their
@@ -572,7 +571,7 @@ func turnRule(width int) string {
 func (m *Model) headerView() string {
 	left := headerBrand.Render("glue") +
 		"  " + headerStyle.Render(fmt.Sprintf("session %s · %s/%s",
-			m.cfg.SessionID, providerOrDefault(m.cfg.Provider), modelOrDefault(m.cfg.Model)))
+		m.cfg.SessionID, providerOrDefault(m.cfg.Provider), modelOrDefault(m.cfg.Model)))
 	right := headerStyle.Render(workOrDot(m.cfg.WorkDir))
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 1 {

--- a/failover_test.go
+++ b/failover_test.go
@@ -149,4 +149,3 @@ func TestFailover_CommitsAfterFirstSuccessfulEvent(t *testing.T) {
 		t.Fatalf("expected committed-but-errored first provider, got %+v", got)
 	}
 }
-

--- a/loop/parallel_test.go
+++ b/loop/parallel_test.go
@@ -38,7 +38,9 @@ func TestRunParallelOverlapsExecutors(t *testing.T) {
 	wait := Tool{
 		ToolSpec: ToolSpec{Name: "wait"},
 		Execute: func(_ context.Context, call ToolCall) (ToolResult, error) {
-			var args struct{ MS int `json:"ms"` }
+			var args struct {
+				MS int `json:"ms"`
+			}
 			if err := json.Unmarshal(call.Arguments, &args); err != nil {
 				return ToolResult{}, err
 			}
@@ -129,7 +131,9 @@ func TestRunParallelEmitsToolEndsInSourceOrder(t *testing.T) {
 	wait := Tool{
 		ToolSpec: ToolSpec{Name: "wait"},
 		Execute: func(_ context.Context, call ToolCall) (ToolResult, error) {
-			var args struct{ MS int `json:"ms"` }
+			var args struct {
+				MS int `json:"ms"`
+			}
 			_ = json.Unmarshal(call.Arguments, &args)
 			time.Sleep(time.Duration(args.MS) * time.Millisecond)
 			return ToolResult{Content: []ContentPart{{Type: ContentTypeText, Text: call.ID}}}, nil

--- a/prompts/catalog_test.go
+++ b/prompts/catalog_test.go
@@ -8,9 +8,9 @@ import (
 
 func newTestFS() fstest.MapFS {
 	return fstest.MapFS{
-		"prompts/v1.md":   {Data: []byte("v1 body\n")},
-		"prompts/v2.md":   {Data: []byte("v2 body\n\n")},
-		"prompts/notes/x": {Data: []byte("nested non-md")},
+		"prompts/v1.md":    {Data: []byte("v1 body\n")},
+		"prompts/v2.md":    {Data: []byte("v2 body\n\n")},
+		"prompts/notes/x":  {Data: []byte("nested non-md")},
 		"prompts/skip.txt": {Data: []byte("not markdown")},
 	}
 }

--- a/providers/codex/auth/auth.go
+++ b/providers/codex/auth/auth.go
@@ -60,10 +60,10 @@ type Manager struct {
 	// Now is used in tests to control time. Nil means time.Now.
 	Now func() time.Time
 
-	mu       sync.Mutex
-	path     string // resolved on first Load
-	apiKey   *string
-	tokens   *Tokens
+	mu     sync.Mutex
+	path   string // resolved on first Load
+	apiKey *string
+	tokens *Tokens
 }
 
 // NewManager returns a Manager with default behavior.

--- a/providers/codex/codex.go
+++ b/providers/codex/codex.go
@@ -280,8 +280,8 @@ func (p *Provider) consumeStream(ctx context.Context, resp *http.Response, model
 	}
 
 	var (
-		text     strings.Builder
-		hasText  bool
+		text      strings.Builder
+		hasText   bool
 		toolCalls []loop.ToolCall
 		completed bool
 		failed    bool

--- a/providers/codex/convert.go
+++ b/providers/codex/convert.go
@@ -12,15 +12,15 @@ import (
 // endpoint. Fields mirror Codex CLI's ResponsesApiRequest in
 // codex-rs/core/src/client.rs.
 type responsesRequest struct {
-	Model              string           `json:"model"`
-	Instructions       string           `json:"instructions,omitempty"`
-	Input              []responsesInput `json:"input"`
-	Tools              []responsesTool  `json:"tools,omitempty"`
-	ToolChoice         string           `json:"tool_choice,omitempty"`
-	ParallelToolCalls  bool             `json:"parallel_tool_calls"`
-	Stream             bool             `json:"stream"`
-	Store              bool             `json:"store"`
-	Include            []string         `json:"include,omitempty"`
+	Model             string           `json:"model"`
+	Instructions      string           `json:"instructions,omitempty"`
+	Input             []responsesInput `json:"input"`
+	Tools             []responsesTool  `json:"tools,omitempty"`
+	ToolChoice        string           `json:"tool_choice,omitempty"`
+	ParallelToolCalls bool             `json:"parallel_tool_calls"`
+	Stream            bool             `json:"stream"`
+	Store             bool             `json:"store"`
+	Include           []string         `json:"include,omitempty"`
 }
 
 // responsesInput is one item in the Responses input array. The active

--- a/providers/codex/sse.go
+++ b/providers/codex/sse.go
@@ -115,10 +115,10 @@ type respCompletedPayload struct {
 		ID    string `json:"id"`
 		Model string `json:"model"`
 		Usage *struct {
-			InputTokens         int64 `json:"input_tokens"`
-			OutputTokens        int64 `json:"output_tokens"`
-			TotalTokens         int64 `json:"total_tokens"`
-			CachedInputTokens   int64 `json:"cached_input_tokens,omitempty"`
+			InputTokens       int64 `json:"input_tokens"`
+			OutputTokens      int64 `json:"output_tokens"`
+			TotalTokens       int64 `json:"total_tokens"`
+			CachedInputTokens int64 `json:"cached_input_tokens,omitempty"`
 		} `json:"usage"`
 	} `json:"response"`
 }

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -263,12 +263,12 @@ func TestMapFinishReason(t *testing.T) {
 	t.Parallel()
 
 	cases := map[genai.FinishReason]loop.StopReason{
-		"":                              loop.StopReasonStop,
-		genai.FinishReasonUnspecified:   loop.StopReasonStop,
-		genai.FinishReasonStop:          loop.StopReasonStop,
-		genai.FinishReasonMaxTokens:     loop.StopReasonLength,
-		genai.FinishReasonSafety:        loop.StopReasonError,
-		genai.FinishReasonRecitation:    loop.StopReasonError,
+		"":                                  loop.StopReasonStop,
+		genai.FinishReasonUnspecified:       loop.StopReasonStop,
+		genai.FinishReasonStop:              loop.StopReasonStop,
+		genai.FinishReasonMaxTokens:         loop.StopReasonLength,
+		genai.FinishReasonSafety:            loop.StopReasonError,
+		genai.FinishReasonRecitation:        loop.StopReasonError,
 		genai.FinishReasonProhibitedContent: loop.StopReasonError,
 	}
 	for input, want := range cases {
@@ -452,9 +452,9 @@ func TestAppendThinkingLatchesSignature(t *testing.T) {
 	t.Parallel()
 
 	msg := &loop.Message{}
-	appendThinking(msg, "reasoning ", "")    // text, no signature yet
-	appendThinking(msg, "continues", "")     // coalesces
-	appendThinking(msg, "", "c2ln")          // signature-only terminator latches
+	appendThinking(msg, "reasoning ", "") // text, no signature yet
+	appendThinking(msg, "continues", "")  // coalesces
+	appendThinking(msg, "", "c2ln")       // signature-only terminator latches
 	if len(msg.Content) != 1 {
 		t.Fatalf("len(Content) = %d, want 1 coalesced thinking block", len(msg.Content))
 	}

--- a/providers/openaicompat/convert.go
+++ b/providers/openaicompat/convert.go
@@ -40,16 +40,16 @@ type chatFuncSpec struct {
 
 // chatRequest is the JSON body sent to /v1/chat/completions.
 type chatRequest struct {
-	Model          string            `json:"model"`
-	Messages       []chatMessage     `json:"messages"`
-	Tools          []chatTool        `json:"tools,omitempty"`
-	Stream         bool              `json:"stream"`
-	StreamOptions  *streamOptions    `json:"stream_options,omitempty"`
-	Temperature    *float64          `json:"temperature,omitempty"`
-	MaxTokens      *int              `json:"max_tokens,omitempty"`
-	TopP           *float64          `json:"top_p,omitempty"`
-	ResponseFormat json.RawMessage   `json:"response_format,omitempty"`
-	Extra          map[string]any    `json:"-"`
+	Model          string          `json:"model"`
+	Messages       []chatMessage   `json:"messages"`
+	Tools          []chatTool      `json:"tools,omitempty"`
+	Stream         bool            `json:"stream"`
+	StreamOptions  *streamOptions  `json:"stream_options,omitempty"`
+	Temperature    *float64        `json:"temperature,omitempty"`
+	MaxTokens      *int            `json:"max_tokens,omitempty"`
+	TopP           *float64        `json:"top_p,omitempty"`
+	ResponseFormat json.RawMessage `json:"response_format,omitempty"`
+	Extra          map[string]any  `json:"-"`
 }
 
 type streamOptions struct {

--- a/store_test.go
+++ b/store_test.go
@@ -134,7 +134,7 @@ type savingErrStore struct{ err error }
 func (s savingErrStore) Load(context.Context, string) (SessionState, bool, error) {
 	return SessionState{}, false, nil
 }
-func (s savingErrStore) Save(context.Context, string, SessionState) error  { return s.err }
+func (s savingErrStore) Save(context.Context, string, SessionState) error { return s.err }
 func (savingErrStore) Delete(context.Context, string) error               { return nil }
 
 func TestSessionPromptSurfacesSaveError(t *testing.T) {

--- a/stores/sqlite/search_test.go
+++ b/stores/sqlite/search_test.go
@@ -165,7 +165,7 @@ func TestSearch_LimitAndOffset(t *testing.T) {
 	state := glue.SessionState{ID: "L", CreatedAt: now, UpdatedAt: now}
 	for i := 0; i < 6; i++ {
 		state.Messages = append(state.Messages, glue.Message{
-			Role: glue.MessageRoleUser,
+			Role:    glue.MessageRoleUser,
 			Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: "needle match line " + string(rune('a'+i))}},
 		})
 	}

--- a/tool_helpers_test.go
+++ b/tool_helpers_test.go
@@ -90,4 +90,3 @@ func TestNewTool_MalformedArgsReturnsErrorResult(t *testing.T) {
 		t.Fatalf("expected error text to name the tool; got %q", res.Content[0].Text)
 	}
 }
-


### PR DESCRIPTION
Closes #334.

- `gofmt -w` over every file `gofmt -l .` reported — 23 files across the root package tests, `cmd/glue/tui`, `providers/codex`, `agents/glue-review`, and others. Comment and struct-field alignment only; no semantic change.
- New `gofmt` step in the CI `test` job fails with the offending file list, so drift can't accumulate silently again (CI previously ran only build/vet/test).

Verified: `gofmt -l .` empty repo-wide; `go build ./... && go test ./...` green.

No overlap with #331 (cmd/glue root files) or #333 (docs) — any merge order is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)