### PR TITLE
glue, tools: structured output truncation — head/tail capture, spooling, read paging (closes #339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Structured output truncation (`glue`, `tools/shell`, `tools/fs`).**
+  `shell_exec` output is now captured head+tail instead of head-only —
+  a long build log keeps both the first error and the final status,
+  with an inline `[... N bytes (~M lines) omitted ...]` marker, a total
+  line count, and (in the coding bundle) the complete stream spooled to
+  a temp file named in the result so the model can read back what was
+  dropped. Timeouts now prepend "command timed out after Ns; partial
+  output below" to the kept output instead of replacing it.
+  `read_file` gains `offset` / `max_lines` paging with dual line+byte
+  caps; truncated reads end with `[Showing lines X-Y of Z. Use
+  offset=N to continue.]`, oversized single lines and >20MB files get
+  explicit shell-tool escape hatches. `ExecResult` gains additive
+  `StdoutTail`/`StderrTail`, `*Omitted`, `*Lines`, and `*Spool` fields;
+  `ExecCommand.SpoolDir` opts executors into spooling
+  ([docs/coding-harness-roadmap.md](docs/coding-harness-roadmap.md)
+  P0.2). Closes #339.
+
 - **`edit_file` repair ladder (`tools/fs`).** `old_string` no longer has
   to match byte-for-byte: a deterministic cascade absorbs the drift
   models introduce — trailing-whitespace differences, indentation drift

--- a/executor.go
+++ b/executor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"time"
 )
@@ -45,15 +46,48 @@ type ExecCommand struct {
 	// MaxOutputBytes caps stdout and stderr independently. Zero uses
 	// DefaultExecMaxOutputBytes.
 	MaxOutputBytes int
+
+	// SpoolDir, when non-empty, asks the executor to write each
+	// stream's complete output to a temp file under this directory.
+	// The file is kept (and named in ExecResult.StdoutSpool /
+	// StderrSpool) only when that stream exceeded MaxOutputBytes;
+	// otherwise it is removed. Executors may ignore this field.
+	SpoolDir string
 }
 
 // ExecResult is the captured result of one command execution.
+//
+// When a stream exceeds the output cap, the executor keeps the head in
+// Stdout/Stderr and a rolling tail in StdoutTail/StderrTail — build
+// logs need both the first error and the final status. The bytes
+// dropped between them are counted in StdoutOmitted/StderrOmitted.
 type ExecResult struct {
 	Stdout    []byte
 	Stderr    []byte
 	ExitCode  int
 	TimedOut  bool
 	Truncated bool
+
+	// StdoutTail / StderrTail hold the kept tail of a truncated
+	// stream. Nil when the stream fit within the cap.
+	StdoutTail []byte
+	StderrTail []byte
+
+	// StdoutOmitted / StderrOmitted count the bytes dropped between
+	// head and tail. Zero when the stream fit.
+	StdoutOmitted int
+	StderrOmitted int
+
+	// StdoutLines / StderrLines are the total lines observed on each
+	// stream, including dropped output.
+	StdoutLines int
+	StderrLines int
+
+	// StdoutSpool / StderrSpool name temp files holding the complete
+	// stream. Set only when the stream truncated and
+	// ExecCommand.SpoolDir was provided.
+	StdoutSpool string
+	StderrSpool string
 }
 
 // LocalExecutor runs commands on the local machine with os/exec. It is
@@ -102,17 +136,25 @@ func (LocalExecutor) Run(ctx context.Context, cmd ExecCommand) (ExecResult, erro
 		c.Stdin = cmd.Stdin
 	}
 
