### PR TITLE
loop: history hardening — repair orphaned tool calls and invalid turns (closes #340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **History hardening (`loop`).** Every `loop.Run` now repairs the
+  transcript before anything reaches the provider, via the new exported
+  `loop.HardenHistory`: assistant tool calls whose result is missing
+  (Esc-cancel, crash, resumed/forked session) get a synthesized
+  `IsError` result marked `glue/synthetic`; orphaned tool results and
+  empty assistant turns are dropped; tool-call IDs are normalized to
+  `[A-Za-z0-9_-]{1,64}` consistently across call and result; and turns
+  produced by a different model lose their thinking blocks and
+  provider-specific signatures. Both the Gemini and OpenAI-compatible
+  APIs reject these malformed transcripts with opaque 400s
+  ([docs/coding-harness-roadmap.md](docs/coding-harness-roadmap.md)
+  P0.3). Closes #340.
+
 - **Structured output truncation (`glue`, `tools/shell`, `tools/fs`).**
   `shell_exec` output is now captured head+tail instead of head-only —
   a long build log keeps both the first error and the final status,

--- a/docs/design.md
+++ b/docs/design.md
@@ -173,6 +173,12 @@ The `loop` package is the architectural center. Its job is to run a transcript
 until the provider stops or the context is canceled.
 
 1. Start with a system prompt, existing messages, available tools, and provider.
+   The history is first repaired by `loop.HardenHistory`: assistant tool
+   calls missing their result (interrupted turns) get a synthesized error
+   result, orphaned results and empty assistant turns are dropped,
+   tool-call IDs are normalized, and turns from a different model lose
+   their thinking blocks and provider signatures — providers reject all
+   of these with opaque 400s otherwise.
 2. Ask the provider to stream an assistant response.
 3. Emit text/tool/lifecycle events as provider events arrive.
 4. Append the final assistant message to the transcript.

--- a/loop/harden.go
+++ b/loop/harden.go
@@ -1,0 +1,242 @@
+package loop
+
+import (
+	"fmt"
+	"strings"
+)
+
+// HardenHistory repairs transcript invariants that providers reject
+// with opaque 400s, returning a repaired copy (the input is not
+// modified). It runs at the start of every [Run], so a transcript that
+// was interrupted mid-turn (Esc-cancel, crash, resume, fork) or that
+// mixes models is always safe to replay:
+//
+//  1. Every assistant tool call gets a result: calls whose tool-result
+//     message is missing (an interrupted turn) receive a synthesized
+//     error result saying the call was interrupted — both the Gemini
+//     and OpenAI-compatible APIs reject dangling tool calls outright.
+//  2. Tool-result messages whose call ID matches no assistant tool
+//     call are dropped (the paired turn was edited away).
+//  3. Assistant messages with no meaningful content — no text, no
+//     thinking, no images, no tool calls — are dropped; replaying an
+//     empty turn poisons some providers and helps none.
+//  4. Tool-call IDs are normalized to `[A-Za-z0-9_-]{1,64}`
+//     consistently across the call and its result.
+//  5. Turns produced by a different model have provider-specific
+//     thinking signatures stripped and thinking blocks dropped —
+//     another model's reasoning artifacts are at best noise and at
+//     worst hard errors when echoed to the wrong API.
+func HardenHistory(messages []Message, activeModel string) []Message {
+	msgs := cloneMessages(messages)
+	normalizeToolCallIDs(msgs)
+
+	// Index every tool-result by call ID and every call by ID.
+	calls := map[string]ToolCall{}
+	for _, m := range msgs {
+		if m.Role != MessageRoleAssistant {
+			continue
+		}
+		for _, c := range collectToolCalls(m) {
+			calls[c.ID] = c
+		}
+	}
+	results := map[string]bool{}
+	for _, m := range msgs {
+		if m.Role == MessageRoleTool && m.ToolCallID != "" {
+			results[m.ToolCallID] = true
+		}
+	}
+
+	out := make([]Message, 0, len(msgs))
+	for i := 0; i < len(msgs); i++ {
+		m := msgs[i]
+		switch m.Role {
+		case MessageRoleAssistant:
+			m = sanitizeForeignTurn(m, activeModel)
+			if !hasMeaningfulContent(m) {
+				continue
+			}
+			out = append(out, m)
+			// Absorb this turn's contiguous tool results, then
+			// synthesize any that are missing so the pairing is
+			// complete before the next turn.
+			turnCalls := collectToolCalls(m)
+			seen := map[string]bool{}
+			for i+1 < len(msgs) && msgs[i+1].Role == MessageRoleTool {
+				i++
+				tm := msgs[i]
+				if _, known := calls[tm.ToolCallID]; !known {
+					continue // orphaned result
+				}
+				seen[tm.ToolCallID] = true
+				out = append(out, tm)
+			}
+			for _, c := range turnCalls {
+				if seen[c.ID] || resultsElsewhere(msgs, i+1, c.ID) {
+					continue
+				}
+				out = append(out, syntheticToolResult(c))
+			}
+		case MessageRoleTool:
+			if _, known := calls[m.ToolCallID]; !known {
+				continue // orphaned result with no paired call
+			}
+			out = append(out, m)
+		default:
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// resultsElsewhere reports whether a result for id appears at or after
+// position from — a later (non-contiguous) result still counts.
+func resultsElsewhere(msgs []Message, from int, id string) bool {
+	for ; from < len(msgs); from++ {
+		if msgs[from].Role == MessageRoleTool && msgs[from].ToolCallID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// syntheticToolResult stands in for a tool call that never produced a
+// result (interrupted turn). Marked both in the text and the metadata
+// so nothing downstream mistakes it for real output.
+func syntheticToolResult(call ToolCall) Message {
+	return Message{
+		Role:       MessageRoleTool,
+		ToolCallID: call.ID,
+		ToolName:   call.Name,
+		IsError:    true,
+		Content: []ContentPart{{
+			Type: ContentTypeText,
+			Text: "tool call was interrupted before producing a result; do not assume it ran",
+		}},
+		Metadata: map[string]any{"glue/synthetic": true},
+	}
+}
+
+// hasMeaningfulContent reports whether an assistant message carries
+// anything worth replaying.
+func hasMeaningfulContent(m Message) bool {
+	for _, p := range m.Content {
+		switch p.Type {
+		case ContentTypeText:
+			if strings.TrimSpace(p.Text) != "" {
+				return true
+			}
+		case ContentTypeThinking:
+			if strings.TrimSpace(p.Thinking) != "" {
+				return true
+			}
+		case ContentTypeImage:
+			if p.Image != nil {
+				return true
+			}
+		case ContentTypeToolCall:
+			if p.ToolCall != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// sanitizeForeignTurn strips model-specific reasoning artifacts from
+// assistant turns produced by a different model: thinking signatures
+// are dropped everywhere and thinking blocks removed.
+func sanitizeForeignTurn(m Message, activeModel string) Message {
+	if activeModel == "" || m.Model == "" || m.Model == activeModel {
+		return m
+	}
+	content := make([]ContentPart, 0, len(m.Content))
+	for _, p := range m.Content {
+		if p.Type == ContentTypeThinking {
+			continue
+		}
+		p.Signature = ""
+		content = append(content, p)
+	}
+	m.Content = content
+	return m
+}
+
+// normalizeToolCallIDs rewrites tool-call IDs that providers reject
+// (anything outside [A-Za-z0-9_-]{1,64}) consistently on the assistant
+// call and its result messages. Returns the old→new mapping.
+func normalizeToolCallIDs(msgs []Message) map[string]string {
+	idMap := map[string]string{}
+	used := map[string]bool{}
+
+	sanitize := func(id string) string {
+		var b strings.Builder
+		for _, r := range id {
+			switch {
+			case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+				b.WriteRune(r)
+			default:
+				b.WriteByte('_')
+			}
+		}
+		s := b.String()
+		if len(s) > 64 {
+			s = s[:64]
+		}
+		return s
+	}
+
+	next := 0
+	mapped := func(id string) string {
+		if id == "" {
+			return id
+		}
+		if m, ok := idMap[id]; ok {
+			return m
+		}
+		s := sanitize(id)
+		if s == id {
+			used[s] = true
+			return id
+		}
+		if s == "" {
+			s = "call"
+		}
+		candidate := s
+		for used[candidate] {
+			next++
+			suffix := fmt.Sprintf("_%d", next)
+			max := 64 - len(suffix)
+			base := s
+			if len(base) > max {
+				base = base[:max]
+			}
+			candidate = base + suffix
+		}
+		used[candidate] = true
+		idMap[id] = candidate
+		return candidate
+	}
+
+	// Pre-mark already-valid IDs so collisions rename the invalid side.
+	for _, m := range msgs {
+		for _, p := range m.Content {
+			if p.Type == ContentTypeToolCall && p.ToolCall != nil && sanitize(p.ToolCall.ID) == p.ToolCall.ID {
+				used[p.ToolCall.ID] = true
+			}
+		}
+	}
+
+	for i := range msgs {
+		for j := range msgs[i].Content {
+			p := &msgs[i].Content[j]
+			if p.Type == ContentTypeToolCall && p.ToolCall != nil {
+				p.ToolCall.ID = mapped(p.ToolCall.ID)
+			}
+		}
+		if msgs[i].Role == MessageRoleTool && msgs[i].ToolCallID != "" {
+			msgs[i].ToolCallID = mapped(msgs[i].ToolCallID)
+		}
+	}
+	return idMap
+}

--- a/loop/harden_test.go
+++ b/loop/harden_test.go
@@ -1,0 +1,193 @@
+package loop
+
+import (
+	"strings"
+	"testing"
+)
+
+func toolCallMsg(model string, calls ...ToolCall) Message {
+	parts := make([]ContentPart, 0, len(calls))
+	for i := range calls {
+		c := calls[i]
+		parts = append(parts, ContentPart{Type: ContentTypeToolCall, ToolCall: &c})
+	}
+	return Message{Role: MessageRoleAssistant, Model: model, Content: parts}
+}
+
+func toolResultMsg(id, name, text string) Message {
+	return Message{
+		Role:       MessageRoleTool,
+		ToolCallID: id,
+		ToolName:   name,
+		Content:    []ContentPart{{Type: ContentTypeText, Text: text}},
+	}
+}
+
+func textMsg(role MessageRole, text string) Message {
+	return Message{Role: role, Content: []ContentPart{{Type: ContentTypeText, Text: text}}}
+}
+
+func TestHardenSynthesizesMissingToolResult(t *testing.T) {
+	history := []Message{
+		textMsg(MessageRoleUser, "run the tests"),
+		toolCallMsg("m", ToolCall{ID: "c1", Name: "shell_exec"}),
+		// interrupted: no tool result for c1
+		textMsg(MessageRoleUser, "continue"),
+	}
+	out := HardenHistory(history, "m")
+	if len(out) != 4 {
+		t.Fatalf("len = %d, want 4: %#v", len(out), out)
+	}
+	syn := out[2]
+	if syn.Role != MessageRoleTool || syn.ToolCallID != "c1" || !syn.IsError {
+		t.Fatalf("synthesized result wrong: %#v", syn)
+	}
+	if !strings.Contains(syn.Content[0].Text, "interrupted") {
+		t.Fatalf("synthesized text = %q", syn.Content[0].Text)
+	}
+	if syn.Metadata["glue/synthetic"] != true {
+		t.Fatalf("missing synthetic marker: %#v", syn.Metadata)
+	}
+}
+
+func TestHardenKeepsCompletePairsUntouched(t *testing.T) {
+	history := []Message{
+		textMsg(MessageRoleUser, "hi"),
+		toolCallMsg("m", ToolCall{ID: "c1", Name: "read_file"}),
+		toolResultMsg("c1", "read_file", "content"),
+		textMsg(MessageRoleAssistant, "done"),
+	}
+	out := HardenHistory(history, "m")
+	if len(out) != 4 {
+		t.Fatalf("len = %d, want 4", len(out))
+	}
+	for i := range history {
+		if out[i].Role != history[i].Role {
+			t.Fatalf("message %d role changed", i)
+		}
+	}
+}
+
+func TestHardenDropsOrphanedToolResult(t *testing.T) {
+	history := []Message{
+		textMsg(MessageRoleUser, "hi"),
+		toolResultMsg("ghost", "read_file", "stale"),
+		textMsg(MessageRoleAssistant, "ok"),
+	}
+	out := HardenHistory(history, "m")
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2: %#v", len(out), out)
+	}
+	for _, m := range out {
+		if m.Role == MessageRoleTool {
+			t.Fatal("orphaned tool result survived")
+		}
+	}
+}
+
+func TestHardenDropsEmptyAssistantTurn(t *testing.T) {
+	history := []Message{
+		textMsg(MessageRoleUser, "hi"),
+		{Role: MessageRoleAssistant, Content: []ContentPart{{Type: ContentTypeText, Text: "  "}}},
+		textMsg(MessageRoleAssistant, "real answer"),
+	}
+	out := HardenHistory(history, "m")
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2: %#v", len(out), out)
+	}
+	if out[1].Content[0].Text != "real answer" {
+		t.Fatalf("kept wrong assistant turn: %#v", out[1])
+	}
+}
+
+func TestHardenNormalizesToolCallIDs(t *testing.T) {
+	bad := "call|with spaces!"
+	history := []Message{
+		toolCallMsg("m", ToolCall{ID: bad, Name: "grep"}),
+		toolResultMsg(bad, "grep", "hits"),
+	}
+	out := HardenHistory(history, "m")
+	call := collectToolCalls(out[0])[0]
+	if strings.ContainsAny(call.ID, "| !") {
+		t.Fatalf("call ID not normalized: %q", call.ID)
+	}
+	if out[1].ToolCallID != call.ID {
+		t.Fatalf("result ID %q != call ID %q", out[1].ToolCallID, call.ID)
+	}
+}
+
+func TestHardenNormalizationAvoidsCollision(t *testing.T) {
+	history := []Message{
+		toolCallMsg("m",
+			ToolCall{ID: "call_1", Name: "a"},
+			ToolCall{ID: "call 1", Name: "b"}, // sanitizes to call_1
+		),
+		toolResultMsg("call_1", "a", "ra"),
+		toolResultMsg("call 1", "b", "rb"),
+	}
+	out := HardenHistory(history, "m")
+	calls := collectToolCalls(out[0])
+	if calls[0].ID == calls[1].ID {
+		t.Fatalf("collision not avoided: %q", calls[0].ID)
+	}
+	if out[1].ToolCallID != calls[0].ID || out[2].ToolCallID != calls[1].ID {
+		t.Fatalf("results remapped wrong: %q %q vs %q %q", out[1].ToolCallID, out[2].ToolCallID, calls[0].ID, calls[1].ID)
+	}
+}
+
+func TestHardenStripsForeignModelArtifacts(t *testing.T) {
+	foreign := Message{
+		Role:  MessageRoleAssistant,
+		Model: "other-model",
+		Content: []ContentPart{
+			{Type: ContentTypeThinking, Thinking: "secret reasoning", Signature: "sig"},
+			{Type: ContentTypeText, Text: "answer", Signature: "sig2"},
+		},
+	}
+	out := HardenHistory([]Message{foreign}, "active-model")
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	for _, p := range out[0].Content {
+		if p.Type == ContentTypeThinking {
+			t.Fatal("foreign thinking block survived")
+		}
+		if p.Signature != "" {
+			t.Fatal("foreign signature survived")
+		}
+	}
+	// Same model: untouched.
+	out = HardenHistory([]Message{foreign}, "other-model")
+	if out[0].Content[0].Type != ContentTypeThinking || out[0].Content[1].Signature != "sig2" {
+		t.Fatal("same-model turn should be untouched")
+	}
+}
+
+func TestHardenDoesNotModifyInput(t *testing.T) {
+	history := []Message{
+		toolCallMsg("m", ToolCall{ID: "bad id", Name: "x"}),
+	}
+	_ = HardenHistory(history, "m")
+	if collectToolCalls(history[0])[0].ID != "bad id" {
+		t.Fatal("input slice was mutated")
+	}
+}
+
+func TestHardenLeavesLaterNonContiguousResultAlone(t *testing.T) {
+	history := []Message{
+		toolCallMsg("m", ToolCall{ID: "c1", Name: "x"}),
+		textMsg(MessageRoleUser, "interruption"),
+		toolResultMsg("c1", "x", "late result"),
+	}
+	out := HardenHistory(history, "m")
+	// No synthesis: the result exists, just not contiguously.
+	count := 0
+	for _, m := range out {
+		if m.Role == MessageRoleTool && m.ToolCallID == "c1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one c1 result, got %d: %#v", count, out)
+	}
+}

--- a/loop/run.go
+++ b/loop/run.go
@@ -67,7 +67,9 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		maxTurns = defaultMaxTurns
 	}
 
-	messages := cloneMessages(req.Messages)
+	// Repair transcript invariants (dangling tool calls, empty turns,
+	// foreign-model artifacts) before anything reaches the provider.
+	messages := HardenHistory(req.Messages, req.Model)
 	req.Hooks = cloneHooks(req.Hooks)
 	newMessages := make([]Message, 0)
 	emit := func(e Event) {


### PR DESCRIPTION
Closes #340. Roadmap P0.3.

`loop.HardenHistory` (exported, pure) now runs at the start of every `loop.Run`:

1. **Synthesized results for dangling tool calls** — interrupted turns (Esc-cancel, crash, resume, fork, goal-loop resume) leave assistant tool calls with no result; both Gemini and OpenAI-compatible APIs 400 on them. The synthesized result is `IsError`, says "do not assume it ran", and is marked `glue/synthetic` in metadata. Skipped when a result exists later non-contiguously.
2. **Orphaned tool results** (call edited away) and **empty assistant turns** dropped from the replayed view.
3. **Tool-call ID normalization** to `[A-Za-z0-9_-]{1,64}`, applied consistently to call + result, collision-safe.
4. **Foreign-model sanitization**: turns from a different model lose thinking blocks and provider signatures (the Gemini provider's synthetic-signature fallback then covers replay, as designed in v1.8.0).

Input is never mutated (tested). Sources: Codex `normalize.rs ensure_call_outputs_present`, Gemini CLI `historyHardening.ts` curated-history, pi `transform-messages.ts`.

9 new tests: synthesis, untouched complete pairs, orphan drop, empty-turn drop, ID normalization + collision, foreign-model stripping (and same-model untouched), input immutability, non-contiguous result handling. design.md loop section updated. Full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)