### PR TITLE
loop, glue: classified retry + overflow recovery (closes #341, ADR-0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Retry/overflow recovery (`loop`, `glue`)
+  ([ADR-0017](docs/adr/0017-loop-retry-overflow-recovery.md)).**
+  Transient provider failures (429/5xx, rate limits, dropped or
+  never-finished streams) are now retried at the loop level with
+  exponential backoff (3 retries, 2s base, 30s cap), honoring
+  server-provided `Retry-After` / Gemini `RetryInfo.retryDelay` hints;
+  the new `EventRetry` event reports each attempt. Auth/billing/
+  invalid-request errors still fail fast, and context-window overflow
+  surfaces as the new typed `*loop.OverflowError` — which
+  `Session.Prompt` catches, compacts once (when a `Compactor` is
+  configured), and retries once. Retries never duplicate history:
+  nothing is appended until an attempt succeeds. Opt out with the new
+  `RunRequest.Retry: loop.RetryPolicy{Disabled: true}`
+  ([docs/coding-harness-roadmap.md](docs/coding-harness-roadmap.md)
+  P1.4). Closes #341.
+
 - **History hardening (`loop`).** Every `loop.Run` now repairs the
   transcript before anything reaches the provider, via the new exported
   `loop.HardenHistory`: assistant tool calls whose result is missing

--- a/docs/adr/0017-loop-retry-overflow-recovery.md
+++ b/docs/adr/0017-loop-retry-overflow-recovery.md
@@ -1,0 +1,62 @@
+# ADR-0017: Loop-Level Retry and Overflow Recovery
+
+## Status
+
+Accepted (2026-06-09).
+
+## Context
+
+Glue deliberately shipped without provider-level retries: transport
+concerns were left to provider SDKs, and ADR-0006 quarantined
+subscription-auth fragility inside the Codex provider on the same
+principle. In practice (dogfooding the coding agent on Gemini and
+OpenRouter open-weight models), two failure shapes dominate lost
+turns:
+
+1. **Transient provider failures** — 429s, 5xx, dropped SSE streams
+   ("stream closed before done event"). The provider SDKs retry some
+   HTTP-level cases, but a stream that dies mid-turn surfaces as a
+   turn error and kills the whole run, even mid-goal-loop.
+2. **Context-window overflow** — the request outgrew the model. This
+   is *never* fixed by retrying, but it is fixed by compacting; the
+   session has a compactor and the loop does not.
+
+Every reference harness we analyzed (pi, Cline, Codex CLI, Gemini
+CLI — see `docs/coding-harness-roadmap.md`) recovers both
+automatically. pi's state machine is the closest shape to glue's
+architecture.
+
+## Decision
+
+Add a small, classified retry layer at the **loop** level, and
+overflow recovery at the **session** level — each where the needed
+capability lives:
+
+- `loop.RetryPolicy` on `RunRequest`. The zero value enables retries
+  (3 retries, 2s base doubling to a 30s cap); `Disabled: true`
+  restores fail-fast. Errors are classified by pattern banks:
+  *overflow* → returned immediately as typed `*loop.OverflowError`;
+  *fatal* (auth, invalid request, billing, 404) → returned
+  immediately; *transient* → retried with backoff, honoring
+  server-provided hints (`Retry-After`, Gemini `RetryInfo.retryDelay`)
+  when they exceed the computed delay. `EventRetry` is emitted before
+  each sleep so UIs can show "reconnecting n/m". Nothing is appended
+  to the transcript until an attempt succeeds, so retries cannot
+  duplicate history.
+- `glue.Session.Prompt` catches `*loop.OverflowError` and, when the
+  agent has a `Compactor`, compacts once (ignoring the size
+  threshold — the provider just said we are over) and retries once.
+  Without a compactor the typed error surfaces unchanged.
+
+## Consequences
+
+- The "no provider-level retry" stance is amended, not reversed:
+  providers still own transport, and the loop owns *turn-level*
+  recovery with bounded, observable, opt-out behavior.
+- Default behavior changes: previously a 429 failed the turn; now it
+  retries up to 3 times (~14s worst case) before failing. Library
+  consumers that depended on fail-fast set `Retry.Disabled`.
+- Pattern-bank classification is heuristic by design (providers do
+  not expose typed errors through the streaming interface). Unknown
+  errors classify as fatal, so the bank can only under-retry, never
+  retry something destructive.

--- a/loop/retry.go
+++ b/loop/retry.go
@@ -1,0 +1,194 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// RetryPolicy bounds the loop-level provider retries that absorb
+// transient failures (429s, 5xx, dropped streams) before they surface
+// as turn errors. The zero value enables retries with the defaults;
+// set Disabled to restore fail-fast behavior.
+type RetryPolicy struct {
+	// Disabled turns loop-level retries off entirely.
+	Disabled bool
+
+	// MaxRetries is the number of retries after the first attempt.
+	// Zero means DefaultMaxRetries.
+	MaxRetries int
+
+	// BaseDelay is the first backoff delay; each retry doubles it.
+	// Zero means DefaultRetryBaseDelay. A server-provided retry hint
+	// (Retry-After, Gemini RetryInfo.retryDelay) overrides the
+	// computed delay when larger.
+	BaseDelay time.Duration
+
+	// MaxDelay caps the backoff. Zero means DefaultRetryMaxDelay.
+	MaxDelay time.Duration
+}
+
+// Retry defaults.
+const (
+	DefaultMaxRetries     = 3
+	DefaultRetryBaseDelay = 2 * time.Second
+	DefaultRetryMaxDelay  = 30 * time.Second
+)
+
+// EventRetry is emitted before each retry sleep, with the triggering
+// error in Event.Error and attempt/delay details in Event.Metadata
+// ("attempt", "max_attempts", "delay").
+const EventRetry EventType = "retry"
+
+// OverflowError marks a provider failure caused by the request
+// exceeding the model's context window. It is never retried at the
+// loop level: retrying an oversized request can only fail again.
+// Callers that own a compactor (glue.Session) catch it, compact once,
+// and retry once.
+type OverflowError struct{ Err error }
+
+func (e *OverflowError) Error() string { return "loop: context window exceeded: " + e.Err.Error() }
+func (e *OverflowError) Unwrap() error { return e.Err }
+
+type errorClass int
+
+const (
+	classFatal errorClass = iota
+	classTransient
+	classOverflow
+)
+
+// Fatal patterns are checked first: errors that retrying cannot fix
+// and that must not be mistaken for transient ones by the broader
+// transient regex (e.g. "quota" alone would match "rate limit"-ish
+// wording on some providers).
+var fatalRe = regexp.MustCompile(`(?i)(api.?key|unauthoriz|unauthenticated|forbidden|permission.?denied|invalid.?(request|argument)|billing|payment|quota exceeded.*plan|model not found|404)`)
+
+// Overflow patterns: the request is too large for the context window.
+// Drawn from the error strings of Gemini, OpenAI-compatible hosts,
+// Anthropic, and Groq (pi's bank, trimmed to providers glue targets).
+var overflowRe = regexp.MustCompile(`(?i)(prompt is too long|context.?window|context.?length|maximum.?context|input token count.*exceed|exceeds.*token|too many tokens|reduce the length of the messages)`)
+
+// Transient patterns: worth retrying with backoff.
+var transientRe = regexp.MustCompile(`(?i)(\b429\b|\b50[0234]\b|too many requests|rate.?limit|resource.?exhausted|overloaded|service.?unavailable|internal (server )?error|bad gateway|gateway timeout|connection (reset|refused|closed)|broken pipe|socket hang up|unexpected EOF|stream (closed|ended|reset)|closed before done|premature|fetch failed|temporar|try again|retry|timed? ?out)`)
+
+func classifyProviderError(err error) errorClass {
+	if err == nil {
+		return classFatal
+	}
+	msg := err.Error()
+	if overflowRe.MatchString(msg) {
+		return classOverflow
+	}
+	if fatalRe.MatchString(msg) {
+		return classFatal
+	}
+	if transientRe.MatchString(msg) {
+		return classTransient
+	}
+	return classFatal
+}
+
+// retryHintRe extracts a server-suggested delay from error text:
+// Gemini embeds RetryInfo as `"retryDelay":"22s"`, HTTP-ish errors say
+// `retry after 7s` or `Retry-After: 7`.
+var retryHintRe = regexp.MustCompile(`(?i)(?:retry.?delay["']?\s*[:=]\s*["']?|retry.?after["':\s]+)(\d+(?:\.\d+)?)\s*(ms|s)?`)
+
+func parseRetryHint(msg string) time.Duration {
+	m := retryHintRe.FindStringSubmatch(msg)
+	if m == nil {
+		return 0
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil || v <= 0 {
+		return 0
+	}
+	unit := time.Second
+	if m[2] == "ms" {
+		unit = time.Millisecond
+	}
+	return time.Duration(v * float64(unit))
+}
+
+func (p RetryPolicy) withDefaults() RetryPolicy {
+	if p.MaxRetries <= 0 {
+		p.MaxRetries = DefaultMaxRetries
+	}
+	if p.BaseDelay <= 0 {
+		p.BaseDelay = DefaultRetryBaseDelay
+	}
+	if p.MaxDelay <= 0 {
+		p.MaxDelay = DefaultRetryMaxDelay
+	}
+	return p
+}
+
+func (p RetryPolicy) delay(attempt int, err error) time.Duration {
+	d := p.BaseDelay << attempt
+	if d > p.MaxDelay {
+		d = p.MaxDelay
+	}
+	if err != nil {
+		if hint := parseRetryHint(err.Error()); hint > d {
+			d = hint
+			if d > p.MaxDelay {
+				d = p.MaxDelay
+			}
+		}
+	}
+	return d
+}
+
+// runAssistantTurnWithRetry wraps runAssistantTurn with classified
+// retries. Transient provider failures (429s, 5xx, dropped/never-
+// finished streams) back off and retry; overflow surfaces as
+// *OverflowError for the caller's compactor; everything else fails
+// fast. Nothing is appended to the transcript until an attempt
+// succeeds, so retries can never duplicate history.
+func runAssistantTurnWithRetry(ctx context.Context, req RunRequest, messages []Message, emit func(Event)) (Message, error) {
+	if req.Retry.Disabled {
+		return runAssistantTurn(ctx, req, messages, emit)
+	}
+	policy := req.Retry.withDefaults()
+
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		assistant, err := runAssistantTurn(ctx, req, messages, emit)
+		if err == nil {
+			return assistant, nil
+		}
+		if ctx.Err() != nil {
+			return Message{}, err
+		}
+		switch classifyProviderError(err) {
+		case classOverflow:
+			return Message{}, &OverflowError{Err: err}
+		case classFatal:
+			return Message{}, err
+		}
+		lastErr = err
+
+		if attempt >= policy.MaxRetries {
+			return Message{}, fmt.Errorf("loop: provider failed after %d attempts: %w", attempt+1, lastErr)
+		}
+		d := policy.delay(attempt, lastErr)
+		emit(Event{
+			Type:  EventRetry,
+			Error: lastErr.Error(),
+			Metadata: map[string]any{
+				"attempt":      attempt + 1,
+				"max_attempts": policy.MaxRetries + 1,
+				"delay":        d.String(),
+			},
+		})
+		timer := time.NewTimer(d)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return Message{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/loop/retry_test.go
+++ b/loop/retry_test.go
@@ -1,0 +1,187 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// flakyProvider fails its first failures Stream calls with err, then
+// delegates to a scripted success turn.
+type flakyProvider struct {
+	mu       sync.Mutex
+	failures int
+	err      error
+	calls    int
+}
+
+func (p *flakyProvider) Stream(_ context.Context, _ ProviderRequest) (<-chan ProviderEvent, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.calls <= p.failures {
+		return nil, p.err
+	}
+	ch := make(chan ProviderEvent, 2)
+	ch <- ProviderEvent{Type: ProviderEventTextDelta, Delta: "recovered"}
+	ch <- ProviderEvent{Type: ProviderEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func fastRetry() RetryPolicy {
+	return RetryPolicy{BaseDelay: time.Millisecond, MaxDelay: 5 * time.Millisecond}
+}
+
+func TestRetryTransientThenSuccess(t *testing.T) {
+	t.Parallel()
+	provider := &flakyProvider{failures: 2, err: errors.New("429 too many requests")}
+	var retries []Event
+	res, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "hi"}}}},
+		Retry:    fastRetry(),
+		Emit: func(e Event) {
+			if e.Type == EventRetry {
+				retries = append(retries, e)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if provider.calls != 3 {
+		t.Fatalf("provider calls = %d, want 3", provider.calls)
+	}
+	if len(retries) != 2 {
+		t.Fatalf("retry events = %d, want 2", len(retries))
+	}
+	if retries[0].Metadata["attempt"] != 1 || retries[0].Metadata["max_attempts"] != 4 {
+		t.Fatalf("retry metadata = %#v", retries[0].Metadata)
+	}
+	last := res.Messages[len(res.Messages)-1]
+	if last.Content[0].Text != "recovered" {
+		t.Fatalf("final text = %q", last.Content[0].Text)
+	}
+}
+
+func TestRetryFatalFailsFast(t *testing.T) {
+	t.Parallel()
+	provider := &flakyProvider{failures: 99, err: errors.New("401 invalid api key")}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "hi"}}}},
+		Retry:    fastRetry(),
+	})
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1 (no retries on fatal)", provider.calls)
+	}
+}
+
+func TestRetryOverflowSurfacesTyped(t *testing.T) {
+	t.Parallel()
+	provider := &flakyProvider{failures: 99, err: errors.New("input token count 250000 exceeds the maximum")}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "hi"}}}},
+		Retry:    fastRetry(),
+	})
+	var overflow *OverflowError
+	if !errors.As(err, &overflow) {
+		t.Fatalf("err = %v, want *OverflowError", err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1 (overflow is not retried)", provider.calls)
+	}
+}
+
+func TestRetryExhausted(t *testing.T) {
+	t.Parallel()
+	provider := &flakyProvider{failures: 99, err: errors.New("503 service unavailable")}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "hi"}}}},
+		Retry:    RetryPolicy{MaxRetries: 2, BaseDelay: time.Millisecond},
+	})
+	if err == nil || !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Fatalf("err = %v, want exhaustion after 3 attempts", err)
+	}
+	if provider.calls != 3 {
+		t.Fatalf("provider calls = %d, want 3", provider.calls)
+	}
+}
+
+func TestRetryDisabledFailsFast(t *testing.T) {
+	t.Parallel()
+	provider := &flakyProvider{failures: 99, err: errors.New("429 too many requests")}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "hi"}}}},
+		Retry:    RetryPolicy{Disabled: true},
+	})
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", provider.calls)
+	}
+}
+
+func TestClassifyProviderError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		msg  string
+		want errorClass
+	}{
+		{"429 too many requests", classTransient},
+		{"rate limit exceeded, retryDelay: 22s", classTransient},
+		{"503 Service Unavailable", classTransient},
+		{"connection reset by peer", classTransient},
+		{"loop: provider stream closed before done event", classTransient},
+		{"prompt is too long: 250000 tokens", classOverflow},
+		{"input token count exceeds the maximum allowed", classOverflow},
+		{"the request exceeds the context window of this model", classOverflow},
+		{"401 unauthorized: invalid api key", classFatal},
+		{"model not found", classFatal},
+		{"some inexplicable failure", classFatal},
+	}
+	for _, c := range cases {
+		if got := classifyProviderError(errors.New(c.msg)); got != c.want {
+			t.Errorf("classify(%q) = %d, want %d", c.msg, got, c.want)
+		}
+	}
+}
+
+func TestParseRetryHint(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		msg  string
+		want time.Duration
+	}{
+		{`status 429 ... "retryDelay":"22s" ...`, 22 * time.Second},
+		{"Retry-After: 7", 7 * time.Second},
+		{"please retry after 500 ms", 500 * time.Millisecond},
+		{"no hint here", 0},
+	}
+	for _, c := range cases {
+		if got := parseRetryHint(c.msg); got != c.want {
+			t.Errorf("parseRetryHint(%q) = %v, want %v", c.msg, got, c.want)
+		}
+	}
+}
+
+func TestRetryHonorsServerHint(t *testing.T) {
+	t.Parallel()
+	p := RetryPolicy{BaseDelay: time.Millisecond, MaxDelay: time.Hour}.withDefaults()
+	d := p.delay(0, fmt.Errorf(`429 "retryDelay":"3s"`))
+	if d != 3*time.Second {
+		t.Fatalf("delay = %v, want 3s (server hint)", d)
+	}
+}