-	stdout := &limitedOutput{limit: maxOutput}
-	stderr := &limitedOutput{limit: maxOutput}
+	stdout := newLimitedOutput(maxOutput, cmd.SpoolDir, "stdout")
+	stderr := newLimitedOutput(maxOutput, cmd.SpoolDir, "stderr")
 	c.Stdout = stdout
 	c.Stderr = stderr
 
 	err := c.Run()
 	result := ExecResult{
-		Stdout:    stdout.Bytes(),
-		Stderr:    stderr.Bytes(),
-		ExitCode:  exitCode(c),
-		Truncated: stdout.Truncated() || stderr.Truncated(),
+		Stdout:        stdout.Head(),
+		Stderr:        stderr.Head(),
+		StdoutTail:    stdout.Tail(),
+		StderrTail:    stderr.Tail(),
+		StdoutOmitted: stdout.Omitted(),
+		StderrOmitted: stderr.Omitted(),
+		StdoutLines:   stdout.Lines(),
+		StderrLines:   stderr.Lines(),
+		StdoutSpool:   stdout.FinishSpool(),
+		StderrSpool:   stderr.FinishSpool(),
+		ExitCode:      exitCode(c),
+		Truncated:     stdout.Truncated() || stderr.Truncated(),
 	}
 
 	if ctxErr := ctx.Err(); ctxErr != nil {
@@ -144,34 +186,119 @@ func exitCode(c *exec.Cmd) int {
 	return c.ProcessState.ExitCode()
 }
 
+// limitedOutput keeps the head and a rolling tail of a stream within a
+// byte budget, counts lines across the whole stream, and optionally
+// spools the complete stream to a temp file.
 type limitedOutput struct {
-	buf       bytes.Buffer
-	limit     int
-	truncated bool
+	headMax int
+	tailMax int
+	head    bytes.Buffer
+	tail    []byte
+	omitted int
+
+	newlines    int
+	lastByte    byte
+	wroteAny    bool
+	spool       *os.File
+	spoolBroken bool
+}
+
+func newLimitedOutput(limit int, spoolDir, stream string) *limitedOutput {
+	tailMax := limit / 2
+	w := &limitedOutput{headMax: limit - tailMax, tailMax: tailMax}
+	if spoolDir != "" {
+		f, err := os.CreateTemp(spoolDir, "glue-exec-*-"+stream+".log")
+		if err == nil {
+			w.spool = f
+		}
+	}
+	return w
 }
 
 func (w *limitedOutput) Write(p []byte) (int, error) {
-	originalLen := len(p)
-	if originalLen == 0 {
+	n := len(p)
+	if n == 0 {
 		return 0, nil
 	}
-	remaining := w.limit - w.buf.Len()
-	if remaining <= 0 {
-		w.truncated = true
-		return originalLen, nil
+	w.wroteAny = true
+	w.newlines += bytes.Count(p, []byte{'\n'})
+	w.lastByte = p[n-1]
+	if w.spool != nil && !w.spoolBroken {
+		if _, err := w.spool.Write(p); err != nil {
+			w.spoolBroken = true
+		}
 	}
-	if len(p) > remaining {
-		w.truncated = true
-		p = p[:remaining]
+	if room := w.headMax - w.head.Len(); room > 0 {
+		take := room
+		if take > len(p) {
+			take = len(p)
+		}
+		_, _ = w.head.Write(p[:take])
+		p = p[take:]
 	}
-	_, _ = w.buf.Write(p)
-	return originalLen, nil
+	if len(p) == 0 {
+		return n, nil
+	}
+	// Past the head: maintain a rolling tail of at most tailMax bytes.
+	if len(p) >= w.tailMax {
+		w.omitted += len(w.tail) + len(p) - w.tailMax
+		w.tail = append(w.tail[:0], p[len(p)-w.tailMax:]...)
+		return n, nil
+	}
+	w.tail = append(w.tail, p...)
+	if over := len(w.tail) - w.tailMax; over > 0 {
+		w.omitted += over
+		w.tail = append(w.tail[:0:0], w.tail[over:]...)
+	}
+	return n, nil
 }
 
-func (w *limitedOutput) Bytes() []byte {
-	return append([]byte(nil), w.buf.Bytes()...)
+// Head returns the kept head of the stream. When nothing was dropped,
+// the head and tail are merged so callers see one contiguous output.
+func (w *limitedOutput) Head() []byte {
+	if w.omitted == 0 && len(w.tail) > 0 {
+		out := make([]byte, 0, w.head.Len()+len(w.tail))
+		out = append(out, w.head.Bytes()...)
+		return append(out, w.tail...)
+	}
+	return append([]byte(nil), w.head.Bytes()...)
 }
 
-func (w *limitedOutput) Truncated() bool {
-	return w.truncated
+// Tail returns the kept tail, nil unless bytes were dropped.
+func (w *limitedOutput) Tail() []byte {
+	if w.omitted == 0 {
+		return nil
+	}
+	return append([]byte(nil), w.tail...)
+}
+
+func (w *limitedOutput) Omitted() int { return w.omitted }
+
+// Lines is the total line count observed, including dropped output.
+func (w *limitedOutput) Lines() int {
+	if !w.wroteAny {
+		return 0
+	}
+	if w.lastByte == '\n' {
+		return w.newlines
+	}
+	return w.newlines + 1
+}
+
+func (w *limitedOutput) Truncated() bool { return w.omitted > 0 }
+
+// FinishSpool closes the spool file and returns its path when the
+// stream truncated; otherwise the file is removed and "" is returned.
+func (w *limitedOutput) FinishSpool() string {
+	if w.spool == nil {
+		return ""
+	}
+	path := w.spool.Name()
+	_ = w.spool.Close()
+	w.spool = nil
+	if w.omitted == 0 || w.spoolBroken {
+		_ = os.Remove(path)
+		return ""
+	}
+	return path
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -101,11 +101,22 @@ func TestLocalExecutorTruncatesEachStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got, want := string(res.Stdout), "aaaa"; got != want {
-		t.Fatalf("stdout = %q, want %q", got, want)
+	// The cap is split between a head and a rolling tail; the bytes
+	// dropped in between are counted.
+	if got, want := string(res.Stdout), "aa"; got != want {
+		t.Fatalf("stdout head = %q, want %q", got, want)
 	}
-	if got, want := string(res.Stderr), "bbbb"; got != want {
-		t.Fatalf("stderr = %q, want %q", got, want)
+	if got, want := string(res.StdoutTail), "aa"; got != want {
+		t.Fatalf("stdout tail = %q, want %q", got, want)
+	}
+	if res.StdoutOmitted <= 0 {
+		t.Fatalf("StdoutOmitted = %d, want > 0", res.StdoutOmitted)
+	}
+	if got, want := string(res.Stderr), "bb"; got != want {
+		t.Fatalf("stderr head = %q, want %q", got, want)
+	}
+	if got, want := string(res.StderrTail), "bb"; got != want {
+		t.Fatalf("stderr tail = %q, want %q", got, want)
 	}
 	if !res.Truncated {
 		t.Fatal("Truncated = false, want true")
@@ -234,4 +245,81 @@ func TestLocalExecutorHelper(t *testing.T) {
 		os.Exit(2)
 	}
 	os.Exit(0)
+}
+
+func TestLimitedOutputHeadTailLinesAndMerge(t *testing.T) {
+	// Within budget: head and tail merge seamlessly.
+	w := newLimitedOutput(10, "", "stdout")
+	_, _ = w.Write([]byte("abcde"))
+	_, _ = w.Write([]byte("fgh\n"))
+	if got := string(w.Head()); got != "abcdefgh\n" {
+		t.Fatalf("merged head = %q", got)
+	}
+	if w.Tail() != nil || w.Truncated() {
+		t.Fatal("should not be truncated")
+	}
+	if w.Lines() != 1 {
+		t.Fatalf("lines = %d, want 1", w.Lines())
+	}
+
+	// Over budget: head keeps the start, tail the end, omitted counts.
+	w = newLimitedOutput(8, "", "stdout")
+	for i := 0; i < 10; i++ {
+		_, _ = w.Write([]byte("line\n"))
+	}
+	if got := string(w.Head()); got != "line" {
+		t.Fatalf("head = %q", got)
+	}
+	if got := string(w.Tail()); got != "ine\n" {
+		t.Fatalf("tail = %q", got)
+	}
+	if w.Omitted() != 50-8 {
+		t.Fatalf("omitted = %d, want %d", w.Omitted(), 50-8)
+	}
+	if w.Lines() != 10 {
+		t.Fatalf("lines = %d, want 10", w.Lines())
+	}
+}
+
+func TestLocalExecutorSpoolKeepsFullOutputWhenTruncated(t *testing.T) {
+	dir := t.TempDir()
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv:           helperArgv(t, "large-output"),
+		MaxOutputBytes: 4,
+		SpoolDir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StdoutSpool == "" {
+		t.Fatal("StdoutSpool not set for truncated stream")
+	}
+	full, err := os.ReadFile(res.StdoutSpool)
+	if err != nil {
+		t.Fatalf("read spool: %v", err)
+	}
+	if string(full) != "aaaaaaaaaa" {
+		t.Fatalf("spool content = %q", full)
+	}
+}
+
+func TestLocalExecutorSpoolRemovedWhenNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	res, err := LocalExecutor{}.Run(context.Background(), ExecCommand{
+		Argv:     helperArgv(t, "large-output"),
+		SpoolDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StdoutSpool != "" || res.StderrSpool != "" {
+		t.Fatalf("spool paths should be empty: %q %q", res.StdoutSpool, res.StderrSpool)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("spool dir not cleaned: %d entries", len(entries))
+	}
 }

--- a/tools/coding/coding.go
+++ b/tools/coding/coding.go
@@ -127,6 +127,7 @@ func Tools(opts Options) ([]glue.Tool, Options, error) {
 		AllowedBinaries: resolved.AllowedBinaries,
 		Timeout:         resolved.ShellTimeout,
 		MaxOutputBytes:  resolved.ShellMaxOutputBytes,
+		SpoolDir:        os.TempDir(),
 	})
 	if err != nil {
 		return nil, opts, err

--- a/tools/fs/read.go
+++ b/tools/fs/read.go
@@ -4,14 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
+	"strings"
 
 	"github.com/erain/glue"
 )
 
 // DefaultReadMaxBytes is the default cap on a single read_file call.
 const DefaultReadMaxBytes = 80 * 1024
+
+// DefaultReadMaxLines is the default line cap on a single read_file
+// call. Whichever of the byte and line caps hits first wins.
+const DefaultReadMaxLines = 2000
+
+// maxReadFileBytes refuses pathologically large files outright; the
+// model should reach for shell tools (grep, sed) instead of paging
+// through them.
+const maxReadFileBytes = 20 << 20
 
 // ReadFileOptions configures ReadFileTool.
 type ReadFileOptions struct {
@@ -32,13 +41,18 @@ type ReadFileOptions struct {
 
 type readFileArgs struct {
 	Path     string `json:"path"`
+	Offset   int    `json:"offset"`
+	MaxLines int    `json:"max_lines"`
 	MaxBytes int    `json:"max_bytes"`
 }
 
 // ReadFileTool returns a glue.Tool named "read_file" that reads UTF-8
-// text from opts.WorkDir, refuses sensitive paths, and truncates output
-// to the requested size. Errors are returned as error ToolResults so
-// the model can recover, not as Go errors that crash the loop.
+// text from opts.WorkDir, refuses sensitive paths, and pages through
+// large files by line offset. Truncated reads embed the exact next
+// call to make ("Use offset=N to continue"), so the model never has to
+// guess how to fetch the rest. Errors are returned as error
+// ToolResults so the model can recover, not as Go errors that crash
+// the loop.
 func ReadFileTool(opts ReadFileOptions) glue.Tool {
 	max := opts.MaxBytes
 	if max <= 0 {
@@ -50,15 +64,17 @@ func ReadFileTool(opts ReadFileOptions) glue.Tool {
 	return glue.NewTool[readFileArgs](
 		glue.ToolSpec{
 			Name:        "read_file",
-			Description: "Read a UTF-8 text file from the working directory. Returns the file content, truncated if larger than max_bytes. Use this to inspect files mentioned in the diff when surrounding context is needed. Refuses to open secret-shaped files (.env, id_rsa, *.pem, credentials.json, etc.).",
-			Parameters: json.RawMessage(`{
+			Description: fmt.Sprintf("Read a UTF-8 text file from the working directory. Returns at most max_lines lines (default %d) and max_bytes bytes (default %d), whichever cap hits first; truncated reads say how to continue with offset. Refuses to open secret-shaped files (.env, id_rsa, *.pem, credentials.json, etc.).", DefaultReadMaxLines, DefaultReadMaxBytes),
+			Parameters: json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "properties": {
     "path":      { "type": "string", "description": "Path relative to the working directory. '..' traversal is rejected." },
-    "max_bytes": { "type": "integer", "description": "Cap on returned bytes. Default 81920." }
+    "offset":    { "type": "integer", "description": "1-based line number to start reading from. Default 1." },
+    "max_lines": { "type": "integer", "description": "Cap on returned lines. Default %d." },
+    "max_bytes": { "type": "integer", "description": "Cap on returned bytes. Default %d." }
   },
   "required": ["path"]
-}`),
+}`, DefaultReadMaxLines, DefaultReadMaxBytes)),
 		},
 		func(_ context.Context, a readFileArgs) (glue.ToolResult, error) {
 			if blocked, pat := blocklist.Match(a.Path); blocked {
@@ -68,20 +84,84 @@ func ReadFileTool(opts ReadFileOptions) glue.Tool {
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
-			limit := a.MaxBytes
-			if limit <= 0 {
-				limit = max
+			byteLimit := a.MaxBytes
+			if byteLimit <= 0 {
+				byteLimit = max
 			}
-			f, err := os.Open(resolved)
+			lineLimit := a.MaxLines
+			if lineLimit <= 0 {
+				lineLimit = DefaultReadMaxLines
+			}
+			offset := a.Offset
+			if offset <= 0 {
+				offset = 1
+			}
+			info, err := os.Stat(resolved)
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
-			defer f.Close()
-			data, err := io.ReadAll(io.LimitReader(f, int64(limit)+1))
+			if info.Size() > maxReadFileBytes {
+				return glue.ErrorResult(fmt.Errorf("file is %d bytes, exceeds the %d-byte read_file limit; use shell_exec with grep/sed/head to extract what you need", info.Size(), maxReadFileBytes)), nil
+			}
+			data, err := os.ReadFile(resolved)
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
-			return glue.TextResult(Truncate(string(data), limit)), nil
+			return glue.TextResult(pageLines(string(data), offset, lineLimit, byteLimit)), nil
 		},
 	)
+}
+
+// pageLines returns the requested line window of content, bounded by
+// both lineLimit and byteLimit, with a trailing note that names the
+// total line count and the offset to continue from when anything was
+// left out.
+func pageLines(content string, offset, lineLimit, byteLimit int) string {
+	lines := strings.Split(content, "\n")
+	total := len(lines)
+	if total > 0 && lines[total-1] == "" {
+		total-- // a trailing newline does not start a new line
+	}
+	if total == 0 {
+		return ""
+	}
+	if offset > total {
+		return fmt.Sprintf("[Offset %d is beyond the end of the file (%d lines total).]", offset, total)
+	}
+
+	end := offset - 1 + lineLimit
+	if end > total {
+		end = total
+	}
+	window := lines[offset-1 : end]
+
+	// Apply the byte cap, never splitting a line unless the very first
+	// line alone exceeds the cap.
+	kept := 0
+	used := 0
+	for _, line := range window {
+		need := len(line)
+		if kept > 0 {
+			need++ // the joining newline
+		}
+		if used+need > byteLimit {
+			break
+		}
+		used += need
+		kept++
+	}
+	if kept == 0 {
+		first := window[0]
+		if len(first) > byteLimit {
+			return fmt.Sprintf("%s\n[Line %d is %d bytes, exceeds the %d-byte cap; shown truncated. Use shell_exec with sed/cut for the rest.]", first[:byteLimit], offset, len(first), byteLimit)
+		}
+		kept = 1
+	}
+	body := strings.Join(window[:kept], "\n")
+	lastShown := offset - 1 + kept
+
+	if offset == 1 && lastShown == total {
+		return body
+	}
+	return fmt.Sprintf("%s\n\n[Showing lines %d-%d of %d. Use offset=%d to continue.]", body, offset, lastShown, total, lastShown+1)
 }

--- a/tools/fs/read_test.go
+++ b/tools/fs/read_test.go
@@ -29,11 +29,11 @@ func TestReadFileTool_ReadsAndTruncates(t *testing.T) {
 		t.Fatalf("unexpected error: %s", res.Content[0].Text)
 	}
 	got := res.Content[0].Text
-	if !strings.HasSuffix(got, "[... truncated]") {
-		t.Fatalf("expected truncation marker; got %q", got)
+	if !strings.HasPrefix(got, strings.Repeat("a", 50)+"\n") {
+		t.Fatalf("expected 50 kept bytes; got %q", got)
 	}
-	if len(got) != 50 {
-		t.Fatalf("expected len=50, got %d", len(got))
+	if !strings.Contains(got, "Line 1 is 200 bytes") || !strings.Contains(got, "exceeds the 50-byte cap") {
+		t.Fatalf("expected oversized-line message; got %q", got)
 	}
 }
 
@@ -81,5 +81,62 @@ func TestReadFileTool_MissingPathArg(t *testing.T) {
 	}
 	if !res.IsError {
 		t.Fatalf("expected error result on missing path")
+	}
+}
+
+func TestPageLinesWindowAndContinuation(t *testing.T) {
+	content := "l1\nl2\nl3\nl4\nl5\n"
+
+	if got := pageLines(content, 1, 100, 1000); got != "l1\nl2\nl3\nl4\nl5" {
+		t.Fatalf("full read = %q", got)
+	}
+
+	got := pageLines(content, 2, 2, 1000)
+	for _, want := range []string{"l2\nl3", "[Showing lines 2-3 of 5. Use offset=4 to continue.]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("window read %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "l4") {
+		t.Fatalf("window leaked next line: %q", got)
+	}
+
+	if got := pageLines(content, 99, 10, 1000); !strings.Contains(got, "beyond the end of the file (5 lines total)") {
+		t.Fatalf("offset error = %q", got)
+	}
+}
+
+func TestPageLinesByteCapNeverSplitsLines(t *testing.T) {
+	content := "aaaa\nbbbb\ncccc\n"
+	got := pageLines(content, 1, 100, 10)
+	if !strings.HasPrefix(got, "aaaa\nbbbb\n") {
+		t.Fatalf("kept lines wrong: %q", got)
+	}
+	if strings.Contains(got, "cccc") {
+		t.Fatalf("byte cap split or leaked a line: %q", got)
+	}
+	if !strings.Contains(got, "Use offset=3 to continue") {
+		t.Fatalf("missing continuation: %q", got)
+	}
+}
+
+func TestReadFileToolOffsetParam(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p.txt"), []byte("x1\nx2\nx3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := ReadFileTool(ReadFileOptions{WorkDir: dir, Blocklist: Default()})
+	res, err := tool.Execute(context.Background(), glue.ToolCall{
+		Arguments: json.RawMessage(`{"path":"p.txt","offset":3}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := res.Content[0].Text
+	if !strings.HasPrefix(got, "x3") || strings.Contains(got, "x2") {
+		t.Fatalf("offset read = %q", got)
+	}
+	if !strings.Contains(got, "Showing lines 3-3 of 3") {
+		t.Fatalf("missing range note: %q", got)
 	}
 }

--- a/tools/shell/shell.go
+++ b/tools/shell/shell.go
@@ -45,6 +45,12 @@ type ExecOptions struct {
 	// MaxOutputBytes caps stdout and stderr independently. Zero falls
 	// back to glue.DefaultExecMaxOutputBytes.
 	MaxOutputBytes int
+
+	// SpoolDir, when non-empty, asks the executor to keep each
+	// truncated stream's complete output in a temp file under this
+	// directory; the tool result names the file so the model can read
+	// back what was dropped. Empty disables spooling.
+	SpoolDir string
 }
 
 type execArgs struct {
@@ -113,6 +119,7 @@ func Exec(opts ExecOptions) (glue.Tool, error) {
 			if err != nil {
 				return glue.ErrorResult(err), nil
 			}
+			cmd.SpoolDir = opts.SpoolDir
 			result, err := executor.Run(ctx, cmd)
 			if err != nil {
 				return glue.ErrorResult(err), nil
@@ -198,7 +205,7 @@ func permissionTarget(call glue.ToolCall) string {
 }
 
 func formatResult(cmd glue.ExecCommand, result glue.ExecResult) glue.ToolResult {
-	text := renderResult(result)
+	text := renderResult(cmd, result)
 	return glue.ToolResult{
 		Content: []glue.ContentPart{{Type: glue.ContentTypeText, Text: text}},
 		IsError: result.ExitCode != 0 || result.TimedOut,
@@ -208,27 +215,50 @@ func formatResult(cmd glue.ExecCommand, result glue.ExecResult) glue.ToolResult 
 			"exit_code":    result.ExitCode,
 			"timed_out":    result.TimedOut,
 			"truncated":    result.Truncated,
-			"stdout_bytes": len(result.Stdout),
-			"stderr_bytes": len(result.Stderr),
+			"stdout_bytes": len(result.Stdout) + len(result.StdoutTail) + result.StdoutOmitted,
+			"stderr_bytes": len(result.Stderr) + len(result.StderrTail) + result.StderrOmitted,
 		},
 	}
 }
 
-func renderResult(result glue.ExecResult) string {
+func renderResult(cmd glue.ExecCommand, result glue.ExecResult) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "exit_code: %d\n", result.ExitCode)
 	fmt.Fprintf(&b, "timed_out: %t\n", result.TimedOut)
-	fmt.Fprintf(&b, "truncated: %t\n\n", result.Truncated)
-	writeStream(&b, "stdout", result.Stdout)
+	fmt.Fprintf(&b, "truncated: %t\n", result.Truncated)
+	if result.TimedOut {
+		fmt.Fprintf(&b, "command timed out after %s; partial output below\n", cmd.Timeout)
+	}
 	b.WriteByte('\n')
-	writeStream(&b, "stderr", result.Stderr)
+	writeStream(&b, "stdout", result.Stdout, result.StdoutTail, result.StdoutOmitted, result.StdoutLines, result.StdoutSpool)
+	b.WriteByte('\n')
+	writeStream(&b, "stderr", result.Stderr, result.StderrTail, result.StderrOmitted, result.StderrLines, result.StderrSpool)
 	return b.String()
 }
 
-func writeStream(b *strings.Builder, name string, data []byte) {
-	if len(data) == 0 {
+// writeStream renders one captured stream. A truncated stream shows the
+// head and tail with a marker counting what was dropped in between —
+// build logs need the first error and the final status, not just one
+// end — plus the spool file holding the complete output, when kept.
+func writeStream(b *strings.Builder, name string, head, tail []byte, omitted, lines int, spool string) {
+	if len(head) == 0 && len(tail) == 0 {
 		fmt.Fprintf(b, "%s: (empty)\n", name)
 		return
 	}
-	fmt.Fprintf(b, "%s:\n%s\n", name, string(data))
+	if omitted == 0 {
+		fmt.Fprintf(b, "%s:\n%s\n", name, string(head))
+		return
+	}
+	fmt.Fprintf(b, "%s (%d lines total):\n%s\n", name, lines, string(head))
+	keptLines := strings.Count(string(head), "\n") + strings.Count(string(tail), "\n")
+	omittedLines := lines - keptLines
+	if omittedLines < 0 {
+		omittedLines = 0
+	}
+	if spool != "" {
+		fmt.Fprintf(b, "[... %d bytes (~%d lines) omitted; full output: %s]\n", omitted, omittedLines, spool)
+	} else {
+		fmt.Fprintf(b, "[... %d bytes (~%d lines) omitted]\n", omitted, omittedLines)
+	}
+	fmt.Fprintf(b, "%s\n", string(tail))
 }

--- a/tools/shell/shell_test.go
+++ b/tools/shell/shell_test.go
@@ -238,3 +238,42 @@ func callTool(t *testing.T, tool glue.Tool, args string) glue.ToolResult {
 	}
 	return res
 }
+
+func TestExecOutputFormattingHeadTail(t *testing.T) {
+	res := callWithFakeResult(t, glue.ExecResult{
+		Stdout:        []byte("first error here\n"),
+		StdoutTail:    []byte("FAIL\texample\t1.2s\n"),
+		StdoutOmitted: 5000,
+		StdoutLines:   400,
+		StdoutSpool:   "/tmp/glue-exec-x-stdout.log",
+		ExitCode:      1,
+		Truncated:     true,
+	})
+	text := res.Content[0].Text
+	for _, want := range []string{
+		"stdout (400 lines total):",
+		"first error here",
+		"bytes (~398 lines) omitted; full output: /tmp/glue-exec-x-stdout.log",
+		"FAIL\texample",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output %q missing %q", text, want)
+		}
+	}
+}
+
+func TestExecOutputFormattingTimeout(t *testing.T) {
+	fake := &fakeExecutor{result: glue.ExecResult{Stdout: []byte("partial"), ExitCode: -1, TimedOut: true}}
+	tool, err := Exec(ExecOptions{Executor: fake, WorkDir: t.TempDir(), AllowedBinaries: []string{"go"}, Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	res := callTool(t, tool, `{"argv":["go"]}`)
+	text := res.Content[0].Text
+	if !strings.Contains(text, "command timed out after 5s; partial output below") {
+		t.Fatalf("missing timeout notice: %q", text)
+	}
+	if !strings.Contains(text, "partial") {
+		t.Fatalf("partial output dropped: %q", text)
+	}
+}


### PR DESCRIPTION
Closes #339. Roadmap P0.2.

**shell_exec / executor**
- Per-stream cap now keeps head + rolling tail (50/50) instead of head-only; `[... N bytes (~M lines) omitted ...]` marker between them, `(N lines total)` on the stream header.
- `ExecCommand.SpoolDir` (additive) spools the complete stream to a temp file, kept and named in the result only when truncation happened; the coding bundle enables it with `os.TempDir()`.
- Timeout prepends "command timed out after Ns; partial output below" to the kept output rather than replacing it.
- `ExecResult` gains additive `StdoutTail/StderrTail`, `*Omitted`, `*Lines`, `*Spool` fields; existing consumers unaffected (only `tools/shell` reads them).

**read_file**
- `offset` (1-based line) + `max_lines` paging, dual line+byte caps, never splits a line; `[Showing lines X-Y of Z. Use offset=N to continue.]`; oversized-single-line and >20MB-file escape hatches pointing at shell tools.

Sources: Codex `head_tail_buffer.rs`/`formatted_truncate_text`, pi `output-accumulator.ts` + `read.ts`.

New tests: head/tail merge + omitted accounting, spool kept-on-truncate / removed-when-clean, truncated render with marker+spool path, timeout notice, page windows, byte-cap line integrity, offset param end-to-end. Two existing tests updated for the intentional behavior change. Full suite + vet green, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)