### PR TITLE
tools/fs: edit_file repair ladder (closes #338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **`edit_file` repair ladder (`tools/fs`).** `old_string` no longer has
+  to match byte-for-byte: a deterministic cascade absorbs the drift
+  models introduce — trailing-whitespace differences, indentation drift
+  (the replacement is re-indented to the file's real indentation, with
+  per-level tab/space mapping), smart-quote/Unicode-dash/exotic-space
+  folding, block-anchor matching for ≥3-line blocks with a misquoted
+  middle, and over-escape repair (literal `\n` sequences from
+  double-escaped JSON). CRLF line endings and a UTF-8 BOM are preserved
+  on write. Non-exact matches are reported in the result; success now
+  echoes the updated lines (so the model needn't re-read the file);
+  failures echo what was searched for with concrete advice; and
+  "rest of code unchanged"-style placeholder replacements are rejected.
+  Source-verified port of the consensus technique across pi, Cline,
+  Codex CLI, and Gemini CLI
+  ([docs/coding-harness-roadmap.md](docs/coding-harness-roadmap.md) P0.1).
+  Closes #338.
+
 ## 1.12.0 — 2026-06-09
 
 - **Headless `glue goal` subcommand — scheduled/CI goal runs (goal loop

--- a/tools/fs/edit.go
+++ b/tools/fs/edit.go
@@ -72,7 +72,7 @@ func FileEdit(opts EditFileOptions) (glue.Tool, error) {
 	return glue.NewTool[fileEditArgs](
 		glue.ToolSpec{
 			Name:               "edit_file",
-			Description:        "Replace an exact string in an existing UTF-8 text file inside the configured workspace. Requires permission. old_string must match exactly once unless replace_all is set. Use this for surgical edits instead of rewriting the whole file with write_file.",
+			Description:        "Replace a string in an existing UTF-8 text file inside the configured workspace. Requires permission. old_string should match the file exactly; small whitespace, indentation, or quote/dash differences are repaired automatically and reported. old_string must match exactly once unless replace_all is set. The result echoes the updated lines — base follow-up edits on them instead of re-reading the file.",
 			RequiresPermission: true,
 			PermissionAction:   "edit_file",
 			PermissionTarget:   fileEditPermissionTarget,
@@ -142,27 +142,40 @@ func editFile(workDir string, args fileEditArgs, policy editPolicy) (glue.ToolRe
 		return glue.ToolResult{}, fmt.Errorf("fs: file %q is %d bytes, exceeds max %d", rel, info.Size(), policy.maxBytes)
 	}
 
+	if containsLazyPlaceholder(args.NewString) && !containsLazyPlaceholder(args.OldString) {
+		return glue.ToolResult{}, fmt.Errorf("fs: new_string contains a placeholder like \"rest of code unchanged\"; write the complete replacement text instead")
+	}
+
 	data, err := os.ReadFile(target)
 	if err != nil {
 		return glue.ToolResult{}, err
 	}
 	content := string(data)
 
-	count := strings.Count(content, args.OldString)
-	if count == 0 {
-		return glue.ToolResult{}, fmt.Errorf("fs: old_string not found in %q; read the file and match its exact text", rel)
+	// Normalize a UTF-8 BOM and CRLF line endings away for matching;
+	// both are restored on write so the file keeps its original form.
+	hadBOM := strings.HasPrefix(content, "\uFEFF")
+	if hadBOM {
+		content = strings.TrimPrefix(content, "\uFEFF")
 	}
-	if count > 1 && !args.ReplaceAll {
-		return glue.ToolResult{}, fmt.Errorf("fs: old_string matches %d times in %q; add surrounding context for a unique match or set replace_all=true", count, rel)
+	hadCRLF := strings.Contains(content, "\r\n")
+	if hadCRLF {
+		content = strings.ReplaceAll(content, "\r\n", "\n")
+	}
+	oldStr := strings.ReplaceAll(args.OldString, "\r\n", "\n")
+	newStr := strings.ReplaceAll(args.NewString, "\r\n", "\n")
+
+	updatedLF, outcome, err := applyLadderEdit(content, oldStr, newStr, args.ReplaceAll)
+	if err != nil {
+		return glue.ToolResult{}, fmt.Errorf("fs: %w in %q", err, rel)
 	}
 
-	var updated string
-	replacements := count
-	if args.ReplaceAll {
-		updated = strings.ReplaceAll(content, args.OldString, args.NewString)
-	} else {
-		updated = strings.Replace(content, args.OldString, args.NewString, 1)
-		replacements = 1
+	updated := updatedLF
+	if hadCRLF {
+		updated = strings.ReplaceAll(updated, "\n", "\r\n")
+	}
+	if hadBOM {
+		updated = "\uFEFF" + updated
 	}
 
 	updatedBytes := []byte(updated)
@@ -180,15 +193,26 @@ func editFile(workDir string, args fileEditArgs, policy editPolicy) (glue.ToolRe
 
 	cleanRel := filepath.ToSlash(filepath.Clean(rel))
 	plural := ""
-	if replacements != 1 {
+	if outcome.updated != 1 {
 		plural = "s"
 	}
+	summary := fmt.Sprintf("made %d replacement%s in %s (%d bytes)", outcome.updated, plural, cleanRel, len(updatedBytes))
+	if outcome.strategy != "exact" || outcome.unescaped {
+		how := outcome.strategy
+		if outcome.unescaped {
+			how += " after unescaping over-escaped sequences"
+		}
+		summary += fmt.Sprintf(" via %s match — old_string did not match the file byte-for-byte; base future edits on the updated lines below", how)
+	}
+	snippet := editSnippet(updatedLF, outcome.firstLine, outcome.lastLine, 2, 24, 2000)
+	text := fmt.Sprintf("%s\n\nupdated lines %d-%d:\n%s", summary, outcome.firstLine, outcome.lastLine, snippet)
 	return glue.ToolResult{
-		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: fmt.Sprintf("made %d replacement%s in %s (%d bytes)", replacements, plural, cleanRel, len(updatedBytes))}},
+		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
 		Metadata: map[string]any{
 			"path":         cleanRel,
-			"replacements": replacements,
+			"replacements": outcome.updated,
 			"bytes":        len(updatedBytes),
+			"strategy":     outcome.strategy,
 		},
 	}, nil
 }

--- a/tools/fs/match.go
+++ b/tools/fs/match.go
@@ -1,0 +1,493 @@
+package fs
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// This file implements the edit_file repair ladder: a cascade of
+// matching strategies, cheapest and strictest first, that absorbs the
+// whitespace and punctuation drift models introduce when quoting file
+// content back. Every strategy is deterministic — no similarity
+// scoring — so a match is always explainable in the tool result.
+//
+// Ladder order (stop at the first strategy that matches):
+//
+//  1. exact            — byte-for-byte (the pre-existing behavior).
+//  2. whitespace       — per-line, ignoring trailing spaces/tabs.
+//  3. indentation      — per-line, ignoring all leading/trailing
+//                        whitespace; the replacement is re-indented to
+//                        the file's actual indentation.
+//  4. punctuation      — per-line like (3), additionally folding smart
+//                        quotes, Unicode dashes, and exotic spaces to
+//                        their ASCII forms; for a single-line fragment,
+//                        folded substring search inside each line.
+//  5. block-anchor     — for blocks of >= 3 lines, match on the first
+//                        and last line only (trimmed), same line count.
+//
+// If nothing matches and old_string looks over-escaped (a known model
+// failure mode: literal `\n` two-byte sequences instead of newlines),
+// the sequences are unescaped and the ladder runs once more.
+
+// editOutcome reports how an edit was applied.
+type editOutcome struct {
+	updated   int    // number of replacements made
+	strategy  string // which ladder rung matched
+	firstLine int    // 1-based first line of the first replacement, in the updated content
+	lastLine  int    // 1-based last line of the first replacement, in the updated content
+	unescaped bool   // true when over-escape repair was needed
+}
+
+type matchAmbiguousError struct {
+	count    int
+	strategy string
+}
+
+func (e *matchAmbiguousError) Error() string {
+	return fmt.Sprintf("old_string matches %d times (via %s match); add surrounding context to make it unique or set replace_all=true", e.count, e.strategy)
+}
+
+type matchNotFoundError struct{ needle string }
+
+func (e *matchNotFoundError) Error() string {
+	echo := e.needle
+	if len(echo) > 120 {
+		echo = echo[:120] + "…"
+	}
+	return fmt.Sprintf("old_string not found (tried exact and whitespace/indentation/punctuation-tolerant matching). Searched for %q. Re-read the file with read_file and copy its exact text — check indentation, line endings, and quote/dash characters", echo)
+}
+
+// applyLadderEdit replaces old with new inside content using the repair
+// ladder. content, old, and new must already be LF-normalized.
+func applyLadderEdit(content, old, new string, replaceAll bool) (string, editOutcome, error) {
+	updated, outcome, err := ladderOnce(content, old, new, replaceAll)
+	if err == nil {
+		return updated, outcome, nil
+	}
+	if _, ambiguous := err.(*matchAmbiguousError); ambiguous {
+		return "", editOutcome{}, err
+	}
+	// Over-escape repair: a model that wrote "\\n" in JSON delivers a
+	// literal backslash+n. Unescape both sides and try once more.
+	uOld, uNew := repairOverEscaping(old), repairOverEscaping(new)
+	if uOld != old {
+		updated, outcome, uerr := ladderOnce(content, uOld, uNew, replaceAll)
+		if uerr == nil {
+			outcome.unescaped = true
+			return updated, outcome, nil
+		}
+		if _, ambiguous := uerr.(*matchAmbiguousError); ambiguous {
+			return "", editOutcome{}, uerr
+		}
+	}
+	return "", editOutcome{}, err
+}
+
+// ladderOnce runs the matching ladder a single time.
+func ladderOnce(content, old, new string, replaceAll bool) (string, editOutcome, error) {
+	type stage struct {
+		name string
+		find func() ([]span, func(span) string)
+	}
+	stages := []stage{
+		{"exact", func() ([]span, func(span) string) {
+			return exactSpans(content, old), func(span) string { return new }
+		}},
+		{"whitespace-tolerant", func() ([]span, func(span) string) {
+			return lineWindowSpans(content, old, lineEqRStrip), func(span) string { return new }
+		}},
+		{"indentation-tolerant", func() ([]span, func(span) string) {
+			spans := lineWindowSpans(content, old, lineEqTrim)
+			return spans, reindentRenderer(content, old, new)
+		}},
+		{"punctuation-tolerant", func() ([]span, func(span) string) {
+			if !strings.Contains(old, "\n") {
+				return foldedFragmentSpans(content, old), func(span) string { return new }
+			}
+			spans := lineWindowSpans(content, old, lineEqFold)
+			return spans, reindentRenderer(content, old, new)
+		}},
+		{"block-anchor", func() ([]span, func(span) string) {
+			spans := blockAnchorSpans(content, old)
+			return spans, reindentRenderer(content, old, new)
+		}},
+	}
+
+	for _, st := range stages {
+		spans, render := st.find()
+		if len(spans) == 0 {
+			continue
+		}
+		if len(spans) > 1 && !replaceAll {
+			return "", editOutcome{}, &matchAmbiguousError{count: len(spans), strategy: st.name}
+		}
+		updated, firstStart := replaceSpans(content, spans, render)
+		firstLine, lastLine := replacedLineRange(updated, firstStart, len(render(spans[0])))
+		return updated, editOutcome{
+			updated:   len(spans),
+			strategy:  st.name,
+			firstLine: firstLine,
+			lastLine:  lastLine,
+		}, nil
+	}
+	return "", editOutcome{}, &matchNotFoundError{needle: old}
+}
+
+// span is a half-open byte range [start, end) into content.
+type span struct{ start, end int }
+
+// exactSpans finds non-overlapping exact occurrences, left to right.
+func exactSpans(content, old string) []span {
+	if old == "" {
+		return nil
+	}
+	var spans []span
+	for from := 0; ; {
+		i := strings.Index(content[from:], old)
+		if i < 0 {
+			break
+		}
+		start := from + i
+		spans = append(spans, span{start, start + len(old)})
+		from = start + len(old)
+	}
+	return spans
+}
+
+// lineInfo locates one line inside content: content[start:end] is the
+// line's text without its trailing newline.
+type lineInfo struct{ start, end int }
+
+func splitLineInfos(content string) []lineInfo {
+	var lines []lineInfo
+	start := 0
+	for i := 0; i < len(content); i++ {
+		if content[i] == '\n' {
+			lines = append(lines, lineInfo{start, i})
+			start = i + 1
+		}
+	}
+	lines = append(lines, lineInfo{start, len(content)})
+	return lines
+}
+
+// oldNeedleLines splits old_string into comparable lines. A trailing
+// newline is recorded separately so the matched span can absorb it.
+func oldNeedleLines(old string) (lines []string, trailingNL bool) {
+	lines = strings.Split(old, "\n")
+	if len(lines) > 1 && lines[len(lines)-1] == "" {
+		return lines[:len(lines)-1], true
+	}
+	return lines, false
+}
+
+func lineEqRStrip(a, b string) bool {
+	return strings.TrimRight(a, " \t") == strings.TrimRight(b, " \t")
+}
+
+func lineEqTrim(a, b string) bool {
+	return strings.TrimSpace(a) == strings.TrimSpace(b)
+}
+
+func lineEqFold(a, b string) bool {
+	return foldASCII(strings.TrimSpace(a)) == foldASCII(strings.TrimSpace(b))
+}
+
+// lineWindowSpans slides a window of len(oldLines) lines over content
+// and reports windows where every line satisfies eq.
+func lineWindowSpans(content, old string, eq func(a, b string) bool) []span {
+	oldLines, trailingNL := oldNeedleLines(old)
+	if len(oldLines) == 0 {
+		return nil
+	}
+	lines := splitLineInfos(content)
+	if len(oldLines) > len(lines) {
+		return nil
+	}
+	var spans []span
+	for i := 0; i+len(oldLines) <= len(lines); i++ {
+		match := true
+		for j, ol := range oldLines {
+			li := lines[i+j]
+			if !eq(content[li.start:li.end], ol) {
+				match = false
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		end := lines[i+len(oldLines)-1].end
+		if trailingNL && end < len(content) && content[end] == '\n' {
+			end++
+		}
+		spans = append(spans, span{lines[i].start, end})
+		i += len(oldLines) - 1 // non-overlapping
+	}
+	return spans
+}
+
+// blockAnchorSpans matches blocks of >= 3 lines on their first and last
+// trimmed lines only, requiring the same line count. This survives
+// drift in the middle of a block the model quoted imperfectly.
+func blockAnchorSpans(content, old string) []span {
+	oldLines, trailingNL := oldNeedleLines(old)
+	if len(oldLines) < 3 {
+		return nil
+	}
+	first := strings.TrimSpace(oldLines[0])
+	last := strings.TrimSpace(oldLines[len(oldLines)-1])
+	if first == "" || last == "" {
+		return nil
+	}
+	lines := splitLineInfos(content)
+	if len(oldLines) > len(lines) {
+		return nil
+	}
+	var spans []span
+	for i := 0; i+len(oldLines) <= len(lines); i++ {
+		fi := lines[i]
+		li := lines[i+len(oldLines)-1]
+		if strings.TrimSpace(content[fi.start:fi.end]) != first ||
+			strings.TrimSpace(content[li.start:li.end]) != last {
+			continue
+		}
+		end := li.end
+		if trailingNL && end < len(content) && content[end] == '\n' {
+			end++
+		}
+		spans = append(spans, span{fi.start, end})
+		i += len(oldLines) - 1
+	}
+	return spans
+}
+
+// foldedFragmentSpans finds a single-line fragment inside content lines
+// after folding punctuation, mapping folded offsets back to the
+// original bytes.
+func foldedFragmentSpans(content, old string) []span {
+	needle := foldASCII(old)
+	if needle == "" {
+		return nil
+	}
+	var spans []span
+	for _, li := range splitLineInfos(content) {
+		line := content[li.start:li.end]
+		folded, starts, ends := foldASCIIWithMap(line)
+		for from := 0; ; {
+			i := strings.Index(folded[from:], needle)
+			if i < 0 {
+				break
+			}
+			fs, fe := from+i, from+i+len(needle)
+			spans = append(spans, span{li.start + starts[fs], li.start + ends[fe-1]})
+			from = fe
+		}
+	}
+	return spans
+}
+
+// foldASCII folds smart quotes, Unicode dashes, and exotic spaces to
+// plain ASCII so model-introduced punctuation drift still matches.
+func foldASCII(s string) string {
+	folded, _, _ := foldASCIIWithMap(s)
+	return folded
+}
+
+// foldASCIIWithMap folds s and records, for every folded byte, the
+// start and end byte offsets of the source rune in s.
+func foldASCIIWithMap(s string) (string, []int, []int) {
+	var b strings.Builder
+	b.Grow(len(s))
+	starts := make([]int, 0, len(s))
+	ends := make([]int, 0, len(s))
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		repl := foldRune(r)
+		for k := 0; k < len(repl); k++ {
+			starts = append(starts, i)
+			ends = append(ends, i+size)
+		}
+		b.WriteString(repl)
+		i += size
+	}
+	return b.String(), starts, ends
+}
+
+func foldRune(r rune) string {
+	switch r {
+	case '‘', '’', '‚', '‛':
+		return "'"
+	case '“', '”', '„', '‟':
+		return `"`
+	case '‐', '‑', '‒', '–', '—', '―', '−':
+		return "-"
+	case ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+		' ', ' ', ' ', ' ', ' ', ' ', ' ', '　':
+		return " "
+	default:
+		return string(r)
+	}
+}
+
+// reindentRenderer re-applies the file's actual indentation when a
+// match succeeded only after ignoring leading whitespace. It pairs each
+// old_string line with the file line it matched, derives an indent
+// substitution map (e.g. "four spaces" → "one tab" per nesting level),
+// and applies the longest-prefix substitution to every replacement
+// line — preserving relative indentation even for tab/space swaps that
+// only appear on inner lines.
+func reindentRenderer(content, old, new string) func(span) string {
+	oldLines, _ := oldNeedleLines(old)
+	return func(sp span) string {
+		matched := strings.Split(content[sp.start:sp.end], "\n")
+		type indentPair struct{ from, to string }
+		var pairs []indentPair
+		seen := map[string]bool{}
+		for j := 0; j < len(oldLines) && j < len(matched); j++ {
+			if strings.TrimSpace(oldLines[j]) == "" {
+				continue
+			}
+			from := leadingWhitespace(oldLines[j])
+			to := leadingWhitespace(matched[j])
+			if seen[from] {
+				continue
+			}
+			seen[from] = true
+			pairs = append(pairs, indentPair{from, to})
+		}
+		// Longest old indent first, so deeper nesting wins prefix checks.
+		for i := 0; i < len(pairs); i++ {
+			for j := i + 1; j < len(pairs); j++ {
+				if len(pairs[j].from) > len(pairs[i].from) {
+					pairs[i], pairs[j] = pairs[j], pairs[i]
+				}
+			}
+		}
+		changed := false
+		for _, p := range pairs {
+			if p.from != p.to {
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			return new
+		}
+		lines := strings.Split(new, "\n")
+		for i, line := range lines {
+			if line == "" {
+				continue
+			}
+			ws := leadingWhitespace(line)
+			for _, p := range pairs {
+				if p.from == "" {
+					if ws == "" {
+						lines[i] = p.to + line
+						break
+					}
+					continue
+				}
+				if strings.HasPrefix(ws, p.from) {
+					lines[i] = p.to + line[len(p.from):]
+					break
+				}
+			}
+		}
+		return strings.Join(lines, "\n")
+	}
+}
+
+func leadingWhitespace(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] != ' ' && s[i] != '\t' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// replaceSpans applies the rendered replacement to every span and
+// returns the updated content plus the byte offset (in the updated
+// content) where the first replacement begins.
+func replaceSpans(content string, spans []span, render func(span) string) (string, int) {
+	var b strings.Builder
+	prev := 0
+	firstStart := 0
+	for i, sp := range spans {
+		b.WriteString(content[prev:sp.start])
+		if i == 0 {
+			firstStart = b.Len()
+		}
+		b.WriteString(render(sp))
+		prev = sp.end
+	}
+	b.WriteString(content[prev:])
+	return b.String(), firstStart
+}
+
+// replacedLineRange computes the 1-based line range covered by the
+// replacement that starts at byte offset start with length n, in the
+// updated content.
+func replacedLineRange(updated string, start, n int) (int, int) {
+	firstLine := 1 + strings.Count(updated[:start], "\n")
+	end := start + n
+	if end > len(updated) {
+		end = len(updated)
+	}
+	lastLine := firstLine + strings.Count(updated[start:end], "\n")
+	return firstLine, lastLine
+}
+
+// repairOverEscaping collapses literal backslash escape sequences that
+// over-eager models emit instead of the control characters themselves.
+// It only rewrites sequences that decode to whitespace or quotes; real
+// code containing intentional `\n` escapes inside string literals is
+// matched by the exact stage long before this runs.
+var overEscapeReplacer = strings.NewReplacer(
+	`\n`, "\n",
+	`\t`, "\t",
+	`\r`, "\r",
+	`\"`, `"`,
+	`\'`, "'",
+)
+
+func repairOverEscaping(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	return overEscapeReplacer.Replace(s)
+}
+
+// lazyPlaceholderRe flags "rest of the code unchanged"-style
+// placeholders a lazy model writes instead of the real replacement.
+var lazyPlaceholderRe = regexp.MustCompile(`(?i)(rest of (the )?(code|file|function|method|class)|remains? unchanged|existing (code|implementation)|unchanged (code|lines)|\.\.\. ?(existing|rest|unchanged|omitted)|(code|implementation) omitted)`)
+
+func containsLazyPlaceholder(s string) bool {
+	return lazyPlaceholderRe.MatchString(s)
+}
+
+// editSnippet renders the updated region with up to context lines on
+// each side, for echoing back to the model so it does not re-read the
+// file to verify its edit.
+func editSnippet(updated string, firstLine, lastLine, context, maxLines, maxBytes int) string {
+	lines := strings.Split(updated, "\n")
+	lo := firstLine - 1 - context
+	if lo < 0 {
+		lo = 0
+	}
+	hi := lastLine + context
+	if hi > len(lines) {
+		hi = len(lines)
+	}
+	if hi-lo > maxLines {
+		hi = lo + maxLines
+	}
+	snippet := strings.Join(lines[lo:hi], "\n")
+	if len(snippet) > maxBytes {
+		snippet = snippet[:maxBytes] + "…"
+	}
+	return snippet
+}

--- a/tools/fs/match_test.go
+++ b/tools/fs/match_test.go
@@ -1,0 +1,237 @@
+package fs
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ladderEdit is a test helper: run an edit through the public tool and
+// return the result plus the file's content afterwards.
+func ladderEdit(t *testing.T, content, args string) (res string, isError bool, after string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := writeTemp(t, dir, "f.txt", content)
+	r := callEdit(t, EditFileOptions{WorkDir: dir}, `{"path":"f.txt",`+args+`}`)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r.Content[0].Text, r.IsError, string(data)
+}
+
+func TestLadderWhitespaceTolerant(t *testing.T) {
+	// File has trailing spaces the model did not quote.
+	content := "func a() {  \n\treturn 1  \n}\n"
+	text, isErr, after := ladderEdit(t, content,
+		`"old_string":"func a() {\n\treturn 1\n}","new_string":"func a() {\n\treturn 2\n}"`)
+	if isErr {
+		t.Fatalf("unexpected error: %s", text)
+	}
+	if !strings.Contains(after, "return 2") {
+		t.Fatalf("edit not applied: %q", after)
+	}
+	if !strings.Contains(text, "whitespace-tolerant") {
+		t.Fatalf("result does not report strategy: %s", text)
+	}
+}
+
+func TestLadderIndentationTolerantReindents(t *testing.T) {
+	// File uses tabs; the model quoted with four spaces. The
+	// replacement must land with the file's tabs, not the model's
+	// spaces.
+	content := "if x {\n\tdoThing()\n}\n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"if x {\n    doThing()\n}","new_string":"if x {\n    doOther()\n}"`)
+	if isErr {
+		t.Fatal("expected success")
+	}
+	if !strings.Contains(after, "\tdoOther()") {
+		t.Fatalf("replacement not re-indented with tabs: %q", after)
+	}
+}
+
+func TestLadderPunctuationTolerantMultiline(t *testing.T) {
+	// File contains an em-dash and curly quotes; model quoted ASCII.
+	content := "// note — see “spec”\nvalue := 1\n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"// note - see \"spec\"\nvalue := 1","new_string":"// note - see \"spec\"\nvalue := 2"`)
+	if isErr {
+		t.Fatal("expected punctuation-tolerant match")
+	}
+	if !strings.Contains(after, "value := 2") {
+		t.Fatalf("edit not applied: %q", after)
+	}
+}
+
+func TestLadderPunctuationTolerantFragment(t *testing.T) {
+	// Single-line fragment with a curly quote in the file.
+	content := "msg := ‘hello’ + suffix\n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"'hello'","new_string":"'goodbye'"`)
+	if isErr {
+		t.Fatal("expected fragment fold match")
+	}
+	if !strings.Contains(after, "'goodbye'") {
+		t.Fatalf("edit not applied: %q", after)
+	}
+	if strings.Contains(after, "hello") {
+		t.Fatalf("old text still present: %q", after)
+	}
+}
+
+func TestLadderBlockAnchor(t *testing.T) {
+	// Middle line drifted (model misquoted the comment); anchors hold.
+	content := "func b() {\n\t// computes the thing carefully\n\treturn compute()\n}\n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"func b() {\n\t// computes the thing\n\treturn compute()\n}","new_string":"func b() {\n\treturn computeFast()\n}"`)
+	if isErr {
+		t.Fatal("expected block-anchor match")
+	}
+	if !strings.Contains(after, "computeFast()") || strings.Contains(after, "carefully") {
+		t.Fatalf("block not replaced: %q", after)
+	}
+}
+
+func TestLadderOverEscapeRepair(t *testing.T) {
+	content := "alpha\nbeta\n"
+	// Model over-escaped: JSON \\n delivers literal backslash-n.
+	text, isErr, after := ladderEdit(t, content,
+		`"old_string":"alpha\\nbeta","new_string":"alpha\\ngamma"`)
+	if isErr {
+		t.Fatalf("expected unescape repair, got: %s", text)
+	}
+	if !strings.Contains(after, "gamma") {
+		t.Fatalf("edit not applied: %q", after)
+	}
+	if !strings.Contains(text, "unescaping") {
+		t.Fatalf("result does not report unescaping: %s", text)
+	}
+}
+
+func TestLadderCRLFPreserved(t *testing.T) {
+	content := "one\r\ntwo\r\nthree\r\n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"two","new_string":"TWO"`)
+	if isErr {
+		t.Fatal("expected success")
+	}
+	if after != "one\r\nTWO\r\nthree\r\n" {
+		t.Fatalf("CRLF not preserved: %q", after)
+	}
+}
+
+func TestLadderBOMPreserved(t *testing.T) {
+	content := "\uFEFFhead\nbody\n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"body","new_string":"BODY"`)
+	if isErr {
+		t.Fatal("expected success")
+	}
+	if !strings.HasPrefix(after, "\uFEFF") || !strings.Contains(after, "BODY") {
+		t.Fatalf("BOM not preserved: %q", after)
+	}
+}
+
+func TestLadderAmbiguousFlexibleMatch(t *testing.T) {
+	content := "  x := 1\n  y := 2\n  x := 1\n"
+	text, isErr, _ := ladderEdit(t, content,
+		`"old_string":"x := 1","new_string":"x := 9"`)
+	if !isErr {
+		t.Fatal("expected ambiguity error")
+	}
+	if !strings.Contains(text, "matches 2 times") || !strings.Contains(text, "replace_all") {
+		t.Fatalf("error not instructive: %s", text)
+	}
+}
+
+func TestLadderReplaceAllFlexible(t *testing.T) {
+	content := "a()  \nb()\na()  \n"
+	_, isErr, after := ladderEdit(t, content,
+		`"old_string":"a()","new_string":"c()","replace_all":true`)
+	if isErr {
+		t.Fatal("expected success")
+	}
+	if strings.Count(after, "c()") != 2 {
+		t.Fatalf("replace_all did not hit both: %q", after)
+	}
+}
+
+func TestLadderNotFoundError(t *testing.T) {
+	text, isErr, _ := ladderEdit(t, "totally different\n",
+		`"old_string":"no such text","new_string":"x"`)
+	if !isErr {
+		t.Fatal("expected not-found error")
+	}
+	for _, want := range []string{"not found", "no such text", "read_file"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("error missing %q: %s", want, text)
+		}
+	}
+}
+
+func TestLadderRejectsLazyPlaceholder(t *testing.T) {
+	text, isErr, after := ladderEdit(t, "func f() {\n\tbody()\n}\n",
+		`"old_string":"func f() {\n\tbody()\n}","new_string":"func f() {\n\t// rest of the code unchanged\n}"`)
+	if !isErr {
+		t.Fatal("expected placeholder rejection")
+	}
+	if !strings.Contains(text, "placeholder") {
+		t.Fatalf("error not instructive: %s", text)
+	}
+	if !strings.Contains(after, "body()") {
+		t.Fatal("file must be untouched")
+	}
+}
+
+func TestLadderResultEchoesUpdatedLines(t *testing.T) {
+	content := "l1\nl2\nl3\nl4\nl5\nl6\nl7\n"
+	text, isErr, _ := ladderEdit(t, content,
+		`"old_string":"l4","new_string":"L4-new"`)
+	if isErr {
+		t.Fatalf("unexpected error: %s", text)
+	}
+	if !strings.Contains(text, "updated lines 4-4") {
+		t.Fatalf("missing line range: %s", text)
+	}
+	// Snippet includes the new line plus two context lines each side.
+	for _, want := range []string{"l2", "l3", "L4-new", "l5", "l6"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("snippet missing %q: %s", want, text)
+		}
+	}
+	if strings.Contains(strings.TrimSuffix(text, "\n"), "l7") {
+		t.Fatalf("snippet should not include l7: %s", text)
+	}
+}
+
+func TestLadderExactStillWinsOverFlexible(t *testing.T) {
+	// An exact match exists alongside a whitespace-drifted candidate;
+	// the exact one must be chosen and reported as exact.
+	content := "key := 1\nkey := 1  \n"
+	text, isErr, after := ladderEdit(t, content,
+		`"old_string":"key := 1\n","new_string":"key := 2\n"`)
+	if isErr {
+		t.Fatalf("unexpected error: %s", text)
+	}
+	if strings.Contains(text, "tolerant") {
+		t.Fatalf("should be an exact match: %s", text)
+	}
+	if !strings.HasPrefix(after, "key := 2\n") {
+		t.Fatalf("wrong occurrence replaced: %q", after)
+	}
+}
+
+func TestFoldASCIIWithMapOffsets(t *testing.T) {
+	line := "a—b" // em-dash is 3 bytes
+	folded, starts, ends := foldASCIIWithMap(line)
+	if folded != "a-b" {
+		t.Fatalf("folded = %q", folded)
+	}
+	if starts[1] != 1 || ends[1] != 4 {
+		t.Fatalf("dash mapping wrong: starts=%v ends=%v", starts, ends)
+	}
+	if starts[2] != 4 || ends[2] != 5 {
+		t.Fatalf("trailing rune mapping wrong: starts=%v ends=%v", starts, ends)
+	}
+}


### PR DESCRIPTION
Closes #338. Roadmap P0.1 — the highest-priority harness item.

`edit_file` now repairs the match drift models introduce instead of bouncing it back:

- **Ladder** (deterministic, strictest first): exact → trailing-whitespace → indentation (replacement re-indented via per-level indent mapping — handles tab↔space swaps on inner lines) → punctuation folding (smart quotes, Unicode dashes, exotic spaces; offset-mapped fragment search within a line) → block-anchor (≥3 lines, first+last anchor).
- **Over-escape repair**: literal `\n`/`\t`/`\"` sequences (double-escaped JSON, a known Gemini/GLM failure) unescaped and retried.
- **BOM + CRLF** normalized for matching, restored byte-exactly on write.
- **Model-facing ergonomics**: non-exact matches are named in the result ("via indentation-tolerant match — base future edits on the updated lines below"); success echoes the updated lines ±2 context lines; not-found errors echo the searched text and tell the model what to check; ambiguity errors name the strategy; lazy placeholders ("rest of code unchanged") rejected pre-write.

Sources (verified): Codex `seek_sequence.rs`, Gemini CLI `edit.ts`/`editCorrector.ts`, pi `edit-diff.ts`, Cline `diff.ts`.

15 new table-driven tests cover every rung, CRLF/BOM, ambiguity, replace_all-with-flexible-match, exact-beats-flexible precedence, snippet contents, and the placeholder guard. `go build ./... && go vet ./... && go test ./...` green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)