--- a/loop/run.go
+++ b/loop/run.go
@@ -37,6 +37,11 @@ type RunRequest struct {
 	Permission   Permission
 	Hooks        []Hook
 	Emit         func(Event)
+
+	// Retry bounds loop-level provider retries (transient failures,
+	// dropped streams). The zero value enables retries with defaults;
+	// set Retry.Disabled for the pre-retry fail-fast behavior.
+	Retry RetryPolicy
 }
 
 // RunResult is returned by [Run]. Messages is the full transcript including
@@ -98,7 +103,7 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 
 		emit(Event{Type: EventTurnStart})
-		assistant, err := runAssistantTurn(ctx, req, messages, emit)
+		assistant, err := runAssistantTurnWithRetry(ctx, req, messages, emit)
 		if err != nil {
 			return fail(err)
 		}

--- a/overflow_test.go
+++ b/overflow_test.go
@@ -1,0 +1,87 @@
+package glue
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// overflowOnceProvider reports a context-window overflow on exactly
+// one call (failAt), succeeding otherwise — the shape of a session
+// that outgrew the model between two prompts.
+type overflowOnceProvider struct {
+	failAt   int
+	calls    int
+	requests []ProviderRequest
+}
+
+func (p *overflowOnceProvider) Stream(_ context.Context, req ProviderRequest) (<-chan ProviderEvent, error) {
+	p.calls++
+	p.requests = append(p.requests, req)
+	if p.calls == p.failAt {
+		return nil, errors.New("prompt is too long: input token count exceeds the maximum")
+	}
+	ch := make(chan ProviderEvent, 2)
+	ch <- ProviderEvent{Type: ProviderEventTextDelta, Delta: "ok"}
+	ch <- ProviderEvent{Type: ProviderEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func TestSessionOverflowCompactsOnceAndRetries(t *testing.T) {
+	provider := &overflowOnceProvider{failAt: 4}
+	agent := NewAgent(AgentOptions{
+		Provider:  provider,
+		Compactor: KeepRecentMessages(1),
+		// Threshold high enough that pre-prompt compaction never
+		// triggers; only the overflow path may compact.
+		CompactionThreshold: 100,
+	})
+	session, err := agent.Session(context.Background(), "overflow-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Grow the transcript: three successful prompts = 6 messages.
+	for _, p := range []string{"one", "two", "three"} {
+		if _, err := session.Prompt(context.Background(), p); err != nil {
+			t.Fatalf("prompt %q: %v", p, err)
+		}
+	}
+
+	// Fourth prompt: provider overflows once; the session must compact
+	// and retry instead of surfacing the error.
+	res, err := session.Prompt(context.Background(), "fourth")
+	if err != nil {
+		t.Fatalf("prompt after overflow: %v", err)
+	}
+	if res.Text != "ok" {
+		t.Fatalf("text = %q", res.Text)
+	}
+	if provider.calls != 5 {
+		t.Fatalf("provider calls = %d, want 5 (3 ok, overflow, retried ok)", provider.calls)
+	}
+	// The retried request must be smaller than the overflowing one.
+	if len(provider.requests[4].Messages) >= len(provider.requests[3].Messages) {
+		t.Fatalf("retry not compacted: %d -> %d messages",
+			len(provider.requests[3].Messages), len(provider.requests[4].Messages))
+	}
+}
+
+func TestSessionOverflowWithoutCompactorSurfaces(t *testing.T) {
+	provider := &overflowOnceProvider{failAt: 2}
+	agent := NewAgent(AgentOptions{Provider: provider})
+	session, err := agent.Session(context.Background(), "overflow-no-compactor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.Prompt(context.Background(), "first"); err != nil {
+		t.Fatalf("first prompt: %v", err)
+	}
+	if _, err := session.Prompt(context.Background(), "second"); err == nil {
+		t.Fatal("want overflow error without a compactor")
+	}
+	if provider.calls != 2 {
+		t.Fatalf("provider calls = %d, want 2 (no retry without compactor)", provider.calls)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -210,27 +210,47 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 		permission = config.permission
 	}
 
-	result, runErr := loop.Run(ctx, loop.RunRequest{
-		Provider:     s.agent.provider,
-		Model:        config.model,
-		SystemPrompt: config.systemPrompt,
-		Messages:     runMessages,
-		Tools:        config.tools,
-		Options:      config.options,
-		MaxTurns:     config.maxTurns,
-		SessionID:    s.id,
-		Permission:   permission,
-		Hooks:        cloneHooks(s.agent.hooks),
-		Emit: func(event Event) {
-			if config.emit != nil {
-				config.emit(event)
-			}
-			for _, aux := range config.auxEmits {
-				aux(event)
-			}
-			s.dispatchEvent(event)
-		},
-	})
+	run := func(messages []Message) (loop.RunResult, error) {
+		return loop.Run(ctx, loop.RunRequest{
+			Provider:     s.agent.provider,
+			Model:        config.model,
+			SystemPrompt: config.systemPrompt,
+			Messages:     messages,
+			Tools:        config.tools,
+			Options:      config.options,
+			MaxTurns:     config.maxTurns,
+			SessionID:    s.id,
+			Permission:   permission,
+			Hooks:        cloneHooks(s.agent.hooks),
+			Emit: func(event Event) {
+				if config.emit != nil {
+					config.emit(event)
+				}
+				for _, aux := range config.auxEmits {
+					aux(event)
+				}
+				s.dispatchEvent(event)
+			},
+		})
+	}
+
+	result, runErr := run(runMessages)
+
+	// Context overflow is not retryable as-is: compact once (ignoring
+	// the size threshold — the provider just told us we are over) and
+	// retry once. Without a compactor the overflow surfaces unchanged.
+	var overflow *loop.OverflowError
+	if errors.As(runErr, &overflow) && s.agent.compactor != nil {
+		compacted, err := s.agent.compactor.Compact(ctx, cloneMessages(base))
+		if err == nil && len(compacted) > 0 && len(compacted) < len(base) {
+			s.mu.Lock()
+			s.messages = cloneMessages(compacted)
+			s.updatedAt = time.Now().UTC()
+			s.mu.Unlock()
+			base = compacted
+			result, runErr = run(append(base, userMessage))
+		}
+	}
 
 	s.mu.Lock()
 	s.messages = append(s.messages, userMessage)


### PR DESCRIPTION
Closes #341. Roadmap P1.4. New [ADR-0017](docs/adr/0017-loop-retry-overflow-recovery.md) amends the original no-provider-retry stance.

**Loop level** (`loop/retry.go`):
- Errors classified by pattern banks (checked overflow → fatal → transient; unknown = fatal, so the bank can only under-retry).
- Transient (429/5xx/rate-limit/stream-drop): backoff `2s·2^n` capped 30s, max 3 retries; server hints (`Retry-After`, Gemini `"retryDelay":"22s"`) override when larger; `EventRetry` emitted with attempt/delay metadata.
- Overflow: returned immediately as typed `*loop.OverflowError`.
- `RunRequest.Retry loop.RetryPolicy` — zero value enables defaults, `Disabled` restores fail-fast. Nothing appended to history until success, so retries can't duplicate turns.

**Session level** (`session.go`): `Prompt` catches `*loop.OverflowError`, compacts once via the configured `Compactor` (threshold ignored — the provider just said we're over), persists the compacted transcript, retries once. No compactor → typed error surfaces unchanged.

Sources: pi `agent-session.ts` retry state machine + `overflow.ts` detection bank, Cline `retry.ts` RetryInfo parsing, Codex two-tier retries.

Tests: transient-then-success (call/event counts, no duplicate history), fatal fails fast, overflow typed + not retried, exhaustion, disabled, classification table, retry-hint parsing, hint-overrides-backoff, session compact-and-retry (request actually shrinks), session no-compactor surfaces. Full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)