### PR TITLE
loop, glue, cmd/glue: next-speaker stall recovery (closes #343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and [`agents/peggy/CHANGELOG.md`](agents/peggy/CHANGELOG.md).
 
 ## Unreleased
 
+- **Next-speaker stall recovery (`loop`, `glue`, `cmd/glue`).** Gemini's
+  classic stall — narrating "I will now update the file." and stopping
+  without calling a tool — is now recovered: with the new opt-in
+  `RunRequest.AutoContinue` / `AgentOptions.AutoContinue`, an assistant
+  turn whose closing sentence announces a future action (and asks no
+  question) gets a synthetic "Please continue." user message (marked
+  `glue/auto-continue`, at most twice per run, `EventAutoContinue`
+  emitted). The `glue` binary enables it automatically for the gemini
+  provider when tools are registered. The surrogate-sanitization item
+  from the roadmap was verified unnecessary back in #313 (Go's
+  `encoding/json` already sanitizes invalid UTF-8)
+  ([docs/coding-harness-roadmap.md](docs/coding-harness-roadmap.md)
+  P2.7). Closes #343.
+
 - **Compaction upgrade (`glue.SummarizingCompactor`).** The default
   summarization prompt now requests a structured state snapshot (Goal /
   Constraints / Progress / Key Decisions / Next Steps / Critical

--- a/agent.go
+++ b/agent.go
@@ -46,6 +46,13 @@ type AgentOptions struct {
 	// persisted by the next save.
 	Compactor           Compactor
 	CompactionThreshold int
+
+	// AutoContinue opts every session into the loop's next-speaker
+	// stall check: an assistant turn that narrates a future action
+	// without calling a tool gets a bounded "Please continue." nudge.
+	// Most useful on Gemini, which is prone to the narrate-then-stop
+	// stall.
+	AutoContinue bool
 }
 
 // Agent owns shared configuration and an in-memory session map.
@@ -56,6 +63,7 @@ type Agent struct {
 	tools        []Tool
 	options      map[string]any
 	maxTurns     int
+	autoContinue bool
 	store        Store
 	workDir      string
 	role         string
@@ -85,6 +93,7 @@ func NewAgent(options AgentOptions) *Agent {
 		tools:               cloneTools(options.Tools),
 		options:             cloneMap(options.Options),
 		maxTurns:            options.MaxTurns,
+		autoContinue:        options.AutoContinue,
 		store:               options.Store,
 		workDir:             options.WorkDir,
 		skills:              cloneSkills(options.Skills),

--- a/cmd/glue/main.go
+++ b/cmd/glue/main.go
@@ -180,6 +180,12 @@ func newAgent(newProvider providerFactory, cfg agentConfig) (*glue.Agent, error)
 		Store:      filestore.New(cfg.StoreDir),
 		WorkDir:    cfg.WorkDir,
 		Permission: cfg.Permission,
+		// Gemini is prone to the narrate-then-stop stall ("I will now
+		// edit the file." with no tool call); the loop's bounded
+		// "Please continue." nudge recovers it. Other providers keep
+		// the default behavior until a capability registry makes this
+		// per-model (#345).
+		AutoContinue: cfg.Provider == "gemini" && len(cfg.Tools) > 0,
 	}), nil
 }
 

--- a/loop/autocontinue.go
+++ b/loop/autocontinue.go
@@ -1,0 +1,88 @@
+package loop
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Auto-continue ("next-speaker check") recovers the classic Gemini
+// stall: the model narrates the action it is about to take — "I will
+// now update the router." — and stops without calling a tool. Gemini
+// CLI fixes this with fast-path heuristics plus an auxiliary model
+// call; glue ships the deterministic heuristic only, opt-in via
+// [RunRequest.AutoContinue], and bounds it to maxAutoContinues per run
+// so a model that keeps narrating cannot loop forever.
+
+// maxAutoContinues bounds the synthetic "Please continue." nudges in a
+// single Run.
+const maxAutoContinues = 2
+
+// EventAutoContinue is emitted when the loop injects a synthetic
+// "Please continue." user message after detecting a narrated-intent
+// stall. Event.Message carries the assistant turn that stalled.
+const EventAutoContinue EventType = "auto_continue"
+
+// autoContinueMessage is the nudge injected after a stall.
+const autoContinueMessage = "Please continue."
+
+// intentRe matches announced-future-action phrasing. It is applied to
+// the final sentence only, and never when that closing region asks the
+// user a question.
+var intentRe = regexp.MustCompile(`(?i)\b(i('| wi)ll( now)?|let me( now)?|i am going to|i'm going to|next,? i('| wi)ll|now i('| wi)ll|proceeding to|about to)\b`)
+
+// stallIntent reports whether an assistant turn looks like a narrated
+// action that never happened: future-intent phrasing in the closing
+// sentence, no question to the user, and no tool call made.
+func stallIntent(m Message) bool {
+	if len(collectToolCalls(m)) > 0 {
+		return false
+	}
+	text := strings.TrimSpace(assistantTurnText(m))
+	if text == "" {
+		return false
+	}
+	closing := closingSentence(text)
+	if strings.Contains(closing, "?") {
+		return false
+	}
+	return intentRe.MatchString(closing)
+}
+
+func assistantTurnText(m Message) string {
+	var b strings.Builder
+	for _, p := range m.Content {
+		if p.Type == ContentTypeText && p.Text != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+// closingSentence returns the last sentence-ish fragment of text.
+func closingSentence(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.TrimRight(text, ".!…:")
+	cut := -1
+	for _, sep := range []string{". ", "! ", "…", ".\n", "!\n", "\n"} {
+		if i := strings.LastIndex(text, sep); i > cut {
+			cut = i + len(sep) - 1
+		}
+	}
+	if cut >= 0 && cut+1 < len(text) {
+		return strings.TrimSpace(text[cut+1:])
+	}
+	return text
+}
+
+// autoContinueUserMessage is the synthetic nudge, marked in metadata
+// so stores, UIs, and compactors can identify it.
+func autoContinueUserMessage() Message {
+	return Message{
+		Role:     MessageRoleUser,
+		Content:  []ContentPart{{Type: ContentTypeText, Text: autoContinueMessage}},
+		Metadata: map[string]any{"glue/auto-continue": true},
+	}
+}

--- a/loop/autocontinue_test.go
+++ b/loop/autocontinue_test.go
@@ -1,0 +1,144 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestStallIntent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"I will now update the router to log requests.", true},
+		{"Let me run the tests.", true},
+		{"I'm going to refactor the helper next.", true},
+		{"Next, I'll wire the handler.", true},
+		{"The tests pass and the feature is complete.", false},
+		{"I will need your API key — what is it?", false},
+		{"Done. Anything else?", false},
+		{"", false},
+		// Future intent earlier, but the closing sentence concludes.
+		{"I will check the file.\nThe file looks correct, no change needed.", false},
+	}
+	for _, c := range cases {
+		m := Message{Role: MessageRoleAssistant, Content: []ContentPart{{Type: ContentTypeText, Text: c.text}}}
+		if got := stallIntent(m); got != c.want {
+			t.Errorf("stallIntent(%q) = %v, want %v", c.text, got, c.want)
+		}
+	}
+}
+
+func TestStallIntentIgnoresTurnsWithToolCalls(t *testing.T) {
+	t.Parallel()
+	call := ToolCall{ID: "c", Name: "x", Arguments: json.RawMessage(`{}`)}
+	m := Message{Role: MessageRoleAssistant, Content: []ContentPart{
+		{Type: ContentTypeText, Text: "I will now edit the file."},
+		{Type: ContentTypeToolCall, ToolCall: &call},
+	}}
+	if stallIntent(m) {
+		t.Fatal("a turn that did call a tool is not a stall")
+	}
+}
+
+func TestAutoContinueNudgesStalledTurn(t *testing.T) {
+	t.Parallel()
+	provider := &fakeProvider{turns: [][]ProviderEvent{
+		{{Type: ProviderEventTextDelta, Delta: "I will now run the tests."}, {Type: ProviderEventDone}},
+		{{Type: ProviderEventTextDelta, Delta: "All tests pass; nothing else to do."}, {Type: ProviderEventDone}},
+	}}
+	var nudges int
+	res, err := Run(context.Background(), RunRequest{
+		Provider:     provider,
+		AutoContinue: true,
+		Tools:        []Tool{{ToolSpec: ToolSpec{Name: "shell_exec"}}},
+		Messages:     []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "run the tests"}}}},
+		Emit: func(e Event) {
+			if e.Type == EventAutoContinue {
+				nudges++
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if nudges != 1 {
+		t.Fatalf("auto-continue events = %d, want 1", nudges)
+	}
+	// Transcript: user, stalled assistant, synthetic user, final assistant.
+	if len(res.NewMessages) != 3 {
+		t.Fatalf("new messages = %d, want 3 (stall, nudge, final)", len(res.NewMessages))
+	}
+	nudge := res.NewMessages[1]
+	if nudge.Role != MessageRoleUser || nudge.Content[0].Text != autoContinueMessage {
+		t.Fatalf("nudge = %#v", nudge)
+	}
+	if nudge.Metadata["glue/auto-continue"] != true {
+		t.Fatalf("nudge metadata = %#v", nudge.Metadata)
+	}
+	final := res.NewMessages[2]
+	if final.Content[0].Text != "All tests pass; nothing else to do." {
+		t.Fatalf("final text = %q", final.Content[0].Text)
+	}
+}
+
+func TestAutoContinueBounded(t *testing.T) {
+	t.Parallel()
+	stall := []ProviderEvent{{Type: ProviderEventTextDelta, Delta: "I will now do the thing."}, {Type: ProviderEventDone}}
+	provider := &fakeProvider{turns: [][]ProviderEvent{stall, stall, stall, stall}}
+	res, err := Run(context.Background(), RunRequest{
+		Provider:     provider,
+		AutoContinue: true,
+		Tools:        []Tool{{ToolSpec: ToolSpec{Name: "shell_exec"}}},
+		Messages:     []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "go"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// 2 nudges max: stall, nudge, stall, nudge, stall — then give up.
+	if provider.calls != 3 {
+		t.Fatalf("provider calls = %d, want 3 (bounded nudging)", provider.calls)
+	}
+	last := res.NewMessages[len(res.NewMessages)-1]
+	if last.Role != MessageRoleAssistant {
+		t.Fatalf("run must end on the assistant turn, got %s", last.Role)
+	}
+}
+
+func TestAutoContinueOffByDefault(t *testing.T) {
+	t.Parallel()
+	provider := &fakeProvider{turns: [][]ProviderEvent{
+		{{Type: ProviderEventTextDelta, Delta: "I will now run the tests."}, {Type: ProviderEventDone}},
+	}}
+	_, err := Run(context.Background(), RunRequest{
+		Provider: provider,
+		Tools:    []Tool{{ToolSpec: ToolSpec{Name: "shell_exec"}}},
+		Messages: []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "go"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1 (no auto-continue by default)", provider.calls)
+	}
+}
+
+func TestAutoContinueRequiresTools(t *testing.T) {
+	t.Parallel()
+	provider := &fakeProvider{turns: [][]ProviderEvent{
+		{{Type: ProviderEventTextDelta, Delta: "I will now think about this."}, {Type: ProviderEventDone}},
+	}}
+	_, err := Run(context.Background(), RunRequest{
+		Provider:     provider,
+		AutoContinue: true,
+		Messages:     []Message{{Role: MessageRoleUser, Content: []ContentPart{{Type: ContentTypeText, Text: "go"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1 (no tools, no nudge)", provider.calls)
+	}
+}

--- a/loop/run.go
+++ b/loop/run.go
@@ -42,6 +42,13 @@ type RunRequest struct {
 	// dropped streams). The zero value enables retries with defaults;
 	// set Retry.Disabled for the pre-retry fail-fast behavior.
 	Retry RetryPolicy
+
+	// AutoContinue opts into the next-speaker stall check: when an
+	// assistant turn narrates a future action ("I will now …") without
+	// calling a tool, the loop injects a "Please continue." user
+	// message (at most twice per run) instead of ending the turn.
+	// Recovers the classic Gemini narrate-then-stop stall.
+	AutoContinue bool
 }
 
 // RunResult is returned by [Run]. Messages is the full transcript including
@@ -97,6 +104,7 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	lastAssistantMsg := -1
 	lastAssistantNew := -1
+	autoContinues := 0
 	for turn := 0; turn < maxTurns; turn++ {
 		if err := ctx.Err(); err != nil {
 			return fail(err)
@@ -115,6 +123,15 @@ func Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 		toolCalls := collectToolCalls(assistant)
 		if len(toolCalls) == 0 {
+			if req.AutoContinue && len(req.Tools) > 0 && autoContinues < maxAutoContinues && stallIntent(assistant) {
+				autoContinues++
+				nudge := autoContinueUserMessage()
+				messages = append(messages, nudge)
+				newMessages = append(newMessages, nudge)
+				emit(Event{Type: EventAutoContinue, Message: messagePtr(assistant)})
+				emit(Event{Type: EventTurnEnd, Message: messagePtr(assistant)})
+				continue
+			}
 			emit(Event{Type: EventTurnEnd, Message: messagePtr(assistant)})
 			return snapshot(), nil
 		}

--- a/session.go
+++ b/session.go
@@ -222,6 +222,7 @@ func (s *Session) Prompt(ctx context.Context, text string, options ...PromptOpti
 			SessionID:    s.id,
 			Permission:   permission,
 			Hooks:        cloneHooks(s.agent.hooks),
+			AutoContinue: s.agent.autoContinue,
 			Emit: func(event Event) {
 				if config.emit != nil {
 					config.emit(event)


### PR DESCRIPTION
Closes #343. Roadmap P2.7.

The classic Gemini stall — the model narrates "I will now run the tests." and stops without a tool call — is recovered with a deterministic next-speaker check (Gemini CLI's fast-path heuristics; we deliberately skip its auxiliary-LLM judge):

- **`RunRequest.AutoContinue`** (opt-in): a no-tool assistant turn whose *closing sentence* matches future-intent phrasing and asks no question gets a synthetic `"Please continue."` user message — marked `glue/auto-continue` in metadata, bounded to 2 per run, `EventAutoContinue` emitted with the stalled turn. No tools registered → never triggers.
- **`AgentOptions.AutoContinue`** plumbs it through sessions; **`cmd/glue`** enables it for `--provider gemini` with tools (per-model gating moves to the #345 capability registry).
- Roadmap's surrogate-sanitization sub-item: verified unnecessary in #313 — Go's `encoding/json` sanitizes invalid UTF-8 already. Noted in CHANGELOG instead of dead code.

Conservative-by-construction false-positive guards (tested): questions never trigger; intent earlier in the message but a concluding final sentence doesn't trigger; turns with tool calls are exempt; off by default.

Tests: intent table (9 cases), nudge round-trip (transcript shape, metadata, event), boundedness (gives up after 2), off-by-default, requires-tools. Full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